### PR TITLE
Matrix exponential

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*~
+.juliahistory
+ltxpng/

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ julia:
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
   - julia -e 'if VERSION >= v"0.4-" Pkg.add("DistributedArrays"); end'
-  - julia -e 'Pkg.clone("https://github.com/dpo/LinearOperators.jl.git"); Pkg.checkout("LinearOperators", "develop")'
+  - julia -e 'Pkg.clone("https://github.com/dpo/LinearOperators.jl.git"); Pkg.checkout("LinearOperators", "master")'
   - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.build("Krylov"); Pkg.test("Krylov"; coverage=true)'
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ julia:
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
   - julia -e 'if VERSION >= v"0.4-" Pkg.add("DistributedArrays"); end'
-  - julia -e 'Pkg.clone("https://github.com/dpo/LinearOperators.jl.git"); Pkg.checkout("LinearOperators", "master")'
+  - julia -e 'Pkg.clone("https://github.com/dpo/LinearOperators.jl.git"); Pkg.checkout("LinearOperators", "develop")'
   - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.build("Krylov"); Pkg.test("Krylov"; coverage=true)'
 
 after_success:

--- a/src/Krylov.jl
+++ b/src/Krylov.jl
@@ -68,4 +68,6 @@ include("craig.jl")
 include("lsmr.jl")
 include("craigmr.jl")
 
+include("exp_lanczos.jl")
+
 end

--- a/src/exp_lanczos.jl
+++ b/src/exp_lanczos.jl
@@ -49,7 +49,7 @@ function exp_lanczos!{T<:Number,R<:Real}(A :: LinearOperator,
     V[:,1] = v/β₀
     
     ε = atol + rtol * β₀
-    verbose && @printf("Initial norm: β₀ %g, stopping threshold: %g\n", β₀, ε)
+    verbose && @printf("Initial norm: β₀ %e, stopping threshold: %e\n", β₀, ε)
 
     fin = false
     j = 1
@@ -75,7 +75,7 @@ function exp_lanczos!{T<:Number,R<:Real}(A :: LinearOperator,
         σ = -ω * σ
         ω = ω * ω
         
-        verbose && @printf("iter %d, α[%d] %g, β[%d] %g, γ %g, ω %g, σ %g\n",
+        verbose && @printf("iter %d, α[%d] %e, β[%d] %e, γ %e, ω %e, σ %e\n",
                           j, j, α[j], j, β[j],
                           γ, ω, σ)
 

--- a/src/exp_lanczos.jl
+++ b/src/exp_lanczos.jl
@@ -1,0 +1,102 @@
+# An implementation of exp(τA)v for Hermitian operators A.
+#
+# exp(τA)v = β₀Vₘ exp(τTₘ)e₁
+#
+# The implementation follows
+# Saad, Y. (1992). Analysis of some krylov subspace
+# approximations. SIAM Journal on Numerical Analysis.
+#
+# The error estimates/stopping criteria are borrowed from
+# cg_lanczos.jl
+#
+# Stefanos Carlström, <stefanos.carlstrom@gmail.com>
+# Lund, Sweden, May 2016.
+
+export exp_lanczos, exp_lanczos!, exp_lanczos_work
+
+# Check arguments and allocate work arrays
+function exp_lanczos_work{T<:Number}(A :: LinearOperator,
+                                     v :: Array{T,1},
+                                     m :: Integer,
+                                     verbose :: Bool=false)
+    n = size(v, 1);
+    (size(A, 1) == n & size(A, 2) == n) || error("Inconsistent problem size, $(size(A))×$(size(v))");
+    verbose && @printf("exp Lanczos: %d×%d system\n", n, n);
+
+    V = zeros(T, n, m+1)
+    α = zeros(real(T), m)
+    β = zeros(real(T), m)
+
+    V,α,β
+end
+
+function expT(α,β,v,τ,β₀)
+    ee = eigfact(SymTridiagonal(α,β))
+    β₀*v*ee[:vectors]*Diagonal(exp(τ*ee[:values]))*ee[:vectors][1,:]'
+end
+
+function exp_lanczos!{T<:Number,R<:Real}(A :: LinearOperator,
+                                               v :: AbstractVector{T},
+                                               τ :: T, m :: Integer,
+                                               vp :: AbstractVector{T},
+                                               V :: Matrix{T},
+                                               α :: Vector{R},
+                                               β :: Vector{R};
+                                               atol :: Float64=1.0e-8,
+                                               rtol :: Float64=1.0e-4,
+                                               verbose :: Bool=false)
+    β₀ = norm(v)
+    V[:,1] = v/β₀
+    
+    ε = atol + rtol * β₀
+    verbose && @printf("Initial norm: β₀ %g, stopping threshold: %g\n", β₀, ε)
+
+    fin = false
+    j = 1
+    jj = 1 # Which Krylov subspace to use, in the end
+    
+    σ = β₀
+    ω = 0
+    γ = 1
+
+    for j = 1:m
+        V[:,j+1] = A*V[:,j]
+        j > 1 && (V[:,j+1] -= β[j-1]*V[:,j-1])
+        α[j] = real(dot(V[:,j],V[:,j+1]))
+        
+        γ = 1 / (α[j] - ω / γ)
+        γ <= 0.0 && break
+
+        V[:,j+1] -= α[j]*V[:,j]
+        β[j] = norm(V[:,j+1])
+        V[:,j+1] /= β[j]
+        
+        ω = β[j] * γ
+        σ = -ω * σ
+        ω = ω * ω
+        
+        verbose && @printf("iter %d, α[%d] %g, β[%d] %g, γ %g, ω %g, σ %g\n",
+                          j, j, α[j], j, β[j],
+                          γ, ω, σ)
+
+        if abs(σ) < ε
+            break
+        else
+            j != m && (jj += 1)
+        end
+    end
+    verbose && println("Krylov subspace size: ", jj)
+    vp[:] = expT(α[1:jj], β[1:jj-1], V[:,1:jj], τ, β₀)
+end
+
+# One-shot version
+function exp_lanczos{T<:Number}(A :: LinearOperator, v :: Array{T,1},
+                                τ :: T, m :: Integer;
+                                atol :: Float64=1.0e-8,
+                                rtol :: Float64=1.0e-6,
+                                verbose :: Bool=false)
+    l_work = exp_lanczos_work(A, v, m, verbose)
+    vp = similar(v)
+    exp_lanczos!(A, v, τ, m, vp, l_work...; βtol = βtol, verbose = verbose)
+    vp
+end

--- a/src/exp_lanczos.jl
+++ b/src/exp_lanczos.jl
@@ -18,16 +18,22 @@ function exp_lanczos_work{T<:Number}(A :: LinearOperator,
 end
 
 if VERSION ≥ v"0.5.0-dev"
-  """Used to calculate the subspace exponetial, where `T` is tridiagonal"""
-  function expT(α, β, v, τ, β₀)
+  """Used to calculate the subspace exponential, where `T` is tridiagonal"""
+  function expT{T<:Number, R<:Real}(α :: Vector{R},
+                                    β :: Vector{R},
+                                    V :: Matrix{T},
+                                    τ :: T, β₀ :: R)
     ee = eigfact(SymTridiagonal(α, β))
-    β₀ * v * ee[:vectors] * Diagonal(exp(τ * ee[:values])) * ee[:vectors][1,:]
+    β₀ * V * ee[:vectors] * Diagonal(exp(τ * ee[:values])) * ee[:vectors][1,:]
   end
 else
-  """Used to calculate the subspace exponetial, where `T` is tridiagonal"""
-  function expT(α, β, v, τ, β₀)
+  """Used to calculate the subspace exponential, where `T` is tridiagonal"""
+  function expT{T<:Number, R<:Real}(α :: Vector{R},
+                                    β :: Vector{R},
+                                    V :: Matrix{T},
+                                    τ :: T, β₀ :: R)
     ee = eigfact(SymTridiagonal(α,β))
-    β₀ * v * ee[:vectors] * Diagonal(exp(τ * ee[:values])) * ee[:vectors][1,:]'
+    β₀ * V * ee[:vectors] * Diagonal(exp(τ * ee[:values])) * ee[:vectors][1,:]'
   end
 end
 

--- a/src/exp_lanczos.jl
+++ b/src/exp_lanczos.jl
@@ -1,20 +1,7 @@
-# An implementation of exp(τA)v for Hermitian operators A.
-#
-# exp(τA)v = β₀Vₘ exp(τTₘ)e₁
-#
-# The implementation follows
-# Saad, Y. (1992). Analysis of some krylov subspace
-# approximations. SIAM Journal on Numerical Analysis.
-#
-# The error estimates/stopping criteria are borrowed from
-# cg_lanczos.jl
-#
-# Stefanos Carlström, <stefanos.carlstrom@gmail.com>
-# Lund, Sweden, May 2016.
-
 export exp_lanczos, exp_lanczos!, exp_lanczos_work
 
-# Check arguments and allocate work arrays
+"""Check arguments and allocate work arrays for the Lanczos
+approximation to exp(τA)v"""
 function exp_lanczos_work{T<:Number}(A :: LinearOperator,
                                      v :: Array{T,1},
                                      m :: Integer,
@@ -35,13 +22,29 @@ if VERSION ≥ v"0.5.0-dev"
         ee = eigfact(SymTridiagonal(α,β))
         β₀*v*ee[:vectors]*Diagonal(exp(τ*ee[:values]))*ee[:vectors][1,:]
     end
+  """Used to calculate the subspace exponetial, where `T` is tridiagonal"""
 else
     function expT(α,β,v,τ,β₀)
         ee = eigfact(SymTridiagonal(α,β))
         β₀*v*ee[:vectors]*Diagonal(exp(τ*ee[:values]))*ee[:vectors][1,:]'
     end
+  """Used to calculate the subspace exponetial, where `T` is tridiagonal"""
 end
 
+"""
+An implementation of exp(τA)v for Hermitian operators `A`.
+
+exp(τA)v = β₀Vₘ exp(τTₘ)e₁
+
+The implementation follows
+Saad, Y. (1992). Analysis of some krylov subspace
+approximations. SIAM Journal on Numerical Analysis.
+
+The error estimates/stopping criteria are borrowed from
+cg_lanczos.jl
+
+Stefanos Carlström, <stefanos.carlstrom@gmail.com>
+Lund, Sweden, May 2016."""
 function exp_lanczos!{T<:Number,R<:Real}(A :: LinearOperator,
                                                v :: AbstractVector{T},
                                                τ :: T, m :: Integer,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,3 +16,4 @@ include("test_lsqr.jl")
 include("test_lsmr.jl")
 include("test_craigmr.jl")
 
+include("test_exp_lanczos.jl")

--- a/test/test_exp_lanczos.jl
+++ b/test/test_exp_lanczos.jl
@@ -52,7 +52,7 @@ function test_propagation(m, N, t, c = nothing;
     println("Finding initial state")
     @time E0,psi0,E_phi,phi,c = initial_state(H0, c)
     DE = Diagonal(E_phi)
-    @printf("Initial energy: %g\n", E0)
+    @printf("Initial energy: %e\n", E0)
 
     τ = -im*(t[2]-t[1])
 

--- a/test/test_exp_lanczos.jl
+++ b/test/test_exp_lanczos.jl
@@ -41,7 +41,8 @@ tot_energy(H0, psi, dx) = real(dot(psi,H0*psi))*dx
 Base.factorize{T<:Complex}(A::SymTridiagonal{T}) = factorize(Tridiagonal(diag(A,-1),diag(A), diag(A,1)))
 
 function test_propagation(m, N, t, c = nothing;
-                          verbose = false)
+                          verbose = false,
+                          cn_dist_tol = 1e-7)
     dx = 1/(N+1)
     x = linspace(dx,1-dx, N)
 
@@ -165,21 +166,23 @@ function test_propagation(m, N, t, c = nothing;
 
     @test_approx_eq_eps tot_energy(H0, psi[:,end], dx) E0 1e-8
     @test_approx_eq_eps psi_norm(psi[:,end], dx) 1 1e-8
+    @test_approx_eq_eps sumabs2(psi[:,end]-psi_cmp[:,end])*dx 0 cn_dist_tol
 end
 
 m = 15
 N = max(m+1,101)
+nt = 2001
 
 # For propagation of a single eigenstate, the propagator is
 # essentially exact
-test_propagation(m, N, linspace(0,1,3001), [1]; verbose = false)
+test_propagation(m, N, linspace(0,1,nt), [1]; verbose = false)
 println()
 println("+++++++++++++++++++++++++++++++")
 println()
-test_propagation(m, N, linspace(0,1,3001), [1,1]; verbose = false)
+test_propagation(m, N, linspace(0,1,nt), [1,1]; verbose = false)
 println()
 println("+++++++++++++++++++++++++++++++")
 println()
-test_propagation(m, N, linspace(0,1,2001), [1,1,1]; verbose = false)
+test_propagation(m, N, linspace(0,1,nt), [1,1,1]; verbose = false, cn_dist_tol = 2e-6)
 
 plot_p && show()

--- a/test/test_exp_lanczos.jl
+++ b/test/test_exp_lanczos.jl
@@ -1,0 +1,185 @@
+plot_p = "TEST_KRYLOV_PLOT" in keys(ENV)
+
+if plot_p
+    using PyCall
+    pygui(:qt)
+    using PyPlot
+    fignum = 0
+end
+
+function diff2mat(N)
+    dx = 1/(N+1)
+    SymTridiagonal(-2ones(N),ones(N-1))/(dx^2)
+end
+
+import Base: -
+    -(T::SymTridiagonal) = SymTridiagonal(-diag(T),-diag(T,1))
+
+Ham(N) = -diff2mat(N)/2
+
+function initial_state{T<:Number}(H::AbstractArray,
+                                  c::Vector{T})
+    d,v = eigs(H; nev = length(c),
+               which = :SM)
+
+    c_norm = sqrt(sumabs2(c))
+    c /= c_norm
+
+    v0 = v*c
+    E0 = dot(c.^2,d)
+
+    N = size(H, 1)
+    dx = 1/(N+1)
+
+    # Return initial state, as well as spectrum
+    E0,v0/(norm(v0)*sqrt(dx)),d,v/sqrt(dx),c
+end
+
+psi_norm(psi, dx) = norm(psi)*sqrt(dx)
+tot_energy(H0, psi, dx) = real(dot(psi,H0*psi))*dx
+
+Base.factorize{T<:Complex}(A::SymTridiagonal{T}) = factorize(Tridiagonal(diag(A,-1),diag(A), diag(A,1)))
+
+function test_propagation(m, N, t, c = nothing;
+                          verbose = false)
+    dx = 1/(N+1)
+    x = linspace(dx,1-dx, N)
+
+    c == nothing && (c = [1])
+
+    @time H0 = Ham(N)
+    println("Finding initial state")
+    @time E0,psi0,E_phi,phi,c = initial_state(H0, c)
+    DE = Diagonal(E_phi)
+    @printf("Initial energy: %g\n", E0)
+
+    τ = -im*(t[2]-t[1])
+
+
+    psi = begin
+        psi = zeros(Complex128,N,length(t))
+        psi[:,1] = psi0
+
+        H0_op = LinearOperator(H0)
+        println("Allocating work arrays")
+        @time l_work = exp_lanczos_work(H0_op, psi[:,1], m, verbose)
+
+        println("Propagating")
+        @time for i = 2:length(t)
+            do_print = (verbose || mod(i,div(length(t), 10)) == 0)
+            do_print && println("----------------------")
+            do_print && println("Step: $i")
+            exp_lanczos!(H0_op, sub(psi, :, i-1), τ, m, sub(psi, :, i), l_work...;
+                         rtol = 1e-5, verbose = do_print)
+            do_print && println("----------------------")
+        end
+        
+        psi
+    end
+
+    psi_cmp = begin
+        # A three-point discretization of the 1D time-dependent
+        # Schrödinger equation can be efficiently propagated using
+        # Crank–Nicolson.
+        I = Diagonal(ones(N))
+        F = I + τ/2*H0
+        B = I - τ/2*H0
+        psi_cmp = similar(psi)
+        psi_cmp[:,1] = psi0
+        println("Propagating using Crank–Nicolson")
+        @time for i = 2:length(t)
+            psi_cmp[:,i] = B \ (F*psi_cmp[:,i-1])
+        end
+        psi_cmp
+    end
+
+    if plot_p
+        n = map(eachindex(t)) do j
+            psi_norm(psi[:,j], dx)
+        end
+        n_cmp = map(eachindex(t)) do j
+            psi_norm(psi_cmp[:,j], dx)
+        end
+
+        E = map(eachindex(t)) do j
+            tot_energy(H0, psi[:,j], dx)
+        end
+        E_cmp = map(eachindex(t)) do j
+            tot_energy(H0, psi_cmp[:,j], dx)
+        end
+
+        function time_series_plot{T<:Number}(v::Vector{T}, args...; kwargs...)
+            av = abs(v)
+            style = length(av) > 100 ? "-" : ".-"
+            plot_f = any(av.>0) ? semilogy : plot
+            plot_f(av, style, args...; kwargs...)
+
+            margins(0,1)
+        end
+
+        function plot_state(i)
+            l = plot(x, abs2(psi[:,i]), "-", label="Lanczos, $i")
+            # plot(x, abs2(phi*exp(-im*t[i]*DE)*c), "o", color = l[1][:get_color]())
+            plot(x, abs2(psi_cmp[:,i]), "x", color = l[1][:get_color](),
+                 label="Crank–Nicolson, $i")
+        end
+
+        global fignum
+        figure(fignum+=1)
+        clf()
+        subplot(221)
+        for i = 1:4
+            plot_state(div(i*length(t),4))
+        end
+        margins(0,0.1)
+        legend(framealpha=0.75)
+        title("State")
+        subplot(243)
+        pcolormesh(t, x, abs2(psi), rasterized=true, cmap = plt[:get_cmap]("viridis"))
+        margins(0,0)
+        xlabel("t")
+        ylabel("x")
+        title("Lanczos")
+        subplot(244)
+        pcolormesh(t, x, abs2(psi_cmp), rasterized=true, cmap = plt[:get_cmap]("viridis"))
+        margins(0,0)
+        xlabel("t")
+        ylabel("x")
+        title("Crank–Nicolson")
+        subplot(223)
+        time_series_plot(n-1, label="Lanczos")
+        time_series_plot(n_cmp-1, label="Crank–Nicolson")
+        time_series_plot(vec(sumabs2(psi-psi_cmp,1)*dx), label="Distance")
+        xlabel("Step")
+        legend(framealpha=0.75)
+        title("Norm loss")
+        subplot(224)
+        time_series_plot(E-E0, label="Lanczos")
+        time_series_plot(E_cmp-E0, label="Crank–Nicolson")
+        legend(framealpha=0.75)
+        margins(0,1)
+        xlabel("Step")
+        title("Total energy loss")
+        tight_layout()
+    end
+
+    @test_approx_eq_eps tot_energy(H0, psi[:,end], dx) E0 1e-8
+    @test_approx_eq_eps psi_norm(psi[:,end], dx) 1 1e-8
+end
+
+m = 15
+N = max(m+1,101)
+
+# For propagation of a single eigenstate, the propagator is
+# essentially exact
+test_propagation(m, N, linspace(0,1,3001), [1]; verbose = false)
+println()
+println("+++++++++++++++++++++++++++++++")
+println()
+test_propagation(m, N, linspace(0,1,3001), [1,1]; verbose = false)
+println()
+println("+++++++++++++++++++++++++++++++")
+println()
+test_propagation(m, N, linspace(0,1,2001), [1,1,1]; verbose = false)
+
+plot_p && show()

--- a/test/test_exp_lanczos.jl
+++ b/test/test_exp_lanczos.jl
@@ -84,7 +84,7 @@ function test_propagation(m, N, t, c = nothing;
         # Crank–Nicolson.
         I = Diagonal(ones(N))
         F = I + τ/2*H0
-        B = I - τ/2*H0
+        B = factorize(I - τ/2*H0)
         psi_cmp = similar(psi)
         psi_cmp[:,1] = psi0
         println("Propagating using Crank–Nicolson")


### PR DESCRIPTION
I have added a routine to calculate the effect of exp(τA) on a vector v (useful for
time stepping of PDEs), where τ and v may be complex and A real symmetric
(possibly also valid for complex Hermitian A's). I have tried to implement it in
such a way that one does not need to (de)allocate a lot of working memory, if
it is used repeatedly, as it would be in time stepping. Still, there is some work to
be done, since for the test runs, ~600 k allocations totalling ~450 MB occur during
2000 time steps (10% garbage collection time, which is not good). I have not tried
to optimize it yet by calling BLAS directly, as is done in e.g. cg_lanczos. Using
Julia's profiling, it seems most of the time is spent in BLAS' dotc and Julia's
matmul, anyway.

When it comes to stopping criteria for the Krylov iteration, it is not my strong suit,
so I simply lifted it from cg_lanczos.jl. Could you have a look and see if it makes
sense?

Furthermore, I could not think of an especially good way to test the algorithm,
except for the case I would want to use it, namely propagation of the time-dependent
Schrödinger equation. I implemented time-stepping for a simple 1D particle-in-a-box,
and compare it with the solution found by Crank–Nicolson, which is very efficient
for this case (one order of magnitude faster for this case). If there is a better way of
testing, let me know.

Lastly, in the future, I would like to use this algorithm on a GPU, that is, perform
the Krylov iterations on the GPU, which is fast for matrix–vector products, and
calculate the subspace exponential on the CPU. Are there any plans in this
direction for Krylov.jl?
