### PR TITLE
Remove A.tprod

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,5 +11,5 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-LinearOperators = "0.5.2, 0.6"
+LinearOperators = "0.7.1, 1"
 julia = "^1.0.0"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -4,4 +4,4 @@ Krylov = "ba0b0d4f-ebba-5204-a429-3ac8c609bfb7"
 LinearOperators = "5c8ed15e-5a4c-59e4-a42b-c7e8811fb125"
 
 [compat]
-LinearOperators = "0.5.2, 0.6"
+LinearOperators = "0.7.1, 1"

--- a/src/bilq.jl
+++ b/src/bilq.jl
@@ -22,7 +22,7 @@ when it exists. The transfer is based on the residual norm.
 
 This version of BiLQ works in any floating-point data type.
 """
-function bilq(A :: AbstractLinearOperator, b :: AbstractVector{T}; c :: AbstractVector{T}=b,
+function bilq(A :: AbstractLinearOperator{T}, b :: AbstractVector{T}; c :: AbstractVector{T}=b,
               atol :: T=√eps(T), rtol :: T=√eps(T), transfer_to_bicg :: Bool=true,
               itmax :: Int=0, verbose :: Bool=false) where T <: AbstractFloat
 
@@ -30,6 +30,9 @@ function bilq(A :: AbstractLinearOperator, b :: AbstractVector{T}; c :: Abstract
   m == n || error("System must be square")
   length(b) == m || error("Inconsistent problem size")
   verbose && @printf("BILQ: system of size %d\n", n)
+
+  # Compute the adjoint of A
+  Aᵀ = A'
 
   # Initial solution x₀ and residual norm ‖r₀‖.
   x = zeros(T, n)
@@ -78,8 +81,8 @@ function bilq(A :: AbstractLinearOperator, b :: AbstractVector{T}; c :: Abstract
     # AVₖ  = VₖTₖ    + βₖ₊₁vₖ₊₁(eₖ)ᵀ = Vₖ₊₁Tₖ₊₁.ₖ
     # AᵀUₖ = Uₖ(Tₖ)ᵀ + γₖ₊₁uₖ₊₁(eₖ)ᵀ = Uₖ₊₁(Tₖ.ₖ₊₁)ᵀ
 
-    q = A * vₖ       # Forms vₖ₊₁ : q ← Avₖ
-    p = A.tprod(uₖ)  # Forms uₖ₊₁ : p ← Aᵀuₖ
+    q = A  * vₖ  # Forms vₖ₊₁ : q ← Avₖ
+    p = Aᵀ * uₖ  # Forms uₖ₊₁ : p ← Aᵀuₖ
 
     @kaxpy!(n, -γₖ, vₖ₋₁, q)  # q ← q - γₖ * vₖ₋₁
     @kaxpy!(n, -βₖ, uₖ₋₁, p)  # p ← p - βₖ * uₖ₋₁

--- a/src/cg.jl
+++ b/src/cg.jl
@@ -18,7 +18,7 @@ The method does _not_ abort if A is not definite.
 A preconditioner M may be provided in the form of a linear operator and is
 assumed to be symmetric and positive definite.
 """
-function cg(A :: AbstractLinearOperator, b :: AbstractVector{T};
+function cg(A :: AbstractLinearOperator{T}, b :: AbstractVector{T};
             M :: AbstractLinearOperator=opEye(), atol :: T=√eps(T),
             rtol :: T=√eps(T), itmax :: Int=0, radius :: T=zero(T),
             verbose :: Bool=false) where T <: AbstractFloat

--- a/src/cgs.jl
+++ b/src/cgs.jl
@@ -32,7 +32,7 @@ TFQMR and BICGSTAB were developed to remedy this difficulty.»
 
 This implementation allows a right preconditioner M.
 """
-function cgs(A :: AbstractLinearOperator, b :: AbstractVector{T};
+function cgs(A :: AbstractLinearOperator{T}, b :: AbstractVector{T};
              M :: AbstractLinearOperator=opEye(),
              atol :: T=√eps(T), rtol :: T=√eps(T),
              itmax :: Int=0, verbose :: Bool=false) where T <: AbstractFloat
@@ -45,7 +45,7 @@ function cgs(A :: AbstractLinearOperator, b :: AbstractVector{T};
   # Initial solution x₀ and residual r₀.
   x = zeros(T, n) # x₀
   r = copy(b)     # r₀
-  # Compute ρ₀ = < r₀,r₀ > and residual norm ‖r₀‖₂.
+  # Compute ρ₀ = ⟨ r₀,r₀ ⟩ and residual norm ‖r₀‖₂.
   ρ = @kdot(n, r, r)
   rNorm = sqrt(ρ)
   rNorm == 0 && return x, SimpleStats(true, false, [rNorm], T[], "x = 0 is a zero-residual solution")
@@ -71,7 +71,7 @@ function cgs(A :: AbstractLinearOperator, b :: AbstractVector{T};
 
     y = M * p                    # yₘ = M⁻¹pₘ
     v = A * y                    # vₘ = Ayₘ
-    σ = @kdot(n, v, b)           # σₘ = < AM⁻¹pₘ,r₀ >
+    σ = @kdot(n, v, b)           # σₘ = ⟨ AM⁻¹pₘ,r₀ ⟩
     α = ρ / σ                    # αₘ = ρₘ / σₘ
     @. q = u - α * v             # qₘ = uₘ - αₘ * AM⁻¹pₘ
     @kaxpy!(n, one(T), q, u)     # uₘ₊½ = uₘ + qₘ
@@ -79,7 +79,7 @@ function cgs(A :: AbstractLinearOperator, b :: AbstractVector{T};
     @kaxpy!(n, α, z, x)          # xₘ₊₁ = xₘ + αₘ * M⁻¹(uₘ + qₘ)
     w = A * z                    # wₘ = AM⁻¹(uₘ + qₘ)
     @kaxpy!(n, -α, w, r)         # rₘ₊₁ = rₘ - αₘ * AM⁻¹(uₘ + qₘ)
-    ρ_next = @kdot(n, r, b)      # ρₘ₊₁ = < rₘ₊₁,r₀ >
+    ρ_next = @kdot(n, r, b)      # ρₘ₊₁ = ⟨ rₘ₊₁,r₀ ⟩
     β = ρ_next / ρ               # βₘ = ρₘ₊₁ / ρₘ
     @. u = r + β * q             # uₘ₊₁ = rₘ₊₁ + βₘ * qₘ
     @kaxpby!(n, one(T), q, β, p) # pₘ₊₁ = uₘ₊₁ + βₘ * (qₘ + βₘ * pₘ)

--- a/src/cr.jl
+++ b/src/cr.jl
@@ -14,7 +14,7 @@ A preconditioner M may be provided in the form of a linear operator and is
 assumed to be symmetric and positive definite.
 In a linesearch context, 'linesearch' must be set to 'true'.
 """
-function cr(A :: AbstractLinearOperator, b :: AbstractVector{T};
+function cr(A :: AbstractLinearOperator{T}, b :: AbstractVector{T};
             M :: AbstractLinearOperator=opEye(), atol :: T=√eps(T),
             rtol :: T=√eps(T), γ :: T=√eps(T), itmax :: Int=0,
             radius :: T=zero(T), verbose :: Bool=false, linesearch :: Bool=false) where T <: AbstractFloat

--- a/src/craig.jl
+++ b/src/craig.jl
@@ -58,7 +58,7 @@ which is equivalent to applying CG to (M + AN⁻¹Aᵀ)y = b.
 
 In this implementation, both the x and y-parts of the solution are returned.
 """
-function craig(A :: AbstractLinearOperator, b :: AbstractVector{T};
+function craig(A :: AbstractLinearOperator{T}, b :: AbstractVector{T};
                M :: AbstractLinearOperator=opEye(),
                N :: AbstractLinearOperator=opEye(),
                λ :: T=zero(T),
@@ -69,6 +69,9 @@ function craig(A :: AbstractLinearOperator, b :: AbstractVector{T};
   m, n = size(A)
   size(b, 1) == m || error("Inconsistent problem size")
   verbose && @printf("CRAIG: system of %d equations in %d variables\n", m, n)
+
+  # Compute the adjoint of A
+  Aᵀ = A'
 
   # Tests M == Iₘ and N == Iₙ
   MisI = isa(M, opEye)
@@ -133,7 +136,7 @@ function craig(A :: AbstractLinearOperator, b :: AbstractVector{T};
   while ! (solved || inconsistent || ill_cond || tired)
     # Generate the next Golub-Kahan vectors
     # 1. αₖ₊₁Nvₖ₊₁ = Aᵀuₖ₊₁ - βₖ₊₁Nvₖ
-    Aᵀu = A.tprod(u)
+    Aᵀu = Aᵀ * u
     @kaxpby!(n, one(T), Aᵀu, -β, Nv)
     v = N * Nv
     α = sqrt(@kdot(n, v, Nv))

--- a/src/craigmr.jl
+++ b/src/craigmr.jl
@@ -60,7 +60,7 @@ It is formally equivalent to CRMR, though can be slightly more accurate,
 and intricate to implement. Both the x- and y-parts of the solution are
 returned.
 """
-function craigmr(A :: AbstractLinearOperator, b :: AbstractVector{T};
+function craigmr(A :: AbstractLinearOperator{T}, b :: AbstractVector{T};
                  M :: AbstractLinearOperator=opEye(),
                  N :: AbstractLinearOperator=opEye(),
                  λ :: T=zero(T), atol :: T=√eps(T), rtol :: T=√eps(T),
@@ -69,6 +69,9 @@ function craigmr(A :: AbstractLinearOperator, b :: AbstractVector{T};
   m, n = size(A);
   size(b, 1) == m || error("Inconsistent problem size");
   verbose && @printf("CRAIG-MR: system of %d equations in %d variables\n", m, n);
+
+  # Compute the adjoint of A
+  Aᵀ = A'
 
   # Tests M == Iₘ and N == Iₙ
   MisI = isa(M, opEye)
@@ -87,7 +90,7 @@ function craigmr(A :: AbstractLinearOperator, b :: AbstractVector{T};
   @kscal!(m, one(T)/β, u)
   MisI || @kscal!(m, one(T)/β, Mu)
   # α₁Nv₁ = Aᵀu₁.
-  Aᵀu = A.tprod(u)
+  Aᵀu = Aᵀ * u
   Nv = copy(Aᵀu)
   v = N * Nv
   α = sqrt(@kdot(n, v, Nv))
@@ -166,7 +169,7 @@ function craigmr(A :: AbstractLinearOperator, b :: AbstractVector{T};
     @kaxpy!(m, ζ, w, y)             # y = y + ζ * w;
 
     # 2. αₖ₊₁Nvₖ₊₁ = Aᵀuₖ₊₁ - βₖ₊₁Nvₖ
-    Aᵀu = A.tprod(u)
+    Aᵀu = Aᵀ * u
     @kaxpby!(n, one(T), Aᵀu, -β, Nv)
     v = N * Nv
     α = sqrt(@kdot(n, v, Nv))
@@ -190,7 +193,7 @@ function craigmr(A :: AbstractLinearOperator, b :: AbstractVector{T};
     tired  = iter >= itmax
   end
 
-  Aᵀy = A.tprod(y)
+  Aᵀy = Aᵀ * y
   N⁻¹Aᵀy = N * Aᵀy
   @. x = N⁻¹Aᵀy
 

--- a/src/diom.jl
+++ b/src/diom.jl
@@ -25,7 +25,7 @@ This implementation allows a left preconditioner M and a right preconditioner N.
 - Right preconditioning : AN⁻¹u = b with x = N⁻¹u
 - Split preconditioning : M⁻¹AN⁻¹u = M⁻¹b with x = N⁻¹u
 """
-function diom(A :: AbstractLinearOperator, b :: AbstractVector{T};
+function diom(A :: AbstractLinearOperator{T}, b :: AbstractVector{T};
               M :: AbstractLinearOperator=opEye(),
               N :: AbstractLinearOperator=opEye(),
               atol :: T=√eps(T), rtol :: T=√eps(T), itmax :: Int=0,

--- a/src/dqgmres.jl
+++ b/src/dqgmres.jl
@@ -23,7 +23,7 @@ This implementation allows a left preconditioner M and a right preconditioner N.
 - Right preconditioning : AN⁻¹u = b with x = N⁻¹u
 - Split preconditioning : M⁻¹AN⁻¹u = M⁻¹b with x = N⁻¹u
 """
-function dqgmres(A :: AbstractLinearOperator, b :: AbstractVector{T};
+function dqgmres(A :: AbstractLinearOperator{T}, b :: AbstractVector{T};
                  M :: AbstractLinearOperator=opEye(),
                  N :: AbstractLinearOperator=opEye(),
                  atol :: T=√eps(T), rtol :: T=√eps(T), itmax :: Int=0,

--- a/src/lslq.jl
+++ b/src/lslq.jl
@@ -92,7 +92,7 @@ The iterations stop as soon as one of the following conditions holds true:
 * R. Estrin, D. Orban and M. A. Saunders, *Estimates of the 2-Norm Forward Error for SYMMLQ and CG*, Cahier du GERAD G-2016-70, GERAD, Montreal, 2016. DOI http://dx.doi.org/10.13140/RG.2.2.19581.77288.
 * R. Estrin, D. Orban and M. A. Saunders, *LSLQ: An Iterative Method for Linear Least-Squares with an Error Minimization Property*, Cahier du GERAD G-2017-xx, GERAD, Montreal, 2017.
 """
-function lslq(A :: AbstractLinearOperator, b :: AbstractVector{T};
+function lslq(A :: AbstractLinearOperator{T}, b :: AbstractVector{T};
               M :: AbstractLinearOperator=opEye(),
               N :: AbstractLinearOperator=opEye(),
               sqd :: Bool=false, λ :: T=zero(T), σ :: T=zero(T),
@@ -107,6 +107,9 @@ function lslq(A :: AbstractLinearOperator, b :: AbstractVector{T};
   # Tests M == Iₙ and N == Iₘ
   MisI = isa(M, opEye)
   NisI = isa(N, opEye)
+
+  # Compute the adjoint of A
+  Aᵀ = A'
 
   # If solving an SQD system, set regularization to 1.
   sqd && (λ = one(T))
@@ -129,7 +132,7 @@ function lslq(A :: AbstractLinearOperator, b :: AbstractVector{T};
 
   @kscal!(m, one(T)/β₁, u)
   MisI || @kscal!(m, one(T)/β₁, Mu)
-  Aᵀu = A.tprod(u)
+  Aᵀu = Aᵀ * u
   Nv = copy(Aᵀu)
   v = N * Nv
   α = sqrt(@kdot(n, v, Nv))  # = α₁
@@ -207,7 +210,7 @@ function lslq(A :: AbstractLinearOperator, b :: AbstractVector{T};
       MisI || @kscal!(m, one(T)/β, Mu)
 
       # 2. αₖ₊₁Nvₖ₊₁ = Aᵀuₖ₊₁ - βₖ₊₁Nvₖ
-      Aᵀu = A.tprod(u)
+      Aᵀu = Aᵀ * u
       @kaxpby!(n, one(T), Aᵀu, -β, Nv)
       v = N * Nv
       α = sqrt(@kdot(n, v, Nv))

--- a/src/lsmr.jl
+++ b/src/lsmr.jl
@@ -57,7 +57,7 @@ indefinite system
 In this case, `N` can still be specified and indicates the norm
 in which `x` should be measured.
 """
-function lsmr(A :: AbstractLinearOperator, b :: AbstractVector{T};
+function lsmr(A :: AbstractLinearOperator{T}, b :: AbstractVector{T};
               M :: AbstractLinearOperator=opEye(),
               N :: AbstractLinearOperator=opEye(),
               sqd :: Bool=false,
@@ -70,6 +70,9 @@ function lsmr(A :: AbstractLinearOperator, b :: AbstractVector{T};
   m, n = size(A)
   size(b, 1) == m || error("Inconsistent problem size")
   verbose && @printf("LSMR: system of %d equations in %d variables\n", m, n)
+
+  # Compute the adjoint of A
+  Aᵀ = A'
 
   # Tests M == Iₙ and N == Iₘ
   MisI = isa(M, opEye)
@@ -90,7 +93,7 @@ function lsmr(A :: AbstractLinearOperator, b :: AbstractVector{T};
 
   @kscal!(m, one(T)/β₁, u)
   MisI || @kscal!(m, one(T)/β₁, Mu)
-  Aᵀu = A.tprod(u)
+  Aᵀu = Aᵀ * u
   Nv = copy(Aᵀu)
   v = N * Nv
   α = sqrt(@kdot(n, v, Nv))
@@ -165,7 +168,7 @@ function lsmr(A :: AbstractLinearOperator, b :: AbstractVector{T};
       MisI || @kscal!(m, one(T)/β, Mu)
 
       # 2. αₖ₊₁Nvₖ₊₁ = Aᵀuₖ₊₁ - βₖ₊₁Nvₖ
-      Aᵀu = A.tprod(u)
+      Aᵀu = Aᵀ * u
       @kaxpby!(n, one(T), Aᵀu, -β, Nv)
       v = N * Nv
       α = sqrt(@kdot(n, v, Nv))

--- a/src/lsqr.jl
+++ b/src/lsqr.jl
@@ -57,7 +57,7 @@ indefinite system
 In this case, `N` can still be specified and indicates the norm
 in which `x` should be measured.
 """
-function lsqr(A :: AbstractLinearOperator, b :: AbstractVector{T};
+function lsqr(A :: AbstractLinearOperator{T}, b :: AbstractVector{T};
               M :: AbstractLinearOperator=opEye(),
               N :: AbstractLinearOperator=opEye(),
               sqd :: Bool=false,
@@ -70,6 +70,9 @@ function lsqr(A :: AbstractLinearOperator, b :: AbstractVector{T};
   m, n = size(A)
   size(b, 1) == m || error("Inconsistent problem size")
   verbose && @printf("LSQR: system of %d equations in %d variables\n", m, n)
+
+  # Compute the adjoint of A
+  Aᵀ = A'
 
   # Tests M == Iₙ and N == Iₘ
   MisI = isa(M, opEye)
@@ -91,7 +94,7 @@ function lsqr(A :: AbstractLinearOperator, b :: AbstractVector{T};
 
   @kscal!(m, one(T)/β₁, u)
   MisI || @kscal!(m, one(T)/β₁, Mu)
-  Aᵀu = A.tprod(u)
+  Aᵀu = Aᵀ * u
   Nv = copy(Aᵀu)
   v = N * Nv
   Anorm² = @kdot(n, v, Nv)
@@ -163,7 +166,7 @@ function lsqr(A :: AbstractLinearOperator, b :: AbstractVector{T};
       λ > 0 && (Anorm² += λ²)
 
       # 2. αₖ₊₁Nvₖ₊₁ = Aᵀuₖ₊₁ - βₖ₊₁Nvₖ
-      Aᵀu = A.tprod(u)
+      Aᵀu = Aᵀ * u
       @kaxpby!(n, one(T), Aᵀu, -β, Nv)
       v = N * Nv
       α = sqrt(@kdot(n, v, Nv))

--- a/src/minres.jl
+++ b/src/minres.jl
@@ -42,7 +42,7 @@ MINRES produces monotonic residuals ‖r‖₂ and optimality residuals ‖Aᵀr
 A preconditioner M may be provided in the form of a linear operator and is
 assumed to be symmetric and positive definite.
 """
-function minres(A :: AbstractLinearOperator, b :: AbstractVector{T};
+function minres(A :: AbstractLinearOperator{T}, b :: AbstractVector{T};
                 M :: AbstractLinearOperator=opEye(), λ :: T=zero(T),
                 atol :: T=√eps(T)/100, rtol :: T=√eps(T)/100, etol :: T=√eps(T),
                 window :: Int=5, itmax :: Int=0, conlim :: T=1/√eps(T),

--- a/src/minres_qlp.jl
+++ b/src/minres_qlp.jl
@@ -23,7 +23,7 @@ It is significantly more complex but can be more reliable than MINRES when A is 
 
 This version of MINRES-QLP works in any floating-point data type.
 """
-function minres_qlp(A :: AbstractLinearOperator, b :: AbstractVector{T};
+function minres_qlp(A :: AbstractLinearOperator{T}, b :: AbstractVector{T};
                     atol :: T=√eps(T), rtol :: T=√eps(T), λ ::T=zero(T),
                     itmax :: Int=0, verbose :: Bool=false) where T <: AbstractFloat
 

--- a/src/qmr.jl
+++ b/src/qmr.jl
@@ -26,7 +26,7 @@ When A is symmetric and b = c, QMR is equivalent to MINRES.
 
 This version of QMR works in any floating-point data type.
 """
-function qmr(A :: AbstractLinearOperator, b :: AbstractVector{T}; c :: AbstractVector{T}=b,
+function qmr(A :: AbstractLinearOperator{T}, b :: AbstractVector{T}; c :: AbstractVector{T}=b,
              atol :: T=√eps(T), rtol :: T=√eps(T),
              itmax :: Int=0, verbose :: Bool=false) where T <: AbstractFloat
 
@@ -34,6 +34,9 @@ function qmr(A :: AbstractLinearOperator, b :: AbstractVector{T}; c :: AbstractV
   m == n || error("System must be square")
   length(b) == m || error("Inconsistent problem size")
   verbose && @printf("QMR: system of size %d\n", n)
+
+  # Compute the adjoint of A
+  Aᵀ = A'
 
   # Initial solution x₀ and residual norm ‖r₀‖.
   x = zeros(T, n)
@@ -80,8 +83,8 @@ function qmr(A :: AbstractLinearOperator, b :: AbstractVector{T}; c :: AbstractV
     # AVₖ  = VₖTₖ    + βₖ₊₁vₖ₊₁(eₖ)ᵀ = Vₖ₊₁Tₖ₊₁.ₖ
     # AᵀUₖ = Uₖ(Tₖ)ᵀ + γₖ₊₁uₖ₊₁(eₖ)ᵀ = Uₖ₊₁(Tₖ.ₖ₊₁)ᵀ
 
-    q = A * vₖ       # Forms vₖ₊₁ : q ← Avₖ
-    p = A.tprod(uₖ)  # Forms uₖ₊₁ : p ← Aᵀuₖ
+    q = A  * vₖ  # Forms vₖ₊₁ : q ← Avₖ
+    p = Aᵀ * uₖ  # Forms uₖ₊₁ : p ← Aᵀuₖ
 
     @kaxpy!(n, -γₖ, vₖ₋₁, q)  # q ← q - γₖ * vₖ₋₁
     @kaxpy!(n, -βₖ, uₖ₋₁, p)  # p ← p - βₖ * uₖ₋₁

--- a/src/symmlq.jl
+++ b/src/symmlq.jl
@@ -24,7 +24,7 @@ SYMMLQ produces monotonic errors ‖x*-x‖₂.
 A preconditioner M may be provided in the form of a linear operator and is
 assumed to be symmetric and positive definite.
 """
-function symmlq(A :: AbstractLinearOperator, b :: AbstractVector{T};
+function symmlq(A :: AbstractLinearOperator{T}, b :: AbstractVector{T};
                 M :: AbstractLinearOperator=opEye(), λ :: T=zero(T),
                 λest :: T=zero(T), atol :: T=√eps(T), rtol :: T=√eps(T),
                 etol :: T=√eps(T), window :: Int=0, itmax :: Int=0,

--- a/src/usymlq.jl
+++ b/src/usymlq.jl
@@ -33,7 +33,7 @@ when it exists. The transfer is based on the residual norm.
 
 This version of USYMLQ works in any floating-point data type.
 """
-function usymlq(A :: AbstractLinearOperator, b :: AbstractVector{T}, c :: AbstractVector{T};
+function usymlq(A :: AbstractLinearOperator{T}, b :: AbstractVector{T}, c :: AbstractVector{T};
                 atol :: T=√eps(T), rtol :: T=√eps(T), transfer_to_usymcg :: Bool=true,
                 itmax :: Int=0, verbose :: Bool=false) where T <: AbstractFloat
 
@@ -41,6 +41,9 @@ function usymlq(A :: AbstractLinearOperator, b :: AbstractVector{T}, c :: Abstra
   length(b) == m || error("Inconsistent problem size")
   length(c) == n || error("Inconsistent problem size")
   verbose && @printf("USYMLQ: system of %d equations in %d variables\n", m, n)
+
+  # Compute the adjoint of A
+  Aᵀ = A'
 
   # Initial solution x₀ and residual norm ‖r₀‖.
   x = zeros(T, n)
@@ -62,7 +65,7 @@ function usymlq(A :: AbstractLinearOperator, b :: AbstractVector{T}, c :: Abstra
   uₖ₋₁ = zeros(T, n)         # u₀ = 0
   vₖ = b / βₖ                # v₁ = b / β₁
   uₖ = c / γₖ                # u₁ = c / γ₁
-  cₖ₋₁ = cₖ = - one(T)       # Givens cosines used for the LQ factorization of Tₖ
+  cₖ₋₁ = cₖ = -one(T)        # Givens cosines used for the LQ factorization of Tₖ
   sₖ₋₁ = sₖ = zero(T)        # Givens sines used for the LQ factorization of Tₖ
   d̅ = zeros(T, n)            # Last column of D̅ₖ = Uₖ(Qₖ)ᵀ
   ζₖ₋₁ = ζbarₖ = zero(T)     # ζₖ₋₁ and ζbarₖ are the last components of z̅ₖ = (L̅ₖ)⁻¹β₁e₁
@@ -83,8 +86,8 @@ function usymlq(A :: AbstractLinearOperator, b :: AbstractVector{T}, c :: Abstra
     # AUₖ  = VₖTₖ    + βₖ₊₁vₖ₊₁(eₖ)ᵀ = Vₖ₊₁Tₖ₊₁.ₖ
     # AᵀVₖ = Uₖ(Tₖ)ᵀ + γₖ₊₁uₖ₊₁(eₖ)ᵀ = Uₖ₊₁(Tₖ.ₖ₊₁)ᵀ
 
-    q = A * uₖ       # Forms vₖ₊₁ : q ← Auₖ
-    p = A.tprod(vₖ)  # Forms uₖ₊₁ : p ← Aᵀvₖ
+    q = A  * uₖ  # Forms vₖ₊₁ : q ← Auₖ
+    p = Aᵀ * vₖ  # Forms uₖ₊₁ : p ← Aᵀvₖ
 
     @kaxpy!(m, -γₖ, vₖ₋₁, q)  # q ← q - γₖ * vₖ₋₁
     @kaxpy!(n, -βₖ, uₖ₋₁, p)  # p ← p - βₖ * uₖ₋₁

--- a/src/usymqr.jl
+++ b/src/usymqr.jl
@@ -30,7 +30,7 @@ USYMQR finds the minimum-norm solution if problems are inconsistent.
 
 This version of USYMQR works in any floating-point data type.
 """
-function usymqr(A :: AbstractLinearOperator, b :: AbstractVector{T}, c :: AbstractVector{T};
+function usymqr(A :: AbstractLinearOperator{T}, b :: AbstractVector{T}, c :: AbstractVector{T};
                 atol :: T=√eps(T), rtol :: T=√eps(T),
                 itmax :: Int=0, verbose :: Bool=false) where T <: AbstractFloat
 
@@ -38,6 +38,9 @@ function usymqr(A :: AbstractLinearOperator, b :: AbstractVector{T}, c :: Abstra
   length(b) == m || error("Inconsistent problem size")
   length(c) == n || error("Inconsistent problem size")
   verbose && @printf("USYMQR: system of %d equations in %d variables\n", m, n)
+
+  # Compute the adjoint of A
+  Aᵀ = A'
 
   # Initial solution x₀ and residual norm ‖r₀‖.
   x = zeros(T, n)
@@ -81,8 +84,8 @@ function usymqr(A :: AbstractLinearOperator, b :: AbstractVector{T}, c :: Abstra
     # AUₖ  = VₖTₖ    + βₖ₊₁vₖ₊₁(eₖ)ᵀ = Vₖ₊₁Tₖ₊₁.ₖ
     # AᵀVₖ = Uₖ(Tₖ)ᵀ + γₖ₊₁uₖ₊₁(eₖ)ᵀ = Uₖ₊₁(Tₖ.ₖ₊₁)ᵀ
 
-    q = A * uₖ      # Forms vₖ₊₁ : q ← Auₖ
-    p = A.tprod(vₖ) # Forms uₖ₊₁ : p ← Aᵀvₖ
+    q = A  * uₖ  # Forms vₖ₊₁ : q ← Auₖ
+    p = Aᵀ * vₖ  # Forms uₖ₊₁ : p ← Aᵀvₖ
 
     @kaxpy!(m, -γₖ, vₖ₋₁, q) # q ← q - γₖ * vₖ₋₁
     @kaxpy!(n, -βₖ, uₖ₋₁, p) # p ← p - βₖ * uₖ₋₁

--- a/test/test_alloc.jl
+++ b/test/test_alloc.jl
@@ -101,6 +101,7 @@ actual_cr_bytes = @allocated cr(A, b, rtol=1e-6)
 # - 1 m-vector: r
 storage_crmr(n, m) = 2 * n + m
 storage_crmr_bytes(n, m) = 8 * storage_crmr(n, m)
+
 expected_crmr_bytes = storage_crmr_bytes(n, m)
 (x, stats) = crmr(Au, c)  # warmup
 actual_crmr_bytes = @allocated crmr(Au, c)
@@ -109,6 +110,7 @@ actual_crmr_bytes = @allocated crmr(Au, c)
 # without preconditioner and with Ap preallocated, CGS needs 5 n-vectors: x, r, u, p, q
 storage_cgs(n) = 5 * n
 storage_cgs_bytes(n) = 8 * storage_cgs(n)
+
 expected_cgs_bytes = storage_cgs_bytes(n)
 cgs(A, b)  # warmup
 actual_cgs_bytes = @allocated cgs(A, b)
@@ -130,6 +132,7 @@ actual_craigmr_bytes = @allocated craigmr(Au, c)
 # - 1 m-vector: r
 storage_cgne(n, m) = 2 * n + m
 storage_cgne_bytes(n, m) = 8 * storage_cgne(n, m)
+
 expected_cgne_bytes = storage_cgne_bytes(n, m)
 (x, stats) = cgne(Au, c)  # warmup
 actual_cgne_bytes = @allocated cgne(Au, c)
@@ -151,6 +154,7 @@ actual_craig_bytes = @allocated craig(Au, c)
 # - 1 n-vector: u
 storage_lslq(n, m) = 3 * m + n
 storage_lslq_bytes(n, m) = 8 * storage_lslq(n, m)
+
 expected_lslq_bytes = storage_lslq_bytes(n, m)
 (x, stats) = lslq(Ao, b)  # warmup
 actual_lslq_bytes = @allocated lslq(Ao, b)
@@ -161,6 +165,7 @@ actual_lslq_bytes = @allocated lslq(Ao, b)
 # - 1 n-vector: r
 storage_cgls(n, m) = n + 2 * m
 storage_cgls_bytes(n, m) = 8 * storage_cgls(n, m)
+
 expected_cgls_bytes = storage_cgls_bytes(n, m)
 (x, stats) = cgls(Ao, b)  # warmup
 actual_cgls_bytes = @allocated cgls(Ao, b)
@@ -171,6 +176,7 @@ actual_cgls_bytes = @allocated cgls(Ao, b)
 # - 1 n-vector: u
 storage_lsqr(n, m) = 3 * m + n
 storage_lsqr_bytes(n, m) = 8 * storage_lsqr(n, m)
+
 expected_lsqr_bytes = storage_lsqr_bytes(n, m)
 (x, stats) = lsqr(Ao, b)  # warmup
 actual_lsqr_bytes = @allocated lsqr(Ao, b)
@@ -181,6 +187,7 @@ actual_lsqr_bytes = @allocated lsqr(Ao, b)
 # - 2 n-vector: r, Ap
 storage_crls(n, m) = 3 * m + 2 * n
 storage_crls_bytes(n, m) = 8 * storage_crls(n, m)
+
 expected_crls_bytes = storage_crls_bytes(n, m)
 (x, stats) = crls(Ao, b)  # warmup
 actual_crls_bytes = @allocated crls(Ao, b)
@@ -191,6 +198,7 @@ actual_crls_bytes = @allocated crls(Ao, b)
 # - 1 n-vector: u
 storage_lsmr(n, m) = 4 * m + n
 storage_lsmr_bytes(n, m) = 8 * storage_lsmr(n, m)
+
 expected_lsmr_bytes = storage_lsmr_bytes(n, m)
 (x, stats) = lsmr(Ao, b)  # warmup
 actual_lsmr_bytes = @allocated lsmr(Ao, b)
@@ -201,6 +209,7 @@ actual_lsmr_bytes = @allocated lsmr(Ao, b)
 # - 2 n-vectors: uₖ₋₁, uₖ
 storage_usymqr(n, m) = 5 * m + 2 * n
 storage_usymqr_bytes(n, m) = 8 * storage_usymqr(n, m)
+
 expected_usymqr_bytes = storage_usymqr_bytes(n, m)
 (x, stats) = usymqr(Ao, b, c) # warmup
 actual_usymqr_bytes = @allocated usymqr(Ao, b, c)
@@ -210,6 +219,7 @@ actual_usymqr_bytes = @allocated usymqr(Ao, b, c)
 # - 6 n-vectors: uₖ₋₁, uₖ, vₖ₋₁, vₖ, x, d̅
 storage_bilq(n) = 6 * n
 storage_bilq_bytes(n) = 8 * storage_bilq(n)
+
 expected_bilq_bytes = storage_bilq_bytes(n)
 bilq(A, b)  # warmup
 actual_bilq_bytes = @allocated bilq(A, b)
@@ -219,6 +229,7 @@ actual_bilq_bytes = @allocated bilq(A, b)
 # - 5 n-vectors: wₖ₋₁, wₖ, vₖ₋₁, vₖ, x
 storage_minres_qlp(n) = 5 * n
 storage_minres_qlp_bytes(n) = 8 * storage_minres_qlp(n)
+
 expected_minres_qlp_bytes = storage_minres_qlp_bytes(n)
 minres_qlp(A, b)  # warmup
 actual_minres_qlp_bytes = @allocated minres_qlp(A, b)
@@ -228,6 +239,7 @@ actual_minres_qlp_bytes = @allocated minres_qlp(A, b)
 # - 7 n-vectors: uₖ₋₁, uₖ, vₖ₋₁, vₖ, x, wₖ₋₁, wₖ
 storage_qmr(n) = 7 * n
 storage_qmr_bytes(n) = 8 * storage_qmr(n)
+
 expected_qmr_bytes = storage_qmr_bytes(n)
 qmr(A, b)  # warmup
 actual_qmr_bytes = @allocated qmr(A, b)
@@ -238,6 +250,7 @@ actual_qmr_bytes = @allocated qmr(A, b)
 # - 2 m-vectors: uₖ₋₁, uₖ
 storage_usymlq(n, m) = 4 * n + 2 * m
 storage_usymlq_bytes(n, m) = 8 * storage_usymlq(n, m)
+
 expected_usymlq_bytes = storage_usymlq_bytes(n, m)
 usymlq(Au, c, b)  # warmup
 actual_usymlq_bytes = @allocated usymlq(Au, c, b)


### PR DESCRIPTION
close #135 

I remove `A.tprod` but I don't understand something.
In the `REPL` with the following code :
```julia
using LinearOperators
M = rand(100,100)
x = rand(100)
A = PreallocatedLinearOperator(M)
A2 = A'
@allocated A2 * x
A3 = A'
@allocated A3 * x
```
Nothing is allocated when I compute `A3 * x` (cost of compilation of `*` method) whereas `Aᵀ * x` seems to be recompiled inside methods even if the method was compiled before.
And `Aᵀ = A'` is not allocating if the function has been "warm up"...