### PR TITLE
Lslq paper - 2-norm error estimate

### DIFF
--- a/src/lslq.jl
+++ b/src/lslq.jl
@@ -74,9 +74,9 @@ function lslq(A :: AbstractLinearOperator, b :: Array{Float64,1}, x_exact :: Vec
   λ² = λ * λ
   ctol = conlim > 0.0 ? 1/conlim : 0.0
 
-  # Check if estimate to minimum eigenvalue of A'A provided
-  # If not but λ² > 0, use that instead
-  λ_est = max(λ², λ_est)
+  # Eigenvalue estimate is sum of regularization and
+  # eigenvalue estimate of A'A
+  λ_est = λ_est + λ²
 
   # Initialize Golub-Kahan process.
   # β₁ M u₁ = b.

--- a/src/lslq.jl
+++ b/src/lslq.jl
@@ -63,7 +63,7 @@ function lslq(A :: AbstractLinearOperator, b :: Array{Float64,1}, x_exact :: Vec
               λ :: Float64=0.0, atol :: Float64=1.0e-8, btol :: Float64=1.0e-8,
               etol :: Float64=1.0e-8, window :: Int=5,
               itmax :: Int=0, conlim :: Float64=1.0e+8, 
-              λ_est :: Float64=0.0, verbose :: Bool=false)
+              σ_est :: Float64=0.0, verbose :: Bool=false)
 
   m, n = size(A)
   size(b, 1) == m || error("Inconsistent problem size")
@@ -76,6 +76,7 @@ function lslq(A :: AbstractLinearOperator, b :: Array{Float64,1}, x_exact :: Vec
 
   # Eigenvalue estimate is sum of regularization and
   # eigenvalue estimate of A'A
+  λ_est = σ_est * σ_est
   λ_est = λ_est + λ²
 
   # Initialize Golub-Kahan process.

--- a/src/lslq.jl
+++ b/src/lslq.jl
@@ -199,16 +199,6 @@ function lslq(A :: AbstractLinearOperator, b :: Array{Float64,1}, x_exact :: Vec
 
       μ = sqrt(ᾱ  - ν * ν)       # μ₂ at first pass of loop
       ρ = sqrt(μ * μ + ν * ν - a - σ * σ) # ρ₂ at first pass of loop
-
-       @show iter
-       @show ν
-       @show μ
-       @show σ
-       @show ρ
-       @show ω
-       @show ᾱ 
-       @show β̄ 
-       println()
     end
     Anorm² = Anorm² + ᾱ  # = ‖Bₖ₋₁‖²
 
@@ -235,14 +225,6 @@ function lslq(A :: AbstractLinearOperator, b :: Array{Float64,1}, x_exact :: Vec
       ω̄ = s * δ̄ - c * ω
 
       ζ_norm = -(ψ * ζ + ϵ * ζ_old) / ω̄
-
-      # @show iter
-      # @show c
-      # @show s
-      # @show ζ
-      # @show ζ̄ 
-      # @show ζ_norm
-      # println()
     end
 
     xlqNorm² = xlqNorm² + ζ * ζ

--- a/src/lslq_methods.jl
+++ b/src/lslq_methods.jl
@@ -3,13 +3,13 @@ lslq{TA <: Number, Tb <: Number, Tc <: Number}(A :: Array{TA,2}, b :: Array{Tb,1
                                  sqd :: Bool=false,
                                  λ :: Float64=0.0, atol :: Float64=1.0e-8, btol :: Float64=1.0e-8,
                                  etol :: Float64=1.0e-8, window :: Int=5,
-                                 itmax :: Int=0, conlim :: Float64=1.0e+8, λ_est :: Float64=0.0, verbose :: Bool=false) =
-  lslq(LinearOperator(A), b, x_exact, M=M, N=N, sqd=sqd, λ=λ, atol=atol, btol=btol, etol=etol, window=window, itmax=itmax, conlim=conlim, λ_est=0.0, verbose=verbose);
+                                 itmax :: Int=0, conlim :: Float64=1.0e+8, σ_est :: Float64=0.0, verbose :: Bool=false) =
+  lslq(LinearOperator(A), b, x_exact, M=M, N=N, sqd=sqd, λ=λ, atol=atol, btol=btol, etol=etol, window=window, itmax=itmax, conlim=conlim, σ_est=0.0, verbose=verbose);
 
 lslq{TA <: Number, Tb <: Number, Tc <: Number, IA <: Integer}(A :: SparseMatrixCSC{TA,IA}, b :: Array{Tb,1}, x_exact :: Array{Tc,1};
                                                 M :: AbstractLinearOperator=opEye(size(A,1)), N :: AbstractLinearOperator=opEye(size(A,2)),
                                                 sqd :: Bool=false,
                                                 λ :: Float64=0.0, atol :: Float64=1.0e-8, btol :: Float64=1.0e-8,
                                                 etol :: Float64=1.0e-8, window :: Int=5,
-                                                itmax :: Int=0, conlim :: Float64=1.0e+8, λ_est :: Float64=0.0, verbose :: Bool=false) =
-  lslq(LinearOperator(A), b, x_exact, M=M, N=N, sqd=sqd, λ=λ, atol=atol, btol=btol, etol=etol, window=window, itmax=itmax, conlim=conlim, λ_est=0.0, verbose=verbose);
+                                                itmax :: Int=0, conlim :: Float64=1.0e+8, σ_est :: Float64=0.0, verbose :: Bool=false) =
+  lslq(LinearOperator(A), b, x_exact, M=M, N=N, sqd=sqd, λ=λ, atol=atol, btol=btol, etol=etol, window=window, itmax=itmax, conlim=conlim, σ_est=0.0, verbose=verbose);

--- a/src/lslq_methods.jl
+++ b/src/lslq_methods.jl
@@ -3,13 +3,13 @@ lslq{TA <: Number, Tb <: Number, Tc <: Number}(A :: Array{TA,2}, b :: Array{Tb,1
                                  sqd :: Bool=false,
                                  λ :: Float64=0.0, atol :: Float64=1.0e-8, btol :: Float64=1.0e-8,
                                  etol :: Float64=1.0e-8, window :: Int=5,
-                                 itmax :: Int=0, conlim :: Float64=1.0e+8, a :: Float64=0.0, verbose :: Bool=false) =
-  lslq(LinearOperator(A), b, x_exact, M=M, N=N, sqd=sqd, λ=λ, atol=atol, btol=btol, etol=etol, window=window, itmax=itmax, conlim=conlim, a=0.0, verbose=verbose);
+                                 itmax :: Int=0, conlim :: Float64=1.0e+8, λest :: Float64=0.0, verbose :: Bool=false) =
+  lslq(LinearOperator(A), b, x_exact, M=M, N=N, sqd=sqd, λ=λ, atol=atol, btol=btol, etol=etol, window=window, itmax=itmax, conlim=conlim, λest=0.0, verbose=verbose);
 
 lslq{TA <: Number, Tb <: Number, Tc <: Number, IA <: Integer}(A :: SparseMatrixCSC{TA,IA}, b :: Array{Tb,1}, x_exact :: Array{Tc,1};
                                                 M :: AbstractLinearOperator=opEye(size(A,1)), N :: AbstractLinearOperator=opEye(size(A,2)),
                                                 sqd :: Bool=false,
                                                 λ :: Float64=0.0, atol :: Float64=1.0e-8, btol :: Float64=1.0e-8,
                                                 etol :: Float64=1.0e-8, window :: Int=5,
-                                                itmax :: Int=0, conlim :: Float64=1.0e+8, a :: Float64=0.0, verbose :: Bool=false) =
-  lslq(LinearOperator(A), b, x_exact, M=M, N=N, sqd=sqd, λ=λ, atol=atol, btol=btol, etol=etol, window=window, itmax=itmax, conlim=conlim, a=0.0, verbose=verbose);
+                                                itmax :: Int=0, conlim :: Float64=1.0e+8, λest :: Float64=0.0, verbose :: Bool=false) =
+  lslq(LinearOperator(A), b, x_exact, M=M, N=N, sqd=sqd, λ=λ, atol=atol, btol=btol, etol=etol, window=window, itmax=itmax, conlim=conlim, λest=0.0, verbose=verbose);

--- a/src/lslq_methods.jl
+++ b/src/lslq_methods.jl
@@ -4,7 +4,7 @@ lslq{TA <: Number, Tb <: Number, Tc <: Number}(A :: Array{TA,2}, b :: Array{Tb,1
                                  λ :: Float64=0.0, atol :: Float64=1.0e-8, btol :: Float64=1.0e-8,
                                  etol :: Float64=1.0e-8, window :: Int=5,
                                  itmax :: Int=0, conlim :: Float64=1.0e+8, σ_est :: Float64=0.0, verbose :: Bool=false) =
-  lslq(LinearOperator(A), b, x_exact, M=M, N=N, sqd=sqd, λ=λ, atol=atol, btol=btol, etol=etol, window=window, itmax=itmax, conlim=conlim, σ_est=0.0, verbose=verbose);
+  lslq(LinearOperator(A), b, x_exact, M=M, N=N, sqd=sqd, λ=λ, atol=atol, btol=btol, etol=etol, window=window, itmax=itmax, conlim=conlim, σ_est=σ_est, verbose=verbose);
 
 lslq{TA <: Number, Tb <: Number, Tc <: Number, IA <: Integer}(A :: SparseMatrixCSC{TA,IA}, b :: Array{Tb,1}, x_exact :: Array{Tc,1};
                                                 M :: AbstractLinearOperator=opEye(size(A,1)), N :: AbstractLinearOperator=opEye(size(A,2)),
@@ -12,4 +12,4 @@ lslq{TA <: Number, Tb <: Number, Tc <: Number, IA <: Integer}(A :: SparseMatrixC
                                                 λ :: Float64=0.0, atol :: Float64=1.0e-8, btol :: Float64=1.0e-8,
                                                 etol :: Float64=1.0e-8, window :: Int=5,
                                                 itmax :: Int=0, conlim :: Float64=1.0e+8, σ_est :: Float64=0.0, verbose :: Bool=false) =
-  lslq(LinearOperator(A), b, x_exact, M=M, N=N, sqd=sqd, λ=λ, atol=atol, btol=btol, etol=etol, window=window, itmax=itmax, conlim=conlim, σ_est=0.0, verbose=verbose);
+  lslq(LinearOperator(A), b, x_exact, M=M, N=N, sqd=sqd, λ=λ, atol=atol, btol=btol, etol=etol, window=window, itmax=itmax, conlim=conlim, σ_est=σ_est, verbose=verbose);

--- a/src/lslq_methods.jl
+++ b/src/lslq_methods.jl
@@ -3,13 +3,13 @@ lslq{TA <: Number, Tb <: Number, Tc <: Number}(A :: Array{TA,2}, b :: Array{Tb,1
                                  sqd :: Bool=false,
                                  λ :: Float64=0.0, atol :: Float64=1.0e-8, btol :: Float64=1.0e-8,
                                  etol :: Float64=1.0e-8, window :: Int=5,
-                                 itmax :: Int=0, conlim :: Float64=1.0e+8, λest :: Float64=0.0, verbose :: Bool=false) =
-  lslq(LinearOperator(A), b, x_exact, M=M, N=N, sqd=sqd, λ=λ, atol=atol, btol=btol, etol=etol, window=window, itmax=itmax, conlim=conlim, λest=0.0, verbose=verbose);
+                                 itmax :: Int=0, conlim :: Float64=1.0e+8, λ_est :: Float64=0.0, verbose :: Bool=false) =
+  lslq(LinearOperator(A), b, x_exact, M=M, N=N, sqd=sqd, λ=λ, atol=atol, btol=btol, etol=etol, window=window, itmax=itmax, conlim=conlim, λ_est=0.0, verbose=verbose);
 
 lslq{TA <: Number, Tb <: Number, Tc <: Number, IA <: Integer}(A :: SparseMatrixCSC{TA,IA}, b :: Array{Tb,1}, x_exact :: Array{Tc,1};
                                                 M :: AbstractLinearOperator=opEye(size(A,1)), N :: AbstractLinearOperator=opEye(size(A,2)),
                                                 sqd :: Bool=false,
                                                 λ :: Float64=0.0, atol :: Float64=1.0e-8, btol :: Float64=1.0e-8,
                                                 etol :: Float64=1.0e-8, window :: Int=5,
-                                                itmax :: Int=0, conlim :: Float64=1.0e+8, λest :: Float64=0.0, verbose :: Bool=false) =
-  lslq(LinearOperator(A), b, x_exact, M=M, N=N, sqd=sqd, λ=λ, atol=atol, btol=btol, etol=etol, window=window, itmax=itmax, conlim=conlim, λest=0.0, verbose=verbose);
+                                                itmax :: Int=0, conlim :: Float64=1.0e+8, λ_est :: Float64=0.0, verbose :: Bool=false) =
+  lslq(LinearOperator(A), b, x_exact, M=M, N=N, sqd=sqd, λ=λ, atol=atol, btol=btol, etol=etol, window=window, itmax=itmax, conlim=conlim, λ_est=0.0, verbose=verbose);

--- a/src/lslq_methods.jl
+++ b/src/lslq_methods.jl
@@ -3,13 +3,13 @@ lslq{TA <: Number, Tb <: Number, Tc <: Number}(A :: Array{TA,2}, b :: Array{Tb,1
                                  sqd :: Bool=false,
                                  λ :: Float64=0.0, atol :: Float64=1.0e-8, btol :: Float64=1.0e-8,
                                  etol :: Float64=1.0e-8, window :: Int=5,
-                                 itmax :: Int=0, conlim :: Float64=1.0e+8, verbose :: Bool=false) =
-  lslq(LinearOperator(A), b, x_exact, M=M, N=N, sqd=sqd, λ=λ, atol=atol, btol=btol, etol=etol, window=window, itmax=itmax, conlim=conlim, verbose=verbose);
+                                 itmax :: Int=0, conlim :: Float64=1.0e+8, a :: Float64=0.0, verbose :: Bool=false) =
+  lslq(LinearOperator(A), b, x_exact, M=M, N=N, sqd=sqd, λ=λ, atol=atol, btol=btol, etol=etol, window=window, itmax=itmax, conlim=conlim, a=0.0, verbose=verbose);
 
 lslq{TA <: Number, Tb <: Number, Tc <: Number, IA <: Integer}(A :: SparseMatrixCSC{TA,IA}, b :: Array{Tb,1}, x_exact :: Array{Tc,1};
                                                 M :: AbstractLinearOperator=opEye(size(A,1)), N :: AbstractLinearOperator=opEye(size(A,2)),
                                                 sqd :: Bool=false,
                                                 λ :: Float64=0.0, atol :: Float64=1.0e-8, btol :: Float64=1.0e-8,
                                                 etol :: Float64=1.0e-8, window :: Int=5,
-                                                itmax :: Int=0, conlim :: Float64=1.0e+8, verbose :: Bool=false) =
-  lslq(LinearOperator(A), b, x_exact, M=M, N=N, sqd=sqd, λ=λ, atol=atol, btol=btol, etol=etol, window=window, itmax=itmax, conlim=conlim, verbose=verbose);
+                                                itmax :: Int=0, conlim :: Float64=1.0e+8, a :: Float64=0.0, verbose :: Bool=false) =
+  lslq(LinearOperator(A), b, x_exact, M=M, N=N, sqd=sqd, λ=λ, atol=atol, btol=btol, etol=etol, window=window, itmax=itmax, conlim=conlim, a=0.0, verbose=verbose);


### PR DESCRIPTION
This pull-request includes the addition of Gauss-Radau quadrature based upper-bound estimate of the LSLQ (and consequently LSQR) 2-norm forward error ||x_k - x*||_2. The shifted linear system that needs to be solved as part of Gauss-Radau quadrature is done via Cholesky decomposition since T_k - (\lambda_est)*I is guaranteed to be SPD.

A new stopping criterion has been added, if ||x_k - x*||_2 <= err_ubnd <= etol*||x_k||.

LSLQ also now takes an extra argument, \lambda_est, which is an underestimate of the smallest eigenvalue of A'*A. \lambda_est becomes \lambda_est + \lambda^2 since eigenvalues get shifted right when regularization is applied.

This requires \lambda_est > 0, otherwise no new behaviour should be exhibited.
