### PR TITLE
SYMMLQ improvements

### DIFF
--- a/src/Krylov.jl
+++ b/src/Krylov.jl
@@ -28,9 +28,9 @@ end
 mutable struct SymmlqStats{T} <: KrylovStats{T}
   solved :: Bool
   residuals :: Array{T}
-  residualscg :: Array{T}
+  residualscg :: Array{Union{T, Missing}}
   errors :: Array{T}
-  errorscg :: Array{T}
+  errorscg :: Array{Union{T, Missing}}
   Anorm :: T
   Acond :: T
   status :: String

--- a/src/krylov_utils.jl
+++ b/src/krylov_utils.jl
@@ -4,28 +4,36 @@
 
 with (ndisp - 1)/2 elements on each side.
 """
-function vec2str(x :: Array{T,1}; ndisp :: Int=7) where T <: Number
-  n = length(x);
-  if n <= ndisp
-    ndisp = n;
-    nside = n;
+function vec2str(x, ndisp :: Int=7)
+  n = length(x)
+  if n ≤ ndisp
+    ndisp = n
+    nside = n
   else
-    nside = max(1, div(ndisp - 1, 2));
+    nside = max(1, div(ndisp - 1, 2))
   end
-  s = "[ ";
-  i = 1;
-  while i <= nside
-    s *= @sprintf("%8.1e ", x[i]);
-    i += 1;
+  s = "["
+  i = 1
+  while i ≤ nside
+    if x[i] !== missing
+      s *= @sprintf("%8.1e ", x[i])
+    else
+      s *= " ✗✗✗✗ "
+    end
+      i += 1
   end
-  if i <= div(n, 2)
-    s *= "... ";
+  if i ≤ div(n, 2)
+    s *= "... "
   end;
-  i = max(i, n - nside + 1);
-  while i <= n
-    s *= @sprintf("%8.1e ", x[i]);
-    i += 1;
+  i = max(i, n - nside + 1)
+  while i ≤ n
+    if x[i] !== missing
+      s *= @sprintf("%8.1e ", x[i])
+    else
+      s *= " ✗✗✗✗ "
+    end
+    i += 1
   end
-  s *= "]";
-  return s;
+  s *= "]"
+  return s
 end

--- a/test/test_bilq.jl
+++ b/test/test_bilq.jl
@@ -66,6 +66,15 @@ function test_bilq()
   b = A * [1:n;]
   (x, stats) = bilq(A, b)
   @test stats.solved
+
+  # System that cause a breakdown with the Lanczos biorthogonalization process.
+  A, b, c = unsymmetric_breakdown()
+  (x, stats) = bilq(A, b, c=c)
+  r = b - A * x
+  resid = norm(r) / norm(b)
+  @printf("BILQ: Relative residual: %8.1e\n", resid)
+  @test(resid ≤ bilq_tol)
+  @test(stats.solved)
 end
 
 test_bilq()

--- a/test/test_symmlq.jl
+++ b/test/test_symmlq.jl
@@ -1,87 +1,89 @@
 function test_symmlq()
-  symmlq_tol = 1.0e-5
+  symmlq_tol = 1.0e-6
 
   # Symmetric and positive definite system.
-  n = 10;
+  n = 10
   A, b = symmetric_definite()
-  (x, xcg, stats) = symmlq(A, b, itmax=n+1)
+  (x, stats) = symmlq(A, b)
   r = b - A * x
   resid = norm(r) / norm(b)
   @printf("SYMMLQ: Relative residual: %8.1e\n", resid)
-  @test(resid <= symmlq_tol)
+  @test(resid ≤ symmlq_tol)
   @test(stats.solved)
 
   # Symmetric indefinite variant.
   A, b = symmetric_indefinite()
-  (x, xcg, stats) = symmlq(A, b, itmax=n+1)
+  (x, stats) = symmlq(A, b)
   r = b - A * x
   resid = norm(r) / norm(b)
   @printf("SYMMLQ: Relative residual: %8.1e\n", resid)
-  @test(resid <= symmlq_tol)
+  @test(resid ≤ symmlq_tol)
   @test(stats.solved)
 
   # Code coverage.
-  (x, xcg, stats) = symmlq(Matrix(A), b)
+  (x, stats) = symmlq(Matrix(A), b)
   show(stats)
 
-  # Sparse Laplacian (CG point will terminate sooner).
+  # Sparse Laplacian.
   A, b = sparse_laplacian()
-  (x, xcg, stats) = symmlq(A, b, atol=1e-12, rtol=1e-12)
+  (x, stats) = symmlq(A, b, atol=1e-12, rtol=1e-12)
   r = b - A * x
   resid = norm(r) / norm(b)
   @show stats
   @printf("SYMMLQ: Relative residual: %8.1e\n", resid)
-  @test(resid <= symmlq_tol)
+  @test(resid ≤ 100 * symmlq_tol)
   @test(stats.solved)
 
-  # Symmetric indefinite variant, almost singular.
-  A = A - 5 * I
-  (x, xcg, stats) = symmlq(A, b)
+  # System that cause a breakdown with the symmetric Lanczos process.
+  A, b = symmetric_breakdown()
+  (x, stats) = symmlq(A, b)
   r = b - A * x
   resid = norm(r) / norm(b)
   @printf("SYMMLQ: Relative residual: %8.1e\n", resid)
-  @test(resid <= 100 * symmlq_tol)
+  @test(resid ≤ symmlq_tol)
   @test(stats.solved)
+  show(stats)
 
   # Test b == 0
   A, b = zero_rhs()
-  (x, xcg, stats) = symmlq(A, zeros(size(A,1)))
-  @test x == zeros(size(A,1))
+  (x, stats) = symmlq(A, b)
+  @test x == b
   @test stats.status == "x = 0 is a zero-residual solution"
 
   # Test integer values
   A, b = square_int()
-  (x, xcg, stats) = symmlq(A, b)
+  (x, stats) = symmlq(A, b)
   @test stats.solved
 
   # Test error estimate
   A = Matrix(get_div_grad(8, 8, 8))
   b = ones(size(A, 1))
-  λest = (1-1e-10)*eigmin(A)
-  x_exact = A\b
-  (x, xcg, stats) = symmlq(A, b, λest=λest)
-  err = norm(x_exact - x)
+  λest = (1 - 1e-10) * eigmin(A)
+  x_exact = A \ b
+  (xlq, stats) = symmlq(A, b, λest=λest, transfer_to_cg = false)
+  xcg = cg(A, b)[1]
+  err = norm(x_exact - xlq)
   errcg = norm(x_exact - xcg)
   @printf("SYMMLQ    : true error: %8.1e\n", err)
   @printf("SYMMLQ-CG : true error: %8.1e\n", errcg)
   @printf("SYMMLQ    : err up-bnd : %8.1e\n", stats.errors[end])
   @printf("SYMMLQ-CG : err up-bnd : %8.1e\n", stats.errorscg[end])
-  @test( err <= stats.errors[end] )
-  @test( errcg <= stats.errorscg[end])
-  (x, xcg, stats) = symmlq(A, b, λest=λest, window=1)
+  @test( err ≤ stats.errors[end] )
+  @test( errcg ≤ stats.errorscg[end])
+  (x, stats) = symmlq(A, b, λest=λest, window=1)
   @printf("SYMMLQ    : err up-bnd : %8.1e\n", stats.errors[end])
   @printf("SYMMLQ-CG : err up-bnd : %8.1e\n", stats.errorscg[end])
-  @test( err <= stats.errors[end] )
-  @test( errcg <= stats.errorscg[end])
-  (x, xcg, stats) = symmlq(A, b, λest=λest, window=5)
+  @test( err ≤ stats.errors[end] )
+  @test( errcg ≤ stats.errorscg[end])
+  (x, stats) = symmlq(A, b, λest=λest, window=5)
   @printf("SYMMLQ    : err up-bnd : %8.1e\n", stats.errors[end])
   @printf("SYMMLQ-CG : err up-bnd : %8.1e\n", stats.errorscg[end])
-  @test( err <= stats.errors[end] )
-  @test( errcg <= stats.errorscg[end])
+  @test( err ≤ stats.errors[end] )
+  @test( errcg ≤ stats.errorscg[end])
 
   # Test with Jacobi (or diagonal) preconditioner
   A, b, M = square_preconditioned()
-  (x, xcg, stats) = symmlq(A, b, M=M)
+  (x, stats) = symmlq(A, b, M=M)
   show(stats)
   r = b - A * x
   resid = norm(r) / norm(b)

--- a/test/test_usymlq.jl
+++ b/test/test_usymlq.jl
@@ -104,6 +104,15 @@ function test_usymlq()
   resid = norm(r) / norm(b)
   @printf("USYMLQ: Relative residual: %8.1e\n", resid)
   @test(resid ≤ usymlq_tol)
+
+  # System that cause a breakdown with the orthogonal tridiagonalization process.
+  A, b, c = unsymmetric_breakdown()
+  (x, stats) = usymlq(A, b, c)
+  r = b - A * x
+  resid = norm(r) / norm(b)
+  @printf("USYMLQ: Relative residual: %8.1e\n", resid)
+  @test(resid ≤ usymlq_tol)
+  @test(stats.solved)
 end
 
 test_usymlq()

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -118,6 +118,22 @@ function almost_singular(n :: Int=16)
   return A, b
 end
 
+# System that cause a breakdown with the symmetric Lanczos process.
+function symmetric_breakdown()
+  A = [0.0 1.0; 1.0 0.0]
+  b = [1.0; 0.0]
+  return A, b
+end
+
+# System that cause a breakdown with the Lanczos biorthogonalization
+# and the orthogonal tridiagonalization processes.
+function unsymmetric_breakdown()
+  A = [0.0 1.0; -1.0 0.0]
+  b = [1.0; 0.0]
+  c = [-1.0; 0.0]
+  return A, b, c
+end
+
 # Square and preconditioned problems.
 function square_preconditioned(n :: Int=10)
   A = ones(n, n) + (n-1) * I


### PR DESCRIPTION
I modified SYMMLQ to be able to compute `x_lq` when `x_cg` doesn't exist.
`ζ = ζbar * c` is equal to `Inf` if `ζbar = Inf`  / `γbar = 0`.
The `η` variable has been introduce to solve this problem.