### PR TITLE
Allocations tests for MINRES

### DIFF
--- a/src/krylov_aux.jl
+++ b/src/krylov_aux.jl
@@ -172,3 +172,11 @@ end
 macro kaxpby!(n, s, x, t, y)
   return esc(:(krylov_axpby!($n, $s, $x, 1, $t, $y, 1)))
 end
+
+macro kswap(x, y)
+  quote
+    local tmp = $(esc(x))
+    $(esc(x)) = $(esc(y))
+    $(esc(y)) = tmp
+  end
+end

--- a/src/minres.jl
+++ b/src/minres.jl
@@ -169,7 +169,7 @@ function minres(A :: AbstractLinearOperator, b :: AbstractVector{T};
 
     # Update directions for x.
     if iter ≥ 2
-      w1, w2 = w2, w
+      @kswap(w1, w2)
     end
 
     # Compute lower bound on forward error.

--- a/test/test_alloc.jl
+++ b/test/test_alloc.jl
@@ -20,8 +20,8 @@ cg(A, b)  # warmup
 actual_cg_bytes = @allocated cg(A, b)
 @test actual_cg_bytes ≤ 1.1 * expected_cg_bytes
 
-# without preconditioner and with Ap preallocated, MINRES needs 6 n-vectors: x, r1, r2, v, w1, w2
-storage_minres(n) = 6 * n
+# without preconditioner and with Ap preallocated, MINRES needs 5 n-vectors: x, r1, r2, w1, w2
+storage_minres(n) = 5 * n
 storage_minres_bytes(n) = 8 * storage_minres(n)
 
 expected_minres_bytes = storage_minres_bytes(n)

--- a/test/test_alloc.jl
+++ b/test/test_alloc.jl
@@ -20,16 +20,13 @@ cg(A, b)  # warmup
 actual_cg_bytes = @allocated cg(A, b)
 @test actual_cg_bytes ≤ 1.1 * expected_cg_bytes
 
-# without preconditioner and with Ap preallocated, MINRES needs 7 n-vectors: x, r1, r2, v, w, w1, w2
-storage_minres(n) = 7 * n
+# without preconditioner and with Ap preallocated, MINRES needs 6 n-vectors: x, r1, r2, v, w1, w2
+storage_minres(n) = 6 * n
 storage_minres_bytes(n) = 8 * storage_minres(n)
 
 expected_minres_bytes = storage_minres_bytes(n)
-println(expected_minres_bytes)
 minres(A, b)  # warmup
 actual_minres_bytes = @allocated minres(A, b)
-println(actual_minres_bytes)
-println(actual_minres_bytes / expected_minres_bytes)
 @test actual_minres_bytes ≤ 1.1 * expected_minres_bytes
 
 # without preconditioner and with Ap preallocated, DIOM needs:

--- a/test/test_alloc.jl
+++ b/test/test_alloc.jl
@@ -20,6 +20,18 @@ cg(A, b)  # warmup
 actual_cg_bytes = @allocated cg(A, b)
 @test actual_cg_bytes ≤ 1.1 * expected_cg_bytes
 
+# without preconditioner and with Ap preallocated, MINRES needs 7 n-vectors: x, r1, r2, v, w, w1, w2
+storage_minres(n) = 7 * n
+storage_minres_bytes(n) = 8 * storage_minres(n)
+
+expected_minres_bytes = storage_minres_bytes(n)
+println(expected_minres_bytes)
+minres(A, b)  # warmup
+actual_minres_bytes = @allocated minres(A, b)
+println(actual_minres_bytes)
+println(actual_minres_bytes / expected_minres_bytes)
+@test actual_minres_bytes ≤ 1.1 * expected_minres_bytes
+
 # without preconditioner and with Ap preallocated, DIOM needs:
 # - 2 n-vectors: x, x_old
 # - 2 (n*mem)-matrices: P, V

--- a/test/test_minres.jl
+++ b/test/test_minres.jl
@@ -63,6 +63,16 @@ function test_minres()
   A, b = square_int()
   (x, stats) = minres(A, b)
   @test stats.solved
+
+  # Test with Jacobi (or diagonal) preconditioner
+  A, b, M = square_preconditioned()
+  (x, stats) = minres(A, b, M=M)
+  show(stats)
+  r = b - A * x
+  resid = norm(r) / norm(b)
+  @printf("MINRES: Relative residual: %8.1e\n", resid)
+  @test(resid ≤ minres_tol)
+  @test(stats.solved)
 end
 
 test_minres()


### PR DESCRIPTION
- Commit `Test preconditioned MINRES` tests that without modification, preconditioned MINRES works.
- Commit `Allocations tests for MINRES` modified `copy(...)` into `@.` and add an allocation test for MINRES in `test_alloc`.
- Commit `Remove allocation for w in MINRES` computes wₖ from  wₖ₋₁ and wₖ₋₂ (w2 and w1) without allocation.
- Commit `Remove allocation for v in MINRES` uses the relation `M * r2 / β = v` to avoid the allocation of v. 
wₖ needs vₖ, so we need to compute it during the Lanczos process and before r2 contains `βₖ₊₁ M⁻¹ * vₖ₊₁` .
