### PR TITLE
Allocations tests for LSQR

### DIFF
--- a/src/crls.jl
+++ b/src/crls.jl
@@ -33,7 +33,7 @@ applying MINRES to the normal equations
 This implementation recurs the residual r := b - Ax.
 
 CRLS produces monotonic residuals ‖r‖₂ and optimality residuals ‖A'r‖₂.
-It is formally equivalent to LSMR, though can be slightly less accurate,
+It is formally equivalent to LSMR, though can be substantially less accurate,
 but simpler to implement.
 """
 function crls(A :: AbstractLinearOperator, b :: AbstractVector{T};

--- a/src/lsmr.jl
+++ b/src/lsmr.jl
@@ -37,7 +37,7 @@ LSQR is formally equivalent to applying MINRES to the normal equations
 (and therefore to CRLS) but is more stable.
 
 LSMR produces monotonic residuals ‖r‖₂ and optimality residuals ‖Aᵀr‖₂.
-It is formally equivalent to CRLS, though can be slightly more accurate.
+It is formally equivalent to CRLS, though can be substantially more accurate.
 
 Preconditioners M and N may be provided in the form of linear operators and are
 assumed to be symmetric and positive definite. If `sqd` is set to `true`,

--- a/test/test_alloc.jl
+++ b/test/test_alloc.jl
@@ -138,6 +138,16 @@ expected_cgls_bytes = storage_cgls_bytes(n, m)
 actual_cgls_bytes = @allocated cgls(Ao, b)
 @test actual_cgls_bytes ≤ 1.1 * expected_cgls_bytes
 
+# without preconditioner and with (Ap, Aᵀq) preallocated, LSQR needs:
+# - 3 m-vectors: x, v, w
+# - 1 n-vector: u
+storage_lsqr(n, m) = 3 * m + n
+storage_lsqr_bytes(n, m) = 8 * storage_lsqr(n, m)
+expected_lsqr_bytes = storage_lsqr_bytes(n, m)
+(x, stats) = lsqr(Ao, b)  # warmup
+actual_lsqr_bytes = @allocated lsqr(Ao, b)
+@test actual_lsqr_bytes ≤ 1.1 * expected_lsqr_bytes
+
 # without preconditioner and with (Ap, Aᵀq) preallocated, LSMR needs:
 # - 4 m-vectors: x, v, h, hbar
 # - 1 n-vector: u


### PR DESCRIPTION
I replace `slightly` by `substantially` like you recommanded.
Modifications are similar to `LSMR` ones. Except 2 other allocations mistakes.
- A vector `d` was allocated at each iteration and was not needed.
- A vector `var` was used but it didn't seem to have any special utility.