### PR TITLE
Preconditioned CG_LANCZOS_SHIFT_SEQ

### DIFF
--- a/test/test_cg_lanczos.jl
+++ b/test/test_cg_lanczos.jl
@@ -70,6 +70,18 @@ function test_cg_lanczos()
   @printf("CG_Lanczos: Relative residual: %8.1e\n", resid)
   @test(resid ≤ cg_tol)
   @test(stats.solved)
+
+  shifts = [1:10;]
+  (x, stats) = cg_lanczos_shift_seq(A, b, shifts, M=M)
+  r = residuals(A, b, shifts, x)
+  resids = map(norm, r) / norm(b)
+  @printf("CG_Lanczos: Relative residuals with shifts:")
+  for resid in resids
+    @printf(" %8.1e", resid)
+  end
+  @printf("\n")
+  @test(all(resids .≤ cg_tol))
+  @test(stats.solved)
 end
 
 test_cg_lanczos()


### PR DESCRIPTION
fix #52 
Exactly the same modifications that I did for `CG_LANCZOS`.
Except that without preconditioner we have the following relation : `δhat = vₖᵀ(A + sᵢI)vₖ = vₖᵀAvₖ + sᵢ‖vₖ‖² = δ + sᵢ`.
But with a preconditioner M, `δhat = vₖᵀ(A + sᵢI)vₖ = vₖᵀAvₖ + sᵢ‖vₖ‖² = δ + ρ * sᵢ`.
‖vₖ‖_M = 1 but ρ = ‖vₖ‖² ≠ 1.