### PR TITLE
Preconditioned CG_LANCZOS

### DIFF
--- a/test/test_cg_lanczos.jl
+++ b/test/test_cg_lanczos.jl
@@ -60,6 +60,16 @@ function test_cg_lanczos()
   A, b = square_int()
   (x, stats) = cg_lanczos(A, b)
   @test stats.solved
+
+  # Test with Jacobi (or diagonal) preconditioner
+  A, b, M = square_preconditioned()
+  (x, stats) = cg_lanczos(A, b, M=M)
+  show(stats)
+  r = b - A * x
+  resid = norm(r) / norm(b)
+  @printf("CG_Lanczos: Relative residual: %8.1e\n", resid)
+  @test(resid ≤ cg_tol)
+  @test(stats.solved)
 end
 
 test_cg_lanczos()


### PR DESCRIPTION
#52 
I preconditioned those methods the same way that I did in `DQGMRES` in `DIOM`.  Lanczos orthogonalization is just a special case of Arnoldi orthogonalization, so we can add a preconditioner the same way.

However I don't really understood how we have the relations for updating `p` and `x`. I only know how to derived relations with a LU factorization of `Tₘ` and  it's quite different.  I suppose that we modified them with the help of the relation `σⱼ² (δⱼ - ωⱼ₋₁ / γⱼ₋₁) = pⱼᵀ A pⱼ`. 