### PR TITLE
An implementation of TFQMR

### DIFF
--- a/src/Krylov.jl
+++ b/src/Krylov.jl
@@ -81,6 +81,7 @@ include("dqgmres.jl")
 include("diom.jl")
 include("symmlq.jl")
 include("cr.jl")
+include("tfqmr.jl")
 
 include("cgls.jl")
 include("crls.jl")

--- a/src/krylov_aux.jl
+++ b/src/krylov_aux.jl
@@ -4,37 +4,37 @@ Given `a` and `b`, return `(c, s, ρ)` such that
     [ c  s ] [ a ] = [ ρ ]
     [ s -c ] [ b ] = [ 0 ].
 """
-function sym_givens(a :: Float64, b :: Float64)
-	#
-	# Modeled after the corresponding Matlab function by M. A. Saunders and S.-C. Choi.
-	# http://www.stanford.edu/group/SOL/dissertations/sou-cheng-choi-thesis.pdf
-	# D. Orban, Montreal, May 2015.
+function sym_givens(a :: T, b :: T) where T <: AbstractFloat
+  #
+  # Modeled after the corresponding Matlab function by M. A. Saunders and S.-C. Choi.
+  # http://www.stanford.edu/group/SOL/dissertations/sou-cheng-choi-thesis.pdf
+  # D. Orban, Montreal, May 2015.
 
-  if b == 0.0
-    if a == 0.0
-      c = 1.0
+  if b == 0
+    if a == 0
+      c = one(T)
     else
       c = sign(a)  # In Julia, sign(0) = 0.
     end
-    s = 0.0;
-    ρ = abs(a);
+    s = zero(T)
+    ρ = abs(a)
 
-  elseif a == 0.0
-    c = 0.0;
-    s = sign(b);
-    ρ = abs(b);
+  elseif a == 0
+    c = zero(T)
+    s = sign(b)
+    ρ = abs(b)
 
   elseif abs(b) > abs(a)
-    t = a / b;
-    s = sign(b) / sqrt(1.0 + t * t);
-    c = s * t;
-    ρ = b / s;  # Computationally better than d = a / c since |c| <= |s|.
+    t = a / b
+    s = sign(b) / sqrt(one(T) + t * t)
+    c = s * t
+    ρ = b / s  # Computationally better than d = a / c since |c| ≤ |s|.
 
   else
-    t = b / a;
-    c = sign(a) / sqrt(1.0 + t * t);
-    s = c * t;
-    ρ = a / c;  # Computationally better than d = b / s since |s| <= |c|
+    t = b / a
+    c = sign(a) / sqrt(one(T) + t * t)
+    s = c * t
+    ρ = a / c  # Computationally better than d = b / s since |s| ≤ |c|
   end
 
   return (c, s, ρ)

--- a/src/tfqmr.jl
+++ b/src/tfqmr.jl
@@ -1,0 +1,113 @@
+# An implementation of TFQMR for the solution of the square linear system Ax = b.
+#
+# This method is described in
+#
+# R. W. Freund, A Transpose-Free Quasi-Minimal Residual Method for Non-Hermitian Linear Systems,
+# SIAM Journal on Scientific Computing, 14(2), pp. 470--482, 1993.
+#
+# C. T. Kelley, Iterative Methods for Linear and Nonlinear Equations,
+# SIAM Frontiers in Applied Mathematics, 16, pp. 575--601, 1995.
+#
+# Alexis Montoison, <alexis.montoison@polymtl.ca>
+# Montreal, October 2018.
+
+export tfqmr
+
+"""Solve the consistent linear system Ax = b using the transpose-free quasi-minimal residual algorithm.
+TFMQR may be used to solve unsymmetric systems.
+
+This implementation allows a right preconditioner M.
+"""
+function tfqmr(A :: AbstractLinearOperator, b :: AbstractVector{T};
+               M :: AbstractLinearOperator=opEye(),
+               atol :: T=√eps(T), rtol :: T=√eps(T),
+               itmax :: Int=0, verbose :: Bool=false) where T <: AbstractFloat
+
+  m, n = size(A)
+  m == n || error("System must be square")
+  size(b, 1) == m || error("Inconsistent problem size")
+  verbose && @printf("TFQMR: system of size %d\n", n)
+
+  # Initial solution x₀.
+  x = zeros(T, n) # x₀
+  # Compute ρ₀ = < r₀,r₀ > and residual norm ‖r₀‖₂.
+  ρ = @kdot(n, b, b)
+  rNorm = sqrt(ρ)
+  rNorm == 0 && return x, SimpleStats(true, false, [rNorm], T[], "x = 0 is a zero-residual solution")
+
+  iter = 0
+  itmax == 0 && (itmax = 2*n)
+
+  rNorms = [rNorm;]
+  ε = atol + rtol * rNorm
+  verbose && @printf("%5d  %7.1e\n", iter, rNorm)
+
+  # Set up workspace.
+  y = copy(b)     # y₀
+  w = copy(b)     # w₀
+  d = zeros(T, n) # d₀
+  τ = rNorm       # τ₀
+  η = zero(T)     # η₀
+  s = zero(T)     # s₀
+  c = one(T)      # c₀
+  z = M * y       # z₀
+  u = A * z       # u₀
+  v = copy(u)     # v₀
+
+  solved = rNorm ≤ ε
+  tired = iter ≥ itmax
+  status = "unknown"
+
+  while !(solved || tired)
+
+    σ = @kdot(n, v, b)                             # σₖ = < vₖ,r₀ >
+    α = ρ / σ                                      # αₖ = ρₖ / σₖ
+
+    @kaxpy!(n, -α, u, w)                           # w₂ₖ₊₁ = w₂ₖ - αₖ * u₂ₖ
+    @kaxpby!(n, one(T), z, s^2 / c^2 * η / α, d)   # d₂ₖ₊₁ = z₂ₖ + η₂ₖ * (s₂ₖ / c₂ₖ)² / αₖ * d₂ₖ
+    nw = @knrm2(n, w)                              # [c₂ₖ₊₁  s₂ₖ₊₁][   τ₂ₖ  ] = [γ₂ₖ]
+    (c, s, γ) = sym_givens(τ, nw)                  # [s₂ₖ₊₁ -c₂ₖ₊₁][‖w₂ₖ₊₁‖₂] = [ 0 ]
+    τ = s * τ                                      # τ₂ₖ₊₁ = s₂ₖ₊₁ * τ₂ₖ
+    η = c * c * α                                  # η₂ₖ₊₁ = (c₂ₖ₊₁)² * αₖ
+    @kaxpy!(n, η, d, x)                            # x₂ₖ₊₁ = x₂ₖ + η₂ₖ₊₁ * d₂ₖ₊₁
+    @kaxpy!(n, -α, v, y)                           # y₂ₖ₊₁ = y₂ₖ - αₖ * vₖ
+    z = M * y                                      # z₂ₖ₊₁ = M⁻¹ * y₂ₖ
+    u = A * z                                      # u₂ₖ₊₁ = A * z₂ₖ₊₁
+
+    @kaxpy!(n, -α, u, w)                           # w₂ₖ₊₂ = w₂ₖ₊₁ - αₖ * u₂ₖ₊₁
+    @kaxpby!(n, one(T), z, s^2 / c^2 * η / α, d)   # d₂ₖ₊₂ = z₂ₖ₊₁ + η₂ₖ₊₁ * (s₂ₖ₊₁ / c₂ₖ₊₁)² / αₖ * d₂ₖ₊₁
+    nw = @knrm2(n, w)                              # [c₂ₖ₊₂  s₂ₖ₊₂][  τ₂ₖ₊₁ ] = [γ₂ₖ₊₁]
+    (c, s, γ) = sym_givens(τ, nw)                  # [s₂ₖ₊₂ -c₂ₖ₊₂][‖w₂ₖ₊₂‖₂] = [  0  ]
+    τ = s * τ                                      # τ₂ₖ₊₂ = s₂ₖ₊₂ * τ₂ₖ₊₁
+    η = c * c * α                                  # η₂ₖ₊₂ = (c₂ₖ₊₂)² * αₖ
+    @kaxpy!(n, η, d, x)                            # x₂ₖ₊₂ = x₂ₖ₊₁ + η₂ₖ₊₂ * d₂ₖ₊₂
+
+    ρ_next = @kdot(n, w, b)                        # ρₖ₊₁ = < w₂ₖ₊₂,r₀ >
+    β = ρ_next / ρ                                 # βₖ = ρₖ₊₁ / ρₖ
+    ρ = ρ_next                                     # ρₖ ← ρₖ₊₁
+
+    @kaxpby!(n, one(T), w, β, y)                   # y₂ₖ₊₂ = w₂ₖ₊₂ + βₖ * y₂ₖ₊₁
+    @kaxpby!(n, one(T), u, β, v); @kscal!(n, β, v) # vₐᵤₓ = βₖ * (u₂ₖ₊₁ + βₖ * vₖ)
+    z = M * y                                      # z₂ₖ₊₂ = M⁻¹ * y₂ₖ₊₂
+    u = A * z                                      # u₂ₖ₊₂ = A * z₂ₖ₊₂
+
+    @kaxpy!(n, one(T), u, v)                       # vₖ₊₁ = u₂ₖ₊₂ + vₐᵤₓ
+    
+    # Update iteration index.
+    iter = iter + 1
+    
+    # Compute residual norm estimate, ‖rₖ‖₂ ≤ √(2k+1) * τ₂ₖ.
+    rNorm = sqrt(2 * iter + 1) * τ
+    push!(rNorms, rNorm)
+
+    # Update stopping criterion.
+    solved = rNorm ≤ ε
+    tired = iter ≥ itmax
+    verbose && @printf("%5d  %7.1e\n", iter, rNorm)
+  end
+  verbose && @printf("\n")
+
+  status = tired ? "maximum number of iterations exceeded" : "solution good enough given atol and rtol"
+  stats = SimpleStats(solved, false, rNorms, T[], status)
+  return (x, stats)
+end

--- a/src/variants.jl
+++ b/src/variants.jl
@@ -10,7 +10,7 @@ function preallocated_LinearOperator(A)
 end
 
 # Variants where A is a matrix without specific properties
-for fn in (:cgls, :cgne, :craig, :craigmr, :crls, :crmr, :lslq, :lsmr, :lsqr, :dqgmres, :diom, :cgs)
+for fn in (:cgls, :cgne, :craig, :craigmr, :crls, :crmr, :lslq, :lsmr, :lsqr, :dqgmres, :diom, :cgs, :tfqmr)
   @eval begin
     $fn(A :: AbstractMatrix{TA}, b :: AbstractVector{Tb}, args...; kwargs...) where {TA, Tb <: Number} =
       $fn(preallocated_LinearOperator(A), convert(Vector{Float64}, b), args...; kwargs...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@ include("test_aux.jl")
 
 include("test_diom.jl")
 include("test_cgs.jl")
+include("test_tfqmr.jl")
 include("test_dqgmres.jl")
 include("test_cg.jl")
 include("test_cg_lanczos.jl")

--- a/test/test_alloc.jl
+++ b/test/test_alloc.jl
@@ -106,6 +106,15 @@ expected_crmr_bytes = storage_crmr_bytes(n, m)
 actual_crmr_bytes = @allocated crmr(Au, c)
 @test actual_crmr_bytes ≤ 1.1 * expected_crmr_bytes
 
+# without preconditioner and with Ap preallocated, TFQMR needs 5 n-vectors: x, y, w, d, v
+storage_tfqmr(n) = 5 * n
+storage_tfqmr_bytes(n) = 8 * storage_tfqmr(n)
+
+expected_tfqmr_bytes = storage_tfqmr_bytes(n)
+tfqmr(A, b)  # warmup
+actual_tfqmr_bytes = @allocated tfqmr(A, b)
+@test actual_tfqmr_bytes ≤ 1.1 * expected_tfqmr_bytes
+
 # without preconditioner and with Ap preallocated, CGS needs 5 n-vectors: x, r, u, p, q
 storage_cgs(n) = 5 * n
 storage_cgs_bytes(n) = 8 * storage_cgs(n)

--- a/test/test_mp.jl
+++ b/test/test_mp.jl
@@ -1,7 +1,7 @@
 function test_mp()
   @printf("Tests of multi-precision methods:\n")
   n = 5
-  for fn in (:cg, :cgls)
+  for fn in (:cg, :cgls, :tfqmr)
     @printf("%s ", string(fn))
     for T in (Float16, Float32, Float64, BigFloat)
       M = spdiagm(-1 => ones(T,n-1), 0 => 4*ones(T,n), 1 => ones(T,n-1))

--- a/test/test_tfqmr.jl
+++ b/test/test_tfqmr.jl
@@ -1,0 +1,75 @@
+function test_tfqmr()
+  tfqmr_tol = 1.0e-6
+
+  # Symmetric and positive definite variant.
+  A, b = symmetric_definite()
+  (x, stats) = tfqmr(A, b)
+  r = b - A * x
+  resid = norm(r) / norm(b)
+  @printf("TFQMR: Relative residual: %8.1e\n", resid)
+  @test(resid ≤ tfqmr_tol)
+  @test(stats.solved)
+
+  # Symmetric indefinite variant.
+  A, b = symmetric_indefinite()
+  (x, stats) = tfqmr(A, b)
+  r = b - A * x
+  resid = norm(r) / norm(b)
+  @printf("TFQMR: Relative residual: %8.1e\n", resid)
+  @test(resid ≤ tfqmr_tol)
+  @test(stats.solved)
+
+  # Nonsymmetric and positive definite variant.
+  A, b = nonsymmetric_definite()
+  (x, stats) = tfqmr(A, b)
+  r = b - A * x
+  resid = norm(r) / norm(b)
+  @printf("TFQMR: Relative residual: %8.1e\n", resid)
+  @test(resid ≤ tfqmr_tol)
+  @test(stats.solved)
+
+  # Nonsymmetric indefinite variant.
+  A, b = nonsymmetric_indefinite()
+  (x, stats) = tfqmr(A, b)
+  r = b - A * x
+  resid = norm(r) / norm(b)
+  @printf("TFQMR: Relative residual: %8.1e\n", resid)
+  @test(resid ≤ tfqmr_tol)
+  @test(stats.solved)
+
+  # Code coverage.
+  (x, stats) = tfqmr(Matrix(A), b)
+  show(stats)
+
+  # Sparse Laplacian.
+  A, b = sparse_laplacian()
+  (x, stats) = tfqmr(A, b)
+  r = b - A * x
+  resid = norm(r) / norm(b)
+  @printf("TFQMR: Relative residual: %8.1e\n", resid)
+  @test(resid ≤ tfqmr_tol)
+  @test(stats.solved)
+
+  # Test b == 0
+  A, b = zero_rhs()
+  (x, stats) = diom(A, b)
+  @test x == zeros(size(A,1))
+  @test stats.status == "x = 0 is a zero-residual solution"
+
+  # Test integer values
+  A, b = square_int()
+  (x, stats) = tfqmr(A, b)
+  @test stats.solved
+
+  # Test with Jacobi (or diagonal) preconditioner
+  A, b, M = square_preconditioned()
+  (x, stats) = tfqmr(A, b, M=M)
+  show(stats)
+  r = b - A * x
+  resid = norm(r) / norm(b)
+  @printf("TFQMR: Relative residual: %8.1e\n", resid)
+  @test(resid ≤ tfqmr_tol)
+  @test(stats.solved)
+end
+
+test_tfqmr()

--- a/test/test_variants.jl
+++ b/test/test_variants.jl
@@ -3,7 +3,7 @@ function test_variants()
   @printf("Tests of variants:\n")
   for fn in (:cg_lanczos, :cg_lanczos_shift_seq, :cg, :cgls, :cgne,
              :cr, :craig, :craigmr, :crls, :crmr, :lslq, :lsmr,
-             :lsqr, :minres, :symmlq, :dqgmres, :diom, :cgs)
+             :lsqr, :minres, :symmlq, :dqgmres, :diom, :cgs, :tfqmr)
     @printf("%s ", string(fn))
     for TA in (Int32, Int64, Float32, Float64)
       for IA in (Int32, Int64)


### PR DESCRIPTION
Version of TFQMR where symmetric Givens cosines/sines (c,s) are used instead of the classic formulation with tangents/cosines (θ,c). Like CGS, it's right preconditioning.

![tfqmr1](https://user-images.githubusercontent.com/35051714/47179667-a65c9400-d2ec-11e8-8cb6-e8927589446f.png)
![tfqmr2](https://user-images.githubusercontent.com/35051714/47179668-a65c9400-d2ec-11e8-823f-2c372d6b55e7.png)
