### PR TITLE
Don't allocate w in SYMMLQ and LSLQ

### DIFF
--- a/src/lslq.jl
+++ b/src/lslq.jl
@@ -153,8 +153,7 @@ function lslq(A :: AbstractLinearOperator, b :: AbstractVector{T};
   xcgNorm  = 0.0
   xcgNorm² = 0.0
 
-  w = zeros(T, n)       # = w₀
-  w̄ = copy(v)        # = w̄₁ = v₁
+  w̄ = copy(v) # w̄₁ = v₁
 
   err_lbnd = 0.0
   err_vec = zeros(T, window)
@@ -298,9 +297,12 @@ function lslq(A :: AbstractLinearOperator, b :: AbstractVector{T};
                        1 + 2 * iter, rNorm, ArNorm, β, α, c, s, Anorm, Acond, xlqNorm)
 
     # update LSLQ point for next iteration
-    @. w = c * w̄ + s * v
+    @kaxpy!(n, c * ζ, w̄, x_lq)
+    @kaxpy!(n, s * ζ, v, x_lq)
+
+    # compute w̄
     @kaxpby!(n, -c, v, s, w̄)
-    @kaxpy!(n, ζ, w, x_lq)
+
     xlqNorm² += ζ * ζ
     xlqNorm = sqrt(xlqNorm²)
 

--- a/test/test_alloc.jl
+++ b/test/test_alloc.jl
@@ -11,8 +11,8 @@ mem = 10
 shifts  = [1:5;]
 nshifts = 5
 
-# without preconditioner and with Ap preallocated, SYMMLQ needs 5 n-vectors: x_lq, vold, v, w, wbar (= x_cg)
-storage_symmlq(n) = 5 * n
+# without preconditioner and with Ap preallocated, SYMMLQ needs 4 n-vectors: x_lq, vold, v, w̅ (= x_cg)
+storage_symmlq(n) = 4 * n
 storage_symmlq_bytes(n) = 8 * storage_symmlq(n)
 
 expected_symmlq_bytes = storage_symmlq_bytes(n)
@@ -147,9 +147,9 @@ actual_craig_bytes = @allocated craig(Au, c)
 @test actual_craig_bytes ≤ 1.1 * expected_craig_bytes
 
 # without preconditioner and with (Ap, Aᵀq) preallocated, LSLQ needs:
-# - 4 m-vectors: x_lq, v, w, w̄ (= x_cg)
+# - 3 m-vectors: x_lq, v, w̄ (= x_cg)
 # - 1 n-vector: u
-storage_lslq(n, m) = 4 * m + n
+storage_lslq(n, m) = 3 * m + n
 storage_lslq_bytes(n, m) = 8 * storage_lslq(n, m)
 expected_lslq_bytes = storage_lslq_bytes(n, m)
 (x, stats) = lslq(Ao, b)  # warmup


### PR DESCRIPTION
A little trick that I found for `USYMLQ`, `BiLQ` and `LNLQ`.
@dpo It could interested you, it's possible to avoid the allocation of `p` and only use `p̅` in your `USYMLQR`.