### PR TITLE
Add a @kaxpby! operation in CG

### DIFF
--- a/src/cg.jl
+++ b/src/cg.jl
@@ -79,8 +79,7 @@ function cg(A :: AbstractLinearOperator, b :: AbstractVector{T};
       β = γ_next / γ;
       γ = γ_next;
 
-      @kscal!(n, β, p)
-      @kaxpy!(n, one(T), z, p)
+      @kaxpby!(n, one(T), z, β, p)
     end
 
     iter = iter + 1;


### PR DESCRIPTION
```julia
n = 10^8
p = rand(n)
z = rand(n)
β = rand()
@time @kscal!(n, β, p)
0.092621 seconds (4 allocations: 160 bytes)
@time @kaxpy!(n, 1.0, z, p)
0.128674 seconds (4 allocations: 160 bytes)
@time @kaxpby!(n, 1.0, z, β, p)
0.147128 seconds (4 allocations: 160 bytes)
```
Benchmarks:
https://gist.github.com/amontoison/49edb603cf7d975b5e73b0e6f61fcf99