### PR TITLE
BiLQR & TriLQR

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -5,6 +5,7 @@ Krylov.KrylovStats
 Krylov.SimpleStats
 Krylov.LanczosStats
 Krylov.SymmlqStats
+Krylov.AdjointStats
 ```
 
 ## Utilities

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -41,6 +41,7 @@ Given a linear operator ``A`` and a right-hand side ``b``, solve ``Ax = b``, whi
 Krylov can be installed and tested through the Julia package manager:
 
 ```julia
+julia> import Pkg
 julia> Pkg.add("Krylov")
 julia> Pkg.test("Krylov")
 ```

--- a/docs/src/solvers.md
+++ b/docs/src/solvers.md
@@ -17,9 +17,11 @@ diom
 dqgmres
 usymlq
 usymqr
+trilqr
 bilq
 cgs
 qmr
+bilqr
 cgls
 crls
 cgne

--- a/src/Krylov.jl
+++ b/src/Krylov.jl
@@ -36,6 +36,15 @@ mutable struct SymmlqStats{T} <: KrylovStats{T}
   status :: String
 end
 
+"Type for statistics returned by adjoint systems solvers"
+mutable struct AdjointStats{T} <: KrylovStats{T}
+  solved_primal :: Bool
+  solved_dual :: Bool
+  residuals_primal :: Vector{T}
+  residuals_dual :: Vector{T}
+  status :: String
+end
+
 import Base.show
 
 function show(io :: IO, stats :: SimpleStats)
@@ -72,6 +81,16 @@ function show(io :: IO, stats :: SymmlqStats)
   print(io, s)
 end
 
+function show(io :: IO, stats :: AdjointStats)
+  s  = "\nAdjoint stats\n"
+  s *= @sprintf("  solved primal: %s\n", stats.solved_primal)
+  s *= @sprintf("  solved dual:   %s\n", stats.solved_dual)
+  s *= @sprintf("  residuals primal: %s\n", vec2str(stats.residuals_primal))
+  s *= @sprintf("  residuals dual:   %s\n", vec2str(stats.residuals_dual))
+  s *= @sprintf("  status: %s\n", stats.status)
+  print(io, s)
+end
+
 include("krylov_aux.jl")
 include("krylov_utils.jl")
 
@@ -88,10 +107,12 @@ include("diom.jl")
 
 include("usymlq.jl")
 include("usymqr.jl")
+include("trilqr.jl")
 
 include("bilq.jl")
 include("cgs.jl")
 include("qmr.jl")
+include("bilqr.jl")
 
 include("cgls.jl")
 include("crls.jl")

--- a/src/bilq.jl
+++ b/src/bilq.jl
@@ -63,7 +63,7 @@ function bilq(A :: AbstractLinearOperator{T}, b :: AbstractVector{T}; c :: Abstr
   d̅ = zeros(T, n)            # Last column of D̅ₖ = Vₖ(Qₖ)ᵀ
   ζₖ₋₁ = ζbarₖ = zero(T)     # ζₖ₋₁ and ζbarₖ are the last components of z̅ₖ = (L̅ₖ)⁻¹β₁e₁
   ζₖ₋₂ = ηₖ = zero(T)        # ζₖ₋₂ and ηₖ are used to update ζₖ₋₁ and ζbarₖ
-  δbarₖ₋₁ = δbarₖ = zero(T)  # Coefficients of Lₖ₋₁ and L̅ₖ modified during two iterations
+  δbarₖ₋₁ = δbarₖ = zero(T)  # Coefficients of Lₖ₋₁ and L̅ₖ modified over the course of two iterations
   norm_vₖ = bNorm / βₖ       # ‖vₖ‖ is used for residual norm estimates
 
   # Stopping criterion.
@@ -178,7 +178,7 @@ function bilq(A :: AbstractLinearOperator{T}, b :: AbstractVector{T}; c :: Abstr
     end
 
     # Compute ⟨vₖ,vₖ₊₁⟩ and ‖vₖ₊₁‖
-    dot_vₖ_vₖ₊₁ = @kdot(n, vₖ₋₁, vₖ)
+    vₖᵀvₖ₊₁ = @kdot(n, vₖ₋₁, vₖ)
     norm_vₖ₊₁ = @knrm2(n, vₖ)
 
     # Compute BiLQ residual norm
@@ -188,7 +188,7 @@ function bilq(A :: AbstractLinearOperator{T}, b :: AbstractVector{T}; c :: Abstr
     else
       μₖ = βₖ * (sₖ₋₁ * ζₖ₋₂ - cₖ₋₁ * cₖ * ζₖ₋₁) + αₖ * sₖ * ζₖ₋₁
       ωₖ = βₖ₊₁ * sₖ * ζₖ₋₁
-      rNorm_lq = sqrt(μₖ^2 * norm_vₖ^2 + ωₖ^2 * norm_vₖ₊₁^2 + 2 * μₖ * ωₖ * dot_vₖ_vₖ₊₁)
+      rNorm_lq = sqrt(μₖ^2 * norm_vₖ^2 + ωₖ^2 * norm_vₖ₊₁^2 + 2 * μₖ * ωₖ * vₖᵀvₖ₊₁)
     end
     push!(rNorms, rNorm_lq)
 

--- a/src/bilqr.jl
+++ b/src/bilqr.jl
@@ -65,7 +65,7 @@ function bilqr(A :: AbstractLinearOperator, b :: AbstractVector{T}, c :: Abstrac
   uₖ₋₁ = zeros(T, n)         # u₀ = 0
   vₖ = b / βₖ                # v₁ = b / β₁
   uₖ = c / γₖ                # u₁ = c / γ₁
-  cₖ₋₁ = cₖ = one(T)         # Givens cosines used for the LQ factorization of Tₖ
+  cₖ₋₁ = cₖ = -one(T)        # Givens cosines used for the LQ factorization of Tₖ
   sₖ₋₁ = sₖ = zero(T)        # Givens sines used for the LQ factorization of Tₖ
   d̅ = zeros(T, n)            # Last column of D̅ₖ = Vₖ(Qₖ)ᵀ
   ζₖ₋₁ = ζbarₖ = zero(T)     # ζₖ₋₁ and ζbarₖ are the last components of z̅ₖ = (L̅ₖ)⁻¹β₁e₁
@@ -139,12 +139,6 @@ function bilqr(A :: AbstractLinearOperator, b :: AbstractVector{T}, c :: Abstrac
       ϵₖ₋₂  =  sₖ₋₁ * βₖ
       λₖ₋₁  = -cₖ₋₁ * cₖ * βₖ + sₖ * αₖ
       δbarₖ = -cₖ₋₁ * sₖ * βₖ - cₖ * αₖ
-    end
-
-    # Update sₖ₋₁ and cₖ₋₁
-    if iter ≥ 2
-      sₖ₋₁ = sₖ
-      cₖ₋₁ = cₖ
     end
 
     if !solved_primal
@@ -287,7 +281,7 @@ function bilqr(A :: AbstractLinearOperator, b :: AbstractVector{T}, c :: Abstrac
       @. uₖ = p / γₖ₊₁ # γₖ₊₁uₖ₊₁ = p
     end
 
-    # Update ϵₖ₋₃, λₖ₋₂, δbarₖ₋₁, γₖ and βₖ.
+    # Update ϵₖ₋₃, λₖ₋₂, δbarₖ₋₁, cₖ₋₁, sₖ₋₁, γₖ and βₖ.
     if iter ≥ 3
       ϵₖ₋₃ = ϵₖ₋₂
     end
@@ -295,6 +289,8 @@ function bilqr(A :: AbstractLinearOperator, b :: AbstractVector{T}, c :: Abstrac
       λₖ₋₂ = λₖ₋₁
     end
     δbarₖ₋₁ = δbarₖ
+    cₖ₋₁    = cₖ
+    sₖ₋₁    = sₖ
     γₖ      = γₖ₊₁
     βₖ      = βₖ₊₁
 

--- a/src/bilqr.jl
+++ b/src/bilqr.jl
@@ -309,9 +309,11 @@ function bilqr(A :: AbstractLinearOperator, b :: AbstractVector{T}, c :: Abstrac
     @kaxpy!(n, ζbarₖ, d̅, x)
   end
 
-  tired     && (status = "maximum number of iterations exceeded")
-  breakdown && (status = "Breakdown ⟨uₖ₊₁,vₖ₊₁⟩ = 0")
-  solved_primal && solved_dual && (status = "solutions good enough given atol and rtol")
+   tired                         && (status = "maximum number of iterations exceeded")
+   breakdown                     && (status = "Breakdown ⟨uₖ₊₁,vₖ₊₁⟩ = 0")
+   solved_primal && !solved_dual && (status = "Only the primal solution is good enough given atol and rtol")
+  !solved_primal &&  solved_dual && (status = "Only the dual solution is good enough given atol and rtol")
+   solved_primal &&  solved_dual && (status = "Both primal and dual solutions are good enough given atol and rtol")
   stats = AdjointStats(solved_primal, solved_dual, rNorms, sNorms, status)
   return (x, t, stats)
 end

--- a/src/bilqr.jl
+++ b/src/bilqr.jl
@@ -20,8 +20,8 @@ export bilqr
 BiLQ is used for solving primal system `Ax = b`.
 QMR is used for solving dual system `Aᵀt = c`.
 
-An option gives the possibility of transferring to the primal BiCG
-point, when it exists. The transfer is based on the residual norm.
+An option gives the possibility of transferring from the BiLQ point to the
+BiCG point, when it exists. The transfer is based on the residual norm.
 
 This version of BiLQR works in any floating-point data type.
 """

--- a/src/bilqr.jl
+++ b/src/bilqr.jl
@@ -1,0 +1,313 @@
+# An implementation of BILQR for the solution of square
+# consistent linear adjoint systems Ax = b and Aᵀt = c.
+#
+# This method is described in
+#
+# A. Montoison and D. Orban
+# BiLQ: An Iterative Method for Nonsymmetric Linear Systems with a Quasi-Minimum Error Property.
+# Cahier du GERAD G-2019-71, GERAD, Montreal, 2019. doi:10.13140/RG.2.2.18287.59042
+#
+# Alexis Montoison, <alexis.montoison@polymtl.ca>
+# Montreal, July 2019.
+
+export bilqr
+
+"""Combine BiLQ and QMR to solve adjoint systems.
+
+    [0  A] [t] = [b]
+    [Aᵀ 0] [x]   [c]
+
+BiLQ is used for solving primal system `Ax = b`.
+QMR is used for solving dual system `Aᵀt = c`.
+
+An option gives the possibility of transferring to the primal BiCG
+point, when it exists. The transfer is based on the residual norm.
+
+This version of BiLQR works in any floating-point data type.
+"""
+function bilqr(A :: AbstractLinearOperator, b :: AbstractVector{T}, c :: AbstractVector{T};
+               atol :: T=√eps(T), rtol :: T=√eps(T), transfer_to_bicg :: Bool=true,
+               itmax :: Int=0, verbose :: Bool=false) where T <: AbstractFloat
+
+  n, m = size(A)
+  m == n || error("Systems must be square")
+  length(b) == m || error("Inconsistent problem size")
+  length(c) == n || error("Inconsistent problem size")
+  verbose && @printf("BILQR: systems of size %d\n", n)
+
+  # Initial solution x₀ and residual norm ‖r₀‖ = ‖b - Ax₀‖.
+  x = zeros(T, n)      # x₀
+  bNorm = @knrm2(n, b) # rNorm = ‖r₀‖
+
+  # Initial solution t₀ and residual norm ‖s₀‖ = ‖c - Aᵀt₀‖.
+  t = zeros(T, n)      # t₀
+  cNorm = @knrm2(n, c) # sNorm = ‖s₀‖
+
+  iter = 0
+  itmax == 0 && (itmax = 2*n)
+
+  rNorms = [bNorm;]
+  sNorms = [cNorm;]
+  ε = atol + rtol * bNorm
+  Κ = atol + rtol * cNorm
+  verbose && @printf("%5d  %7.1e  %7.1e\n", iter, bNorm, cNorm)
+
+  # Initialize the Lanczos biorthogonalization process.
+  bᵗc = @kdot(n, b, c)  # ⟨b,c⟩
+  bᵗc == 0 && return (x, y, AdjointStats(false, false, [bNorm], [cNorm], "Breakdown bᵀc = 0"))
+
+  # Set up workspace.
+  bᵗc = @kdot(n, b, c)       # ⟨b,c⟩
+  βₖ = √(abs(bᵗc))           # β₁γ₁ = bᵀc
+  γₖ = bᵗc / βₖ              # β₁γ₁ = bᵀc
+  vₖ₋₁ = zeros(T, n)         # v₀ = 0
+  uₖ₋₁ = zeros(T, n)         # u₀ = 0
+  vₖ = b / βₖ                # v₁ = b / β₁
+  uₖ = c / γₖ                # u₁ = c / γ₁
+  cₖ₋₁ = cₖ = one(T)         # Givens cosines used for the LQ factorization of Tₖ
+  sₖ₋₁ = sₖ = zero(T)        # Givens sines used for the LQ factorization of Tₖ
+  d̅ = zeros(T, n)            # Last column of D̅ₖ = Vₖ(Qₖ)ᵀ
+  ζₖ₋₁ = ζbarₖ = zero(T)     # ζₖ₋₁ and ζbarₖ are the last components of z̅ₖ = (L̅ₖ)⁻¹β₁e₁
+  ζₖ₋₂ = ηₖ = zero(T)        # ζₖ₋₂ and ηₖ are used to update ζₖ₋₁ and ζbarₖ
+  δbarₖ₋₁ = δbarₖ = zero(T)  # Coefficients of Lₖ₋₁ and L̅ₖ modified during two iterations
+  ψbarₖ₋₁ = ψₖ₋₁ = zero(T)   # ψₖ₋₁ and ψbarₖ are the last components of h̅ₖ = 
+  norm_vₖ = bNorm / βₖ       # ‖vₖ‖ used for residual norm estimates
+  ϵₖ₋₃ = λₖ₋₂ = zero(T)      # Components of Lₖ₋₁
+  wₖ₋₃ = zeros(T, n)         # Column k-3 of Wₖ = Uₖ(Lₖ)⁻ᵀ
+  wₖ₋₂ = zeros(T, n)         # Column k-2 of Wₖ = Uₖ(Lₖ)⁻ᵀ
+
+  # Stopping criterion.
+  solved_lq = false
+  solved_cg = false
+  solved_primal = bNorm ≤ ε
+  solved_dual = cNorm ≤ Κ
+  tired = iter ≥ itmax
+  breakdown = false
+  status = "unknown"
+
+  while !((solved_primal && solved_dual) || tired || breakdown)
+    # Update iteration index.
+    iter = iter + 1
+
+    # Continue the Lanczos biorthogonalization process.
+    # AVₖ  = VₖTₖ    + βₖ₊₁vₖ₊₁(eₖ)ᵀ = Vₖ₊₁Tₖ₊₁.ₖ
+    # AᵀUₖ = Uₖ(Tₖ)ᵀ + γₖ₊₁uₖ₊₁(eₖ)ᵀ = Uₖ₊₁(Tₖ.ₖ₊₁)ᵀ
+
+    q = A * vₖ      # Forms vₖ₊₁ : q ← Avₖ
+    p = A.tprod(uₖ) # Forms uₖ₊₁ : p ← Aᵀuₖ
+
+    @kaxpy!(n, -γₖ, vₖ₋₁, q) # q ← q - γₖ * vₖ₋₁
+    @kaxpy!(n, -βₖ, uₖ₋₁, p) # p ← p - βₖ * uₖ₋₁
+
+    αₖ = @kdot(n, q, uₖ)     # αₖ = qᵀuₖ
+
+    @kaxpy!(n, -αₖ, vₖ, q)   # q ← q - αₖ * vₖ
+    @kaxpy!(n, -αₖ, uₖ, p)   # p ← p - αₖ * uₖ
+
+    qᵗp = @kdot(n, p, q)     # qᵗp  = ⟨q,p⟩
+    βₖ₊₁ = √(abs(qᵗp))       # βₖ₊₁ = √(|qᵗp|)
+    γₖ₊₁ = qᵗp / βₖ₊₁        # γₖ₊₁ = qᵗp / βₖ₊₁
+
+    # Update the LQ factorization of Tₖ = L̅ₖQₖ.
+    # [ α₁ γ₂ 0  •  •  •  0 ]   [ δ₁   0    •   •   •    •    0   ]
+    # [ β₂ α₂ γ₃ •        • ]   [ λ₁   δ₂   •                 •   ]
+    # [ 0  •  •  •  •     • ]   [ ϵ₁   λ₂   δ₃  •             •   ]
+    # [ •  •  •  •  •  •  • ] = [ 0    •    •   •   •         •   ] Qₖ
+    # [ •     •  •  •  •  0 ]   [ •    •    •   •   •    •    •   ]
+    # [ •        •  •  •  γₖ]   [ •         •   •   •    •    0   ]
+    # [ 0  •  •  •  0  βₖ αₖ]   [ •    •    •   0  ϵₖ₋₂ λₖ₋₁ δbarₖ]
+
+    if iter == 1
+      δbarₖ = αₖ
+    elseif iter == 2
+      # [δbar₁ γ₂] [c₂  s₂] = [δ₁   0  ]
+      # [ β₂   α₂] [s₂ -c₂]   [λ₁ δbar₂]
+      (cₖ, sₖ, δₖ₋₁) = sym_givens(δbarₖ₋₁, γₖ)
+      λₖ₋₁  = cₖ * βₖ + sₖ * αₖ
+      δbarₖ = sₖ * βₖ - cₖ * αₖ
+    else
+      # [0  βₖ  αₖ] [cₖ₋₁   sₖ₋₁   0] = [sₖ₋₁βₖ  -cₖ₋₁βₖ  αₖ]
+      #             [sₖ₋₁  -cₖ₋₁   0]
+      #             [ 0      0     1]
+      #
+      # [ λₖ₋₂   δbarₖ₋₁  γₖ] [1   0   0 ] = [λₖ₋₂  δₖ₋₁    0  ]
+      # [sₖ₋₁βₖ  -cₖ₋₁βₖ  αₖ] [0   cₖ  sₖ]   [ϵₖ₋₂  λₖ₋₁  δbarₖ]
+      #                       [0   sₖ -cₖ]
+      (cₖ, sₖ, δₖ₋₁) = sym_givens(δbarₖ₋₁, γₖ)
+      ϵₖ₋₂  =  sₖ₋₁ * βₖ
+      λₖ₋₁  = -cₖ₋₁ * cₖ * βₖ + sₖ * αₖ
+      δbarₖ = -cₖ₋₁ * sₖ * βₖ - cₖ * αₖ
+    end
+
+    # Update sₖ₋₁ and cₖ₋₁
+    if iter ≥ 2
+      sₖ₋₁ = sₖ
+      cₖ₋₁ = cₖ
+    end
+
+    if !solved_primal
+      # Compute ζₖ₋₁ and ζbarₖ, last components of the solution of Lₖz̅ₖ = β₁e₁
+      # [δbar₁] [ζbar₁] = [β₁]
+      if iter == 1
+        ηₖ = βₖ
+      end
+      # [δ₁    0  ] [  ζ₁ ] = [β₁]
+      # [λ₁  δbar₂] [ζbar₂]   [0 ]
+      if iter == 2
+        ηₖ₋₁ = ηₖ
+        ζₖ₋₁ = ηₖ₋₁ / δₖ₋₁
+        ηₖ   = -λₖ₋₁ * ζₖ₋₁
+      end
+      # [λₖ₋₂  δₖ₋₁    0  ] [ζₖ₋₂ ] = [0]
+      # [ϵₖ₋₂  λₖ₋₁  δbarₖ] [ζₖ₋₁ ]   [0]
+      #                     [ζbarₖ]
+      if iter ≥ 3
+        ζₖ₋₂ = ζₖ₋₁
+        ηₖ₋₁ = ηₖ
+        ζₖ₋₁ = ηₖ₋₁ / δₖ₋₁
+        ηₖ   = -ϵₖ₋₂ * ζₖ₋₂ - λₖ₋₁ * ζₖ₋₁
+      end
+
+      # Relations for the directions dₖ₋₁ and d̅ₖ, the last two columns of D̅ₖ = Vₖ(Qₖ)ᵀ.
+      # [d̅ₖ₋₁ vₖ] [cₖ  sₖ] = [dₖ₋₁ d̅ₖ] ⟷ dₖ₋₁ = cₖ * d̅ₖ₋₁ + sₖ * vₖ
+      #           [sₖ -cₖ]             ⟷ d̅ₖ   = sₖ * d̅ₖ₋₁ - cₖ * vₖ
+      if iter ≥ 2
+        # Compute solution xₖ.
+        # (xᴸ)ₖ₋₁ ← (xᴸ)ₖ₋₂ + ζₖ₋₁ * dₖ₋₁
+        @kaxpy!(n, ζₖ₋₁ * cₖ,  d̅, x)
+        @kaxpy!(n, ζₖ₋₁ * sₖ, vₖ, x)
+      end
+
+      # Compute d̅ₖ.
+      if iter == 1
+        # d̅₁ = v₁
+        @. d̅ = vₖ
+      else
+        # d̅ₖ = sₖ * d̅ₖ₋₁ - cₖ * vₖ
+        @kaxpby!(n, -cₖ, vₖ, sₖ, d̅)
+      end
+
+      # Compute ⟨vₖ,vₖ₊₁⟩ and ‖vₖ₊₁‖
+      dot_vₖ_vₖ₊₁ = @kdot(n, vₖ₋₁, vₖ)
+      norm_vₖ₊₁ = @knrm2(n, vₖ)
+
+      # Compute BiLQ residual norm
+      # ‖rₖ‖ = √((μₖ)²‖vₖ‖² + (ωₖ)²‖vₖ₊₁‖² + 2μₖωₖ⟨vₖ,vₖ₊₁⟩)
+      if iter == 1
+        rNorm_lq = bNorm
+      else
+        μₖ = βₖ * (sₖ₋₁ * ζₖ₋₂ - cₖ₋₁ * cₖ * ζₖ₋₁) + αₖ * sₖ * ζₖ₋₁
+        ωₖ = βₖ₊₁ * sₖ * ζₖ₋₁
+        rNorm_lq = sqrt(μₖ^2 * norm_vₖ^2 + ωₖ^2 * norm_vₖ₊₁^2 + 2 * μₖ * ωₖ * dot_vₖ_vₖ₊₁)
+      end
+      push!(rNorms, rNorm_lq)
+
+      # Update norm_vₖ
+      norm_vₖ = norm_vₖ₊₁
+
+      # Compute BiCG residual norm
+      # ‖rₖ‖ = |ρₖ| * ‖vₖ₊₁‖
+      if transfer_to_bicg && (δbarₖ ≠ 0)
+        ζbarₖ = ηₖ / δbarₖ
+        ρₖ = βₖ₊₁ * (sₖ * ζₖ₋₁ - cₖ * ζbarₖ)
+        rNorm_cg = abs(ρₖ) * norm_vₖ₊₁
+      end    
+
+      # Update primal stopping criterion
+      solved_lq = rNorm_lq ≤ ε
+      solved_cg = transfer_to_bicg && (δbarₖ ≠ 0) && (rNorm_cg ≤ ε)
+      solved_primal = solved_lq || solved_cg
+    end
+
+    if !solved_dual
+      # Compute ψₖ₋₁ and ψbarₖ.
+      if iter == 1
+        ψbarₖ = γₖ
+      else
+        ψₖ₋₁  = cₖ * ψbarₖ₋₁
+        ψbarₖ = sₖ * ψbarₖ₋₁
+      end
+
+      # Compute the direction wₖ₋₁, the last column of Wₖ₋₁ = (Uₖ₋₁)(Lₖ₋₁)⁻ᵀ ⟷ (Lₖ₋₁)(Wₖ₋₁)ᵀ = (Uₖ₋₁)ᵀ.
+      # w₁ = u₁ / δ₁
+      if iter == 2
+        wₖ₋₁ = wₖ₋₂
+        @kaxpy!(n, one(T), uₖ₋₁, wₖ₋₁)
+        @. wₖ₋₁ = uₖ₋₁ / δₖ₋₁
+      end
+      # w₂ = (u₂ - λ₁w₁) / δ₂
+      if iter == 3
+        wₖ₋₁ = wₖ₋₃
+        @kaxpy!(n, one(T), uₖ₋₁, wₖ₋₁)
+        @kaxpy!(n, -λₖ₋₂, wₖ₋₂, wₖ₋₁)
+        @. wₖ₋₁ = wₖ₋₁ / δₖ₋₁
+      end
+      # wₖ₋₁ = (uₖ₋₁ - λₖ₋₂wₖ₋₂ - ϵₖ₋₃wₖ₋₃) / δₖ₋₁
+      if iter ≥ 4
+        @kscal!(n, -ϵₖ₋₃, wₖ₋₃)
+        wₖ₋₁ = wₖ₋₃
+        @kaxpy!(n, one(T), uₖ₋₁, wₖ₋₁)
+        @kaxpy!(n, -λₖ₋₂, wₖ₋₂, wₖ₋₁)
+        @. wₖ₋₁ = wₖ₋₁ / δₖ₋₁
+      end
+
+      if iter ≥ 3
+        # Swap pointers.
+        @kswap(wₖ₋₃, wₖ₋₂)
+      end
+
+      if iter ≥ 2
+        # Compute solution tₖ₋₁.
+        # tₖ₋₁ ← tₖ₋₂ + ψₖ₋₁ * wₖ₋₁
+        @kaxpy!(n, ψₖ₋₁, wₖ₋₁, t)
+      end
+
+      # Update ψbarₖ₋₁
+      ψbarₖ₋₁ = ψbarₖ
+
+      # Compute QMR residual norm ‖sₖ₋₁‖ = |ψbarₖ| * ‖uₖ‖.
+      sNorm = abs(ψbarₖ) * @knrm2(n, uₖ)
+      push!(sNorms, sNorm)
+
+      # Update dual stopping criterion
+      solved_dual = sNorm ≤ Κ
+    end
+
+    # Compute vₖ₊₁ and uₖ₊₁.
+    @. vₖ₋₁ = vₖ # vₖ₋₁ ← vₖ
+    @. uₖ₋₁ = uₖ # uₖ₋₁ ← uₖ
+
+    if qᵗp ≠ zero(T)
+      @. vₖ = q / βₖ₊₁ # βₖ₊₁vₖ₊₁ = q
+      @. uₖ = p / γₖ₊₁ # γₖ₊₁uₖ₊₁ = p
+    end
+
+    # Update ϵₖ₋₃, λₖ₋₂, δbarₖ₋₁, γₖ and βₖ.
+    if iter ≥ 3
+      ϵₖ₋₃ = ϵₖ₋₂
+    end
+    if iter ≥ 2
+      λₖ₋₂ = λₖ₋₁
+    end
+    δbarₖ₋₁ = δbarₖ
+    γₖ      = γₖ₊₁
+    βₖ      = βₖ₊₁
+
+    tired = iter ≥ itmax
+    breakdown = !solved_lq && !solved_cg && (qᵗp == 0)
+    verbose && @printf("%5d  %7.1e  %7.1e\n", iter, rNorm, sNorm)
+  end
+  verbose && @printf("\n")
+
+  # Compute BICG point
+  # (xᶜ)ₖ ← (xᴸ)ₖ₋₁ + ζbarₖ * d̅ₖ
+  if solved_cg
+    @kaxpy!(n, ζbarₖ, d̅, x)
+  end
+
+  tired     && (status = "maximum number of iterations exceeded")
+  breakdown && (status = "Breakdown ⟨uₖ₊₁,vₖ₊₁⟩ = 0")
+  solved_primal && solved_dual && (status = "solutions good enough given atol and rtol")
+  stats = AdjointStats(solved_primal, solved_dual, rNorms, sNorms, status)
+  return (x, t, stats)
+end

--- a/src/bilqr.jl
+++ b/src/bilqr.jl
@@ -71,11 +71,12 @@ function bilqr(A :: AbstractLinearOperator, b :: AbstractVector{T}, c :: Abstrac
   ζₖ₋₁ = ζbarₖ = zero(T)     # ζₖ₋₁ and ζbarₖ are the last components of z̅ₖ = (L̅ₖ)⁻¹β₁e₁
   ζₖ₋₂ = ηₖ = zero(T)        # ζₖ₋₂ and ηₖ are used to update ζₖ₋₁ and ζbarₖ
   δbarₖ₋₁ = δbarₖ = zero(T)  # Coefficients of Lₖ₋₁ and L̅ₖ modified during two iterations
-  ψbarₖ₋₁ = ψₖ₋₁ = zero(T)   # ψₖ₋₁ and ψbarₖ are the last components of h̅ₖ = 
+  ψbarₖ₋₁ = ψₖ₋₁ = zero(T)   # ψₖ₋₁ and ψbarₖ are the last components of h̅ₖ = Qₖγ₁e₁
   norm_vₖ = bNorm / βₖ       # ‖vₖ‖ used for residual norm estimates
   ϵₖ₋₃ = λₖ₋₂ = zero(T)      # Components of Lₖ₋₁
   wₖ₋₃ = zeros(T, n)         # Column k-3 of Wₖ = Uₖ(Lₖ)⁻ᵀ
   wₖ₋₂ = zeros(T, n)         # Column k-2 of Wₖ = Uₖ(Lₖ)⁻ᵀ
+  τₖ = zero(T)               # τₖ is used for the dual residual norm estimate
 
   # Stopping criterion.
   solved_lq = false
@@ -266,8 +267,11 @@ function bilqr(A :: AbstractLinearOperator, b :: AbstractVector{T}, c :: Abstrac
       # Update ψbarₖ₋₁
       ψbarₖ₋₁ = ψbarₖ
 
-      # Compute QMR residual norm ‖sₖ₋₁‖ = |ψbarₖ| * ‖uₖ‖.
-      sNorm = abs(ψbarₖ) * @knrm2(n, uₖ)
+      # Compute τₖ = τₖ₋₁ + ‖uₖ‖²
+      τₖ += @kdot(n, uₖ, uₖ)
+
+      # Compute QMR residual norm ‖sₖ₋₁‖ ≤ |ψbarₖ| * √τₖ
+      sNorm = abs(ψbarₖ) * √τₖ
       push!(sNorms, sNorm)
 
       # Update dual stopping criterion

--- a/src/bilqr.jl
+++ b/src/bilqr.jl
@@ -50,6 +50,7 @@ function bilqr(A :: AbstractLinearOperator, b :: AbstractVector{T}, c :: Abstrac
   sNorms = [cNorm;]
   ε = atol + rtol * bNorm
   Κ = atol + rtol * cNorm
+  verbose && @printf("%5s  %7s  %7s\n", "k", "‖rₖ‖", "‖sₖ‖")
   verbose && @printf("%5d  %7.1e  %7.1e\n", iter, bNorm, cNorm)
 
   # Initialize the Lanczos biorthogonalization process.
@@ -295,7 +296,10 @@ function bilqr(A :: AbstractLinearOperator, b :: AbstractVector{T}, c :: Abstrac
 
     tired = iter ≥ itmax
     breakdown = !solved_lq && !solved_cg && (qᵗp == 0)
-    verbose && @printf("%5d  %7.1e  %7.1e\n", iter, rNorm, sNorm)
+
+    verbose &&  solved_primal && !solved_dual && @printf("%5d  %7s  %7.1e\n", iter, "✗ ✗ ✗ ✗", sNorm)
+    verbose && !solved_primal &&  solved_dual && @printf("%5d  %7.1e  %7s\n", iter, rNorm_lq, "✗ ✗ ✗ ✗")
+    verbose && !solved_primal && !solved_dual && @printf("%5d  %7.1e  %7.1e\n", iter, rNorm_lq, sNorm)
   end
   verbose && @printf("\n")
 

--- a/src/krylov_utils.jl
+++ b/src/krylov_utils.jl
@@ -4,7 +4,7 @@
 
 with (ndisp - 1)/2 elements on each side.
 """
-function vec2str(x, ndisp :: Int=7)
+function vec2str(x :: AbstractVector{T}, ndisp :: Int=7) where T <: Union{AbstractFloat, Missing}
   n = length(x)
   if n ≤ ndisp
     ndisp = n

--- a/src/trilqr.jl
+++ b/src/trilqr.jl
@@ -50,6 +50,7 @@ function trilqr(A :: AbstractLinearOperator, b :: AbstractVector{T}, c :: Abstra
   sNorms = [cNorm;]
   ε = atol + rtol * bNorm
   Κ = atol + rtol * cNorm
+  verbose && @printf("%5s  %7s  %7s\n", "k", "‖rₖ‖", "‖sₖ‖")
   verbose && @printf("%5d  %7.1e  %7.1e\n", iter, bNorm, cNorm)
 
   # Set up workspace.
@@ -281,7 +282,10 @@ function trilqr(A :: AbstractLinearOperator, b :: AbstractVector{T}, c :: Abstra
     βₖ      = βₖ₊₁
     
     tired = iter ≥ itmax
-    verbose && @printf("%5d  %7.1e  %7.1e\n", iter, rNorm, sNorm)
+
+    verbose &&  solved_primal && !solved_dual && @printf("%5d  %7s  %7.1e\n", iter, "✗ ✗ ✗ ✗", sNorm)
+    verbose && !solved_primal &&  solved_dual && @printf("%5d  %7.1e  %7s\n", iter, rNorm_lq, "✗ ✗ ✗ ✗")
+    verbose && !solved_primal && !solved_dual && @printf("%5d  %7.1e  %7.1e\n", iter, rNorm_lq, sNorm)
   end
   verbose && @printf("\n")
 

--- a/src/trilqr.jl
+++ b/src/trilqr.jl
@@ -20,8 +20,8 @@ export trilqr
 USYMLQ is used for solving primal system `Ax = b`.
 USYMQR is used for solving dual system `Aᵀt = c`.
 
-An option gives the possibility of transferring to the primal USYMCG
-point, when it exists. The transfer is based on the residual norm.
+An option gives the possibility of transferring from the USYMLQ point to the
+USYMCG point, when it exists. The transfer is based on the residual norm.
 
 This version of TriLQR works in any floating-point data type.
 """

--- a/src/trilqr.jl
+++ b/src/trilqr.jl
@@ -76,10 +76,12 @@ function trilqr(A :: AbstractLinearOperator{T}, b :: AbstractVector{T}, c :: Abs
   wₖ₋₂ = zeros(T, m)         # Column k-2 of Wₖ = Vₖ(Lₖ)⁻ᵀ
 
   # Stopping criterion.
-  solved_lq = bNorm == 0
-  solved_cg = false
   inconsistent = false
-  solved_primal = solved_lq || solved_cg
+  solved_lq = bNorm == 0
+  solved_lq_tol = solved_lq_mach = false
+  solved_cg = solved_cg_tol = solved_cg_mach = false
+  solved_primal = solved_lq || solved_cg
+  solved_qr_tol = solved_qr_mach = false
   solved_dual = cNorm == 0
   tired = iter ≥ itmax
   status = "unknown"
@@ -307,10 +309,21 @@ function trilqr(A :: AbstractLinearOperator{T}, b :: AbstractVector{T}, c :: Abs
     @kaxpy!(n, ζbarₖ, d̅, x)
   end
 
-   tired                         && (status = "maximum number of iterations exceeded")
-   solved_primal && !solved_dual && (status = "Only the primal solution is good enough given atol and rtol")
-  !solved_primal &&  solved_dual && (status = "Only the dual solution is good enough given atol and rtol")
-   solved_primal &&  solved_dual && (status = "Both primal and dual solutions are good enough given atol and rtol")
+   tired                            && (status = "maximum number of iterations exceeded")
+   solved_lq_tol  && !solved_dual   && (status = "Only the primal solution xᴸ is good enough given atol and rtol")
+   solved_cg_tol  && !solved_dual   && (status = "Only the primal solution xᶜ is good enough given atol and rtol")
+  !solved_primal  && solved_qr_tol  && (status = "Only the dual solution t is good enough given atol and rtol")
+   solved_lq_tol  && solved_qr_tol  && (status = "Both primal and dual solutions (xᴸ, t) are good enough given atol and rtol")
+   solved_cg_tol  && solved_qr_tol  && (status = "Both primal and dual solutions (xᶜ, t) are good enough given atol and rtol")
+   solved_lq_mach && !solved_dual   && (status = "Only found approximate zero-residual primal solution xᴸ")
+   solved_cg_mach && !solved_dual   && (status = "Only found approximate zero-residual primal solution xᶜ")
+  !solved_primal  && solved_qr_mach && (status = "Only found approximate zero-residual dual solution t")
+   solved_lq_mach && solved_qr_mach && (status = "Found approximate zero-residual primal and dual solutions (xᴸ, t)")
+   solved_cg_mach && solved_qr_mach && (status = "Found approximate zero-residual primal and dual solutions (xᶜ, t)")
+   solved_lq_mach && solved_qr_tol  && (status = "Found approximate zero-residual primal solutions xᴸ and a dual solution t good enough given atol and rtol")
+   solved_cg_mach && solved_qr_tol  && (status = "Found approximate zero-residual primal solutions xᶜ and a dual solution t good enough given atol and rtol")
+   solved_lq_tol  && solved_qr_mach && (status = "Found a primal solution xᴸ good enough given atol and rtol and an approximate zero-residual dual solutions t")
+   solved_cg_tol  && solved_qr_mach && (status = "Found a primal solution xᶜ good enough given atol and rtol and an approximate zero-residual dual solutions t")
   stats = AdjointStats(solved_primal, solved_dual, rNorms, sNorms, status)
   return (x, t, stats)
 end

--- a/src/trilqr.jl
+++ b/src/trilqr.jl
@@ -61,7 +61,7 @@ function trilqr(A :: AbstractLinearOperator, b :: AbstractVector{T}, c :: Abstra
   uₖ₋₁ = zeros(T, n)         # u₀ = 0
   vₖ = b / βₖ                # v₁ = b / β₁
   uₖ = c / γₖ                # u₁ = c / γ₁
-  cₖ₋₁ = cₖ = one(T)         # Givens cosines used for the LQ factorization of Tₖ
+  cₖ₋₁ = cₖ = -one(T)        # Givens cosines used for the LQ factorization of Tₖ
   sₖ₋₁ = sₖ = zero(T)        # Givens sines used for the LQ factorization of Tₖ
   d̅ = zeros(T, n)            # Last column of D̅ₖ = Uₖ(Qₖ)ᵀ
   ζₖ₋₁ = ζbarₖ = zero(T)     # ζₖ₋₁ and ζbarₖ are the last components of z̅ₖ = (L̅ₖ)⁻¹β₁e₁

--- a/src/trilqr.jl
+++ b/src/trilqr.jl
@@ -1,0 +1,297 @@
+# An implementation of TRILQR for the solution of square or 
+# rectangular consistent linear adjoint systems Ax = b and Aᵀt = c.
+#
+# This method is described in
+#
+# A. Montoison and D. Orban
+# BiLQ: An Iterative Method for Nonsymmetric Linear Systems with a Quasi-Minimum Error Property.
+# Cahier du GERAD G-2019-71, GERAD, Montreal, 2019. doi:10.13140/RG.2.2.18287.59042
+#
+# Alexis Montoison, <alexis.montoison@polymtl.ca>
+# Montreal, July 2019.
+
+export trilqr
+
+"""Combine USYMLQ and USYMQR to solve adjoint systems.
+
+    [0  A] [t] = [b]
+    [Aᵀ 0] [x]   [c]
+
+USYMLQ is used for solving primal system `Ax = b`.
+USYMQR is used for solving dual system `Aᵀt = c`.
+
+An option gives the possibility of transferring to the primal USYMCG
+point, when it exists. The transfer is based on the residual norm.
+
+This version of TriLQR works in any floating-point data type.
+"""
+function trilqr(A :: AbstractLinearOperator, b :: AbstractVector{T}, c :: AbstractVector{T};
+                atol :: T=√eps(T), rtol :: T=√eps(T), transfer_to_usymcg :: Bool=true,
+                itmax :: Int=0, verbose :: Bool=false) where T <: AbstractFloat
+
+  m, n = size(A)
+  length(b) == m || error("Inconsistent problem size")
+  length(c) == n || error("Inconsistent problem size")
+  verbose && @printf("TRILQR: primal system of %d equations in %d variables\n", m, n)
+  verbose && @printf("TRILQR: dual system of %d equations in %d variables\n", n, m)
+
+  # Initial solution x₀ and residual r₀ = b - Ax₀.
+  x = zeros(T, n)       # x₀
+  bNorm = @knrm2(m, b)  # rNorm = ‖r₀‖
+
+  # Initial solution y₀ and residual s₀ = c - Aᵀy₀.
+  t = zeros(T, m)       # t₀
+  cNorm = @knrm2(n, c)  # sNorm = ‖s₀‖
+
+  iter = 0
+  itmax == 0 && (itmax = 2*n)
+
+  rNorms = [bNorm;]
+  sNorms = [cNorm;]
+  ε = atol + rtol * bNorm
+  Κ = atol + rtol * cNorm
+  verbose && @printf("%5d  %7.1e  %7.1e\n", iter, bNorm, cNorm)
+
+  # Set up workspace.
+  βₖ = @knrm2(m, b)          # β₁ = ‖v₁‖
+  γₖ = @knrm2(n, c)          # γ₁ = ‖u₁‖
+  vₖ₋₁ = zeros(T, m)         # v₀ = 0
+  uₖ₋₁ = zeros(T, n)         # u₀ = 0
+  vₖ = b / βₖ                # v₁ = b / β₁
+  uₖ = c / γₖ                # u₁ = c / γ₁
+  cₖ₋₁ = cₖ = one(T)         # Givens cosines used for the LQ factorization of Tₖ
+  sₖ₋₁ = sₖ = zero(T)        # Givens sines used for the LQ factorization of Tₖ
+  d̅ = zeros(T, n)            # Last column of D̅ₖ = Uₖ(Qₖ)ᵀ
+  ζₖ₋₁ = ζbarₖ = zero(T)     # ζₖ₋₁ and ζbarₖ are the last components of z̅ₖ = (L̅ₖ)⁻¹β₁e₁
+  ζₖ₋₂ = ηₖ = zero(T)        # ζₖ₋₂ and ηₖ are used to update ζₖ₋₁ and ζbarₖ
+  δbarₖ₋₁ = δbarₖ = zero(T)  # Coefficients of Lₖ₋₁ and L̅ₖ modified during two iterations
+  ψbarₖ₋₁ = ψₖ₋₁ = zero(T)   # ψₖ₋₁ and ψbarₖ are the last components of h̅ₖ = Qₖγ₁e₁
+  ϵₖ₋₃ = λₖ₋₂ = zero(T)      # Components of Lₖ₋₁
+  wₖ₋₃ = zeros(T, m)         # Column k-3 of Wₖ = Vₖ(Lₖ)⁻ᵀ
+  wₖ₋₂ = zeros(T, m)         # Column k-2 of Wₖ = Vₖ(Lₖ)⁻ᵀ
+
+  # Stopping criterion.
+  solved_lq = false
+  solved_cg = false
+  solved_primal = bNorm ≤ ε
+  solved_dual = cNorm ≤ Κ
+  tired = iter ≥ itmax
+  status = "unknown"
+
+  while !((solved_primal && solved_dual) || tired)
+    # Update iteration index.
+    iter = iter + 1
+
+    # Continue the SSY tridiagonalization process.
+    # AUₖ  = VₖTₖ    + βₖ₊₁vₖ₊₁(eₖ)ᵀ = Vₖ₊₁Tₖ₊₁.ₖ
+    # AᵀVₖ = Uₖ(Tₖ)ᵀ + γₖ₊₁uₖ₊₁(eₖ)ᵀ = Uₖ₊₁(Tₖ.ₖ₊₁)ᵀ
+
+    q = A * uₖ       # Forms vₖ₊₁ : q ← Auₖ
+    p = A.tprod(vₖ)  # Forms uₖ₊₁ : p ← Aᵀvₖ
+
+    @kaxpy!(m, -γₖ, vₖ₋₁, q)  # q ← q - γₖ * vₖ₋₁
+    @kaxpy!(n, -βₖ, uₖ₋₁, p)  # p ← p - βₖ * uₖ₋₁
+
+    αₖ = @kdot(m, q, vₖ)      # αₖ = qᵀvₖ
+
+    @kaxpy!(m, -αₖ, vₖ, q)    # q ← q - αₖ * vₖ
+    @kaxpy!(n, -αₖ, uₖ, p)    # p ← p - αₖ * uₖ
+
+    βₖ₊₁ = @knrm2(m, q)       # βₖ₊₁ = ‖q‖
+    γₖ₊₁ = @knrm2(n, p)       # γₖ₊₁ = ‖p‖
+
+    # Update the LQ factorization of Tₖ = L̅ₖQₖ.
+    # [ α₁ γ₂ 0  •  •  •  0 ]   [ δ₁   0    •   •   •    •    0   ]
+    # [ β₂ α₂ γ₃ •        • ]   [ λ₁   δ₂   •                 •   ]
+    # [ 0  •  •  •  •     • ]   [ ϵ₁   λ₂   δ₃  •             •   ]
+    # [ •  •  •  •  •  •  • ] = [ 0    •    •   •   •         •   ] Qₖ
+    # [ •     •  •  •  •  0 ]   [ •    •    •   •   •    •    •   ]
+    # [ •        •  •  •  γₖ]   [ •         •   •   •    •    0   ]
+    # [ 0  •  •  •  0  βₖ αₖ]   [ •    •    •   0  ϵₖ₋₂ λₖ₋₁ δbarₖ]
+
+    if iter == 1
+      δbarₖ = αₖ
+    elseif iter == 2
+      # [δbar₁ γ₂] [c₂  s₂] = [δ₁   0  ]
+      # [ β₂   α₂] [s₂ -c₂]   [λ₁ δbar₂]
+      (cₖ, sₖ, δₖ₋₁) = sym_givens(δbarₖ₋₁, γₖ)
+      λₖ₋₁  = cₖ * βₖ + sₖ * αₖ
+      δbarₖ = sₖ * βₖ - cₖ * αₖ
+    else
+      # [0  βₖ  αₖ] [cₖ₋₁   sₖ₋₁   0] = [sₖ₋₁βₖ  -cₖ₋₁βₖ  αₖ]
+      #             [sₖ₋₁  -cₖ₋₁   0]
+      #             [ 0      0     1]
+      #
+      # [ λₖ₋₂   δbarₖ₋₁  γₖ] [1   0   0 ] = [λₖ₋₂  δₖ₋₁    0  ]
+      # [sₖ₋₁βₖ  -cₖ₋₁βₖ  αₖ] [0   cₖ  sₖ]   [ϵₖ₋₂  λₖ₋₁  δbarₖ]
+      #                       [0   sₖ -cₖ]
+      (cₖ, sₖ, δₖ₋₁) = sym_givens(δbarₖ₋₁, γₖ)
+      ϵₖ₋₂  =  sₖ₋₁ * βₖ
+      λₖ₋₁  = -cₖ₋₁ * cₖ * βₖ + sₖ * αₖ
+      δbarₖ = -cₖ₋₁ * sₖ * βₖ - cₖ * αₖ
+    end
+
+    # Update sₖ₋₁ and cₖ₋₁
+    if iter ≥ 2
+      sₖ₋₁ = sₖ
+      cₖ₋₁ = cₖ
+    end
+
+    if !solved_primal
+      # Compute ζₖ₋₁ and ζbarₖ, last components of the solution of Lₖz̅ₖ = β₁e₁
+      # [δbar₁] [ζbar₁] = [β₁]
+      if iter == 1
+        ηₖ = βₖ
+      end
+      # [δ₁    0  ] [  ζ₁ ] = [β₁]
+      # [λ₁  δbar₂] [ζbar₂]   [0 ]
+      if iter == 2
+        ηₖ₋₁ = ηₖ
+        ζₖ₋₁ = ηₖ₋₁ / δₖ₋₁
+        ηₖ   = -λₖ₋₁ * ζₖ₋₁
+      end
+      # [λₖ₋₂  δₖ₋₁    0  ] [ζₖ₋₂ ] = [0]
+      # [ϵₖ₋₂  λₖ₋₁  δbarₖ] [ζₖ₋₁ ]   [0]
+      #                     [ζbarₖ]
+      if iter ≥ 3
+        ζₖ₋₂ = ζₖ₋₁
+        ηₖ₋₁ = ηₖ
+        ζₖ₋₁ = ηₖ₋₁ / δₖ₋₁
+        ηₖ   = -ϵₖ₋₂ * ζₖ₋₂ - λₖ₋₁ * ζₖ₋₁
+      end
+
+      # Relations for the directions dₖ₋₁ and d̅ₖ, the last two columns of D̅ₖ = Uₖ(Qₖ)ᵀ.
+      # [d̅ₖ₋₁ uₖ] [cₖ  sₖ] = [dₖ₋₁ d̅ₖ] ⟷ dₖ₋₁ = cₖ * d̅ₖ₋₁ + sₖ * uₖ
+      #           [sₖ -cₖ]             ⟷ d̅ₖ   = sₖ * d̅ₖ₋₁ - cₖ * uₖ
+      if iter ≥ 2
+        # Compute solution xₖ.
+        # (xᴸ)ₖ₋₁ ← (xᴸ)ₖ₋₂ + ζₖ₋₁ * dₖ₋₁
+        @kaxpy!(n, ζₖ₋₁ * cₖ,  d̅, x)
+        @kaxpy!(n, ζₖ₋₁ * sₖ, uₖ, x)
+      end
+
+      # Compute d̅ₖ.
+      if iter == 1
+        # d̅₁ = u₁
+        @. d̅ = uₖ
+      else
+        # d̅ₖ = sₖ * d̅ₖ₋₁ - cₖ * uₖ
+        @kaxpby!(n, -cₖ, uₖ, sₖ, d̅)
+      end
+
+      # Compute USYMLQ residual norm
+      # ‖rₖ‖ = √((μₖ)² + (ωₖ)²)
+      if iter == 1
+        rNorm_lq = bNorm
+      else
+        μₖ = βₖ * (sₖ₋₁ * ζₖ₋₂ - cₖ₋₁ * cₖ * ζₖ₋₁) + αₖ * sₖ * ζₖ₋₁
+        ωₖ = βₖ₊₁ * sₖ * ζₖ₋₁
+        rNorm_lq = sqrt(μₖ^2 + ωₖ^2)
+      end
+      push!(rNorms, rNorm_lq)
+
+      # Compute USYMCG residual norm
+      # ‖rₖ‖ = |ρₖ|
+      if transfer_to_usymcg && (δbarₖ ≠ 0)
+        ζbarₖ = ηₖ / δbarₖ
+        ρₖ = βₖ₊₁ * (sₖ * ζₖ₋₁ - cₖ * ζbarₖ)
+        rNorm_cg = abs(ρₖ)
+      end
+
+      # Update primal stopping criterion
+      solved_lq = rNorm_lq ≤ ε
+      solved_cg = transfer_to_usymcg && (δbarₖ ≠ 0) && (rNorm_cg ≤ ε)
+      solved_primal = solved_lq || solved_cg
+    end
+
+    if !solved_dual
+      # Compute ψₖ₋₁ and ψbarₖ.
+      if iter == 1
+        ψbarₖ = γₖ
+      else
+        ψₖ₋₁  = cₖ * ψbarₖ₋₁
+        ψbarₖ = sₖ * ψbarₖ₋₁
+      end
+
+      # Compute the direction wₖ₋₁, the last column of Wₖ₋₁ = (Vₖ₋₁)(Lₖ₋₁)⁻ᵀ ⟷ (Lₖ₋₁)(Wₖ₋₁)ᵀ = (Vₖ₋₁)ᵀ.
+      # w₁ = v₁ / δ₁
+      if iter == 2
+        wₖ₋₁ = wₖ₋₂
+        @kaxpy!(m, one(T), vₖ₋₁, wₖ₋₁)
+        @. wₖ₋₁ = vₖ₋₁ / δₖ₋₁
+      end
+      # w₂ = (v₂ - λ₁w₁) / δ₂
+      if iter == 3
+        wₖ₋₁ = wₖ₋₃
+        @kaxpy!(m, one(T), vₖ₋₁, wₖ₋₁)
+        @kaxpy!(m, -λₖ₋₂, wₖ₋₂, wₖ₋₁)
+        @. wₖ₋₁ = wₖ₋₁ / δₖ₋₁
+      end
+      # wₖ₋₁ = (vₖ₋₁ - λₖ₋₂wₖ₋₂ - ϵₖ₋₃wₖ₋₃) / δₖ₋₁
+      if iter ≥ 4
+        @kscal!(m, -ϵₖ₋₃, wₖ₋₃)
+        wₖ₋₁ = wₖ₋₃
+        @kaxpy!(m, one(T), vₖ₋₁, wₖ₋₁)
+        @kaxpy!(m, -λₖ₋₂, wₖ₋₂, wₖ₋₁)
+        @. wₖ₋₁ = wₖ₋₁ / δₖ₋₁
+      end
+
+      if iter ≥ 3
+        # Swap pointers.
+        @kswap(wₖ₋₃, wₖ₋₂)
+      end
+
+      if iter ≥ 2
+        # Compute solution tₖ₋₁.
+        # tₖ₋₁ ← tₖ₋₂ + ψₖ₋₁ * wₖ₋₁
+        @kaxpy!(m, ψₖ₋₁, wₖ₋₁, t)
+      end
+
+      # Update ψbarₖ₋₁
+      ψbarₖ₋₁ = ψbarₖ
+
+      # Compute USYMQR residual norm ‖sₖ₋₁‖ = |ψbarₖ|.
+      sNorm = abs(ψbarₖ)
+      push!(sNorms, sNorm)
+
+      # Update dual stopping criterion
+      solved_dual = sNorm ≤ Κ
+    end
+
+    # Compute uₖ₊₁ and uₖ₊₁.
+    @. vₖ₋₁ = vₖ # vₖ₋₁ ← vₖ
+    @. uₖ₋₁ = uₖ # uₖ₋₁ ← uₖ
+
+    if βₖ₊₁ ≠ zero(T)
+      @. vₖ = q / βₖ₊₁ # βₖ₊₁vₖ₊₁ = q
+    end
+    if γₖ₊₁ ≠ zero(T)
+      @. uₖ = p / γₖ₊₁ # γₖ₊₁uₖ₊₁ = p
+    end
+
+    # Update ϵₖ₋₃, λₖ₋₂, δbarₖ₋₁, γₖ and βₖ.
+    if iter ≥ 3
+      ϵₖ₋₃ = ϵₖ₋₂
+    end
+    if iter ≥ 2
+      λₖ₋₂ = λₖ₋₁
+    end
+    δbarₖ₋₁ = δbarₖ
+    γₖ      = γₖ₊₁
+    βₖ      = βₖ₊₁
+    
+    tired = iter ≥ itmax
+    verbose && @printf("%5d  %7.1e  %7.1e\n", iter, rNorm, sNorm)
+  end
+  verbose && @printf("\n")
+
+  # Compute USYMCG point
+  # (xᶜ)ₖ ← (xᴸ)ₖ₋₁ + ζbarₖ * d̅ₖ
+  if solved_cg
+    @kaxpy!(n, ζbarₖ, d̅, x)
+  end
+
+  status = tired ? "maximum number of iterations exceeded" : "solutions good enough given atol and rtol"
+  stats = AdjointStats(solved_primal, solved_dual, rNorms, sNorms, status)
+  return (x, t, stats)
+end

--- a/src/trilqr.jl
+++ b/src/trilqr.jl
@@ -295,7 +295,10 @@ function trilqr(A :: AbstractLinearOperator, b :: AbstractVector{T}, c :: Abstra
     @kaxpy!(n, ζbarₖ, d̅, x)
   end
 
-  status = tired ? "maximum number of iterations exceeded" : "solutions good enough given atol and rtol"
+   tired                         && (status = "maximum number of iterations exceeded")
+   solved_primal && !solved_dual && (status = "Only the primal solution is good enough given atol and rtol")
+  !solved_primal &&  solved_dual && (status = "Only the dual solution is good enough given atol and rtol")
+   solved_primal &&  solved_dual && (status = "Both primal and dual solutions are good enough given atol and rtol")
   stats = AdjointStats(solved_primal, solved_dual, rNorms, sNorms, status)
   return (x, t, stats)
 end

--- a/src/trilqr.jl
+++ b/src/trilqr.jl
@@ -199,9 +199,13 @@ function trilqr(A :: AbstractLinearOperator{T}, b :: AbstractVector{T}, c :: Abs
       end
 
       # Update primal stopping criterion
-      solved_lq = rNorm_lq ≤ εL
-      solved_cg = transfer_to_usymcg && (δbarₖ ≠ 0) && (rNorm_cg ≤ εL)
-      solved_primal = solved_lq || solved_cg || (rNorm_lq + 1 ≤ 1)
+      solved_lq_tol = rNorm_lq ≤ εL
+      solved_lq_mach = rNorm_lq + 1 ≤ 1
+      solved_lq = solved_lq_tol || solved_lq_mach
+      solved_cg_tol = transfer_to_usymcg && (δbarₖ ≠ 0) && (rNorm_cg ≤ εL)
+      solved_cg_mach = transfer_to_usymcg && (δbarₖ ≠ 0) && (rNorm_cg + 1 ≤ 1)
+      solved_cg = solved_cg_tol || solved_cg_mach
+      solved_primal = solved_lq || solved_cg
     end
 
     if !solved_dual
@@ -259,8 +263,10 @@ function trilqr(A :: AbstractLinearOperator{T}, b :: AbstractVector{T}, c :: Abs
 
       # Update dual stopping criterion
       iter == 1 && (ξ = atol + rtol * AsNorm)
+      solved_qr_tol = sNorm ≤ εQ
+      solved_qr_mach = sNorm + 1 ≤ 1
       inconsistent = AsNorm ≤ ξ
-      solved_dual = sNorm ≤ εQ || inconsistent || (sNorm + 1 ≤ 1)
+      solved_dual = solved_qr_tol || solved_qr_mach || inconsistent
     end
 
     # Compute uₖ₊₁ and uₖ₊₁.

--- a/src/usymlq.jl
+++ b/src/usymlq.jl
@@ -70,7 +70,7 @@ function usymlq(A :: AbstractLinearOperator{T}, b :: AbstractVector{T}, c :: Abs
   d̅ = zeros(T, n)            # Last column of D̅ₖ = Uₖ(Qₖ)ᵀ
   ζₖ₋₁ = ζbarₖ = zero(T)     # ζₖ₋₁ and ζbarₖ are the last components of z̅ₖ = (L̅ₖ)⁻¹β₁e₁
   ζₖ₋₂ = ηₖ = zero(T)        # ζₖ₋₂ and ηₖ are used to update ζₖ₋₁ and ζbarₖ
-  δbarₖ₋₁ = δbarₖ = zero(T)  # Coefficients of Lₖ₋₁ and Lₖ modified during two iterations
+  δbarₖ₋₁ = δbarₖ = zero(T)  # Coefficients of Lₖ₋₁ and Lₖ modified over the course of two iterations
 
   # Stopping criterion.
   solved_lq = bNorm ≤ ε

--- a/src/variants.jl
+++ b/src/variants.jl
@@ -28,8 +28,8 @@ for fn in (:cgls, :cgne, :craig, :craigmr, :crls, :crmr, :lslq, :lsmr, :lsqr, :d
   end
 end
 
-# Variants for USYMLQ and USYMQR
-for fn in (:usymlq, :usymqr)
+# Variants for USYMLQ, USYMQR, TriLQR and BiLQR
+for fn in (:usymlq, :usymqr, :trilqr, :bilqr)
   @eval begin
     function $fn(A :: AbstractMatrix{TA}, b :: AbstractVector{Tb}, c :: AbstractVector{Tc}, args...; kwargs...) where {TA, Tb, Tc <: Number}
       S = promote_type(TA, Tb, Tc)

--- a/test/get_div_grad.jl
+++ b/test/get_div_grad.jl
@@ -36,7 +36,7 @@ function ODE(n, f, g, ode_coefs; dim_x=[0.0, 1.0])
   χ₂ = ode_coefs[2]
   χ₃ = ode_coefs[3]
 
-  # Modelize problems with Au = b and Aᵀv = c
+  # Model problems with Au = b and Aᵀv = c
   #
   # A ∈ ℜⁿ*ⁿ, u ∈ ℜⁿ, b ∈ ℜⁿ, v ∈ ℜⁿ, c ∈ ℜⁿ
   #
@@ -82,7 +82,7 @@ function PDE(n, m, f, g, pde_coefs; dim_x=[0.0, 1.0], dim_y=[0.0, 1.0])
   d = pde_coefs[4]
   e = pde_coefs[5]
 
-  # Modelize problems with Au = b and Aᵀv = c
+  # Model problems with Au = b and Aᵀv = c
   #
   # A ∈ ℜᵐⁿ*ᵐⁿ, u ∈ ℜᵐⁿ, b ∈ ℜᵐⁿ, v ∈ ℜᵐⁿ, c ∈ ℜᵐⁿ
   # xᵢ = i * Δx, yⱼ = j * Δy and zᵢ.ⱼ = z(xᵢ, yⱼ)

--- a/test/get_div_grad.jl
+++ b/test/get_div_grad.jl
@@ -20,3 +20,116 @@ function ddx(n :: Int)
   e = ones(n)
   return sparse([1:n; 1:n], [1:n; 2:n+1], [-e; e])
 end
+
+# Primal and dual ODEs discretized with central second order finite differences.
+function ODE(n, f, g, ode_coefs; dim_x=[0.0, 1.0])
+  # Ω = ]xₗ, xᵣ[
+  # Ω ∪ ∂Ω = [xₗ, xᵣ]
+  xₗ = dim_x[1]
+  xᵣ = dim_x[2]
+
+  # Uniform grid of Ω with n points
+  Δx = (xᵣ - xₗ) / (n + 1)
+  grid = [i * Δx for i = 1 : n]
+
+  χ₁ = ode_coefs[1]
+  χ₂ = ode_coefs[2]
+  χ₃ = ode_coefs[3]
+
+  # Modelize problems with Au = b and Aᵀv = c
+  #
+  # A ∈ ℜⁿ*ⁿ, u ∈ ℜⁿ, b ∈ ℜⁿ, v ∈ ℜⁿ, c ∈ ℜⁿ
+  #
+  # ∂²z(xᵢ) / ∂x² ≈ (zᵢ₋₁ -2zᵢ + zᵢ₊₁) / (Δx)²
+  #
+  # ∂z(xᵢ) / ∂x ≈ (zᵢ₊₁ - zᵢ₋₁) / (2 * Δx)
+  A = spzeros(n, n)
+  for i = 1 : n
+    if i ≠ 1
+      A[i, i-1] = χ₁ / (Δx * Δx) - χ₂ / (2 * Δx)
+    end
+    A[i, i] = -2 * χ₁ / (Δx * Δx) + χ₃
+    if i ≠ n
+      A[i, i+1] = χ₁ / (Δx * Δx) + χ₂ / (2 * Δx)
+    end
+  end
+
+  b = f(grid)
+  c = g(grid)
+  return A, b, c
+end
+
+# Primal and dual PDEs discretized with central second order finite differences.
+function PDE(n, m, f, g, pde_coefs; dim_x=[0.0, 1.0], dim_y=[0.0, 1.0])
+  # Ω = ]xₗ,xᵣ[ × ]yₗ,yᵣ[
+  # Ω ∪ ∂Ω = [xₗ,xᵣ] × [yₗ,yᵣ]
+  xₗ = dim_x[1]
+  xᵣ = dim_x[2]
+
+  yₗ = dim_y[1]
+  yᵣ = dim_y[2]
+
+  # Uniform grid of Ω with n × m points
+  Δx = (xᵣ - xₗ) / (n + 1)
+  x = [xₗ + i * Δx for i = 1 : n]
+
+  Δy = (yᵣ - yₗ) / (m + 1)
+  y = [yₗ + j * Δy for j = 1 : m]
+
+  a = pde_coefs[1]
+  b = pde_coefs[2]
+  c = pde_coefs[3]
+  d = pde_coefs[4]
+  e = pde_coefs[5]
+
+  # Modelize problems with Au = b and Aᵀv = c
+  #
+  # A ∈ ℜᵐⁿ*ᵐⁿ, u ∈ ℜᵐⁿ, b ∈ ℜᵐⁿ, v ∈ ℜᵐⁿ, c ∈ ℜᵐⁿ
+  # xᵢ = i * Δx, yⱼ = j * Δy and zᵢ.ⱼ = z(xᵢ, yⱼ)
+  #
+  # ∂²z(xᵢ, yⱼ) / ∂x² ≈ (zᵢ₋₁.ⱼ -2zᵢ.ⱼ + zᵢ₊₁.ⱼ) / (Δx)²
+  # ∂²z(xᵢ, yⱼ) / ∂y² ≈ (zᵢ.ⱼ₋₁ -2zᵢ.ⱼ + zᵢ.ⱼ₊₁) / (Δy)²
+  #
+  # ∂z(xᵢ, yⱼ) / ∂x ≈ (zᵢ₊₁.ⱼ - zᵢ₋₁.ⱼ) / (2 * Δx)
+  # ∂z(xᵢ, yⱼ) / ∂y ≈ (zᵢ.ⱼ₊₁ - zᵢ.ⱼ₋₁) / (2 * Δy)
+  #
+  # uᵢ.ⱼ = u[i + m * (j-1)]
+  # bᵢ.ⱼ = f[i + m * (j-1)]
+  #
+  # vᵢ.ⱼ = v[i + m * (j-1)]
+  # cᵢ.ⱼ = g[i + m * (j-1)]
+  A = spzeros(n * m, n * m)
+  for i = 1 : n
+    for j = 1 : m
+      A[i + m*(j-1), i + m*(j-1)] = - 2*a / (Δx * Δx) - 2*b / (Δy * Δy) + e
+      if i ≥ 2
+        A[i + m*(j-1), (i-1) + m*(j-1)] = a / (Δx * Δx) - c / (2*Δx)
+      end
+      if i ≤ n-1
+        A[i + m*(j-1), (i+1) + m*(j-1)] = a / (Δx * Δx) + c / (2*Δx)
+      end
+      if j ≥ 2
+        A[i + m*(j-1), i + m*(j-2)] = b / (Δy * Δy) - d / (2*Δy)
+      end
+      if j ≤ m-1
+        A[i + m*(j-1), i + m*j] = b / (Δy * Δy) + d / (2*Δy)
+      end
+    end
+  end
+
+  b = zeros(n * m)
+  for i = 1 : n
+    for j = 1 : m
+      b[i + m*(j-1)] = f(x[i], y[j])
+    end
+  end
+
+  c = zeros(n * m)
+  for i = 1 : n
+    for j = 1 : m
+      c[i + m*(j-1)] = g(x[i], y[j])
+    end
+  end
+
+  return A, b, c
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,8 @@ include("test_utils.jl")
 include("test_aux.jl")
 
 include("test_usymlq.jl")
+include("test_bilqr.jl")
+include("test_trilqr.jl")
 include("test_usymqr.jl")
 include("test_qmr.jl")
 include("test_diom.jl")

--- a/test/test_alloc.jl
+++ b/test/test_alloc.jl
@@ -219,6 +219,7 @@ actual_usymqr_bytes = @allocated usymqr(Ao, b, c)
 # - 9 n-vectors: uₖ₋₁, uₖ, vₖ₋₁, vₖ, x, t, d̅, wₖ₋₁, wₖ
 storage_trilqr(n) = 9 * n
 storage_trilqr_bytes(n) = 8 * storage_trilqr(n)
+
 expected_trilqr_bytes = storage_trilqr_bytes(n)
 trilqr(A, b, b)  # warmup
 actual_trilqr_bytes = @allocated trilqr(A, b, b)
@@ -238,6 +239,7 @@ actual_bilq_bytes = @allocated bilq(A, b)
 # - 9 n-vectors: uₖ₋₁, uₖ, vₖ₋₁, vₖ, x, t, d̅, wₖ₋₁, wₖ
 storage_bilqr(n) = 9 * n
 storage_bilqr_bytes(n) = 8 * storage_bilqr(n)
+
 expected_bilqr_bytes = storage_bilqr_bytes(n)
 bilqr(A, b, b)  # warmup
 actual_bilqr_bytes = @allocated bilqr(A, b, b)

--- a/test/test_alloc.jl
+++ b/test/test_alloc.jl
@@ -215,6 +215,15 @@ expected_usymqr_bytes = storage_usymqr_bytes(n, m)
 actual_usymqr_bytes = @allocated usymqr(Ao, b, c)
 @test actual_usymqr_bytes ≤ 1.1 * expected_usymqr_bytes
 
+# with (Ap, Aᵀq) preallocated, TRILQR needs:
+# - 9 n-vectors: uₖ₋₁, uₖ, vₖ₋₁, vₖ, x, t, d̅, wₖ₋₁, wₖ
+storage_trilqr(n) = 9 * n
+storage_trilqr_bytes(n) = 8 * storage_trilqr(n)
+expected_trilqr_bytes = storage_trilqr_bytes(n)
+trilqr(A, b, b)  # warmup
+actual_trilqr_bytes = @allocated trilqr(A, b, b)
+@test actual_trilqr_bytes ≤ 1.1 * expected_trilqr_bytes
+
 # with (Ap, Aᵀq) preallocated, BILQ needs:
 # - 6 n-vectors: uₖ₋₁, uₖ, vₖ₋₁, vₖ, x, d̅
 storage_bilq(n) = 6 * n
@@ -224,6 +233,15 @@ expected_bilq_bytes = storage_bilq_bytes(n)
 bilq(A, b)  # warmup
 actual_bilq_bytes = @allocated bilq(A, b)
 @test actual_bilq_bytes ≤ 1.1 * expected_bilq_bytes
+
+# with (Ap, Aᵀq) preallocated, BILQR needs:
+# - 9 n-vectors: uₖ₋₁, uₖ, vₖ₋₁, vₖ, x, t, d̅, wₖ₋₁, wₖ
+storage_bilqr(n) = 9 * n
+storage_bilqr_bytes(n) = 8 * storage_bilqr(n)
+expected_bilqr_bytes = storage_bilqr_bytes(n)
+bilqr(A, b, b)  # warmup
+actual_bilqr_bytes = @allocated bilqr(A, b, b)
+@test actual_bilqr_bytes ≤ 1.1 * expected_bilqr_bytes
 
 # with Ap preallocated, MINRES-QLP needs:
 # - 5 n-vectors: wₖ₋₁, wₖ, vₖ₋₁, vₖ, x

--- a/test/test_bilqr.jl
+++ b/test/test_bilqr.jl
@@ -17,6 +17,40 @@ function test_bilqr()
   @printf("BiLQR: Dual relative residual: %8.1e\n", resid_dual)
   @test(resid_dual ≤ bilqr_tol)
   @test(stats.solved_dual)
+
+  # Test adjoint ODEs.
+  A, b, c = adjoint_ode()
+  (x, t, stats) = bilqr(A, b, c)
+  show(stats)
+
+  r = b - A * x
+  resid_primal = norm(r) / norm(b)
+  @printf("BiLQR: Primal relative residual: %8.1e\n", resid_primal)
+  @test(resid_primal ≤ bilqr_tol)
+  @test(stats.solved_primal)
+
+  s = c - A' * t
+  resid_dual = norm(s) / norm(c)
+  @printf("BiLQR: Dual relative residual: %8.1e\n", resid_dual)
+  @test(resid_dual ≤ bilqr_tol)
+  @test(stats.solved_dual)
+
+  # Test adjoint PDEs.
+  A, b, c = adjoint_pde()
+  (x, t, stats) = bilqr(A, b, c)
+  show(stats)
+
+  r = b - A * x
+  resid_primal = norm(r) / norm(b)
+  @printf("BiLQR: Primal relative residual: %8.1e\n", resid_primal)
+  @test(resid_primal ≤ bilqr_tol)
+  @test(stats.solved_primal)
+
+  s = c - A' * t
+  resid_dual = norm(s) / norm(c)
+  @printf("BiLQR: Dual relative residual: %8.1e\n", resid_dual)
+  @test(resid_dual ≤ bilqr_tol)
+  @test(stats.solved_dual)
 end
 
 test_bilqr()

--- a/test/test_bilqr.jl
+++ b/test/test_bilqr.jl
@@ -1,0 +1,22 @@
+function test_bilqr()
+  bilqr_tol = 1.0e-6
+
+  # Test square adjoint systems.
+  A, b, c = square_adjoint()
+  (x, t, stats) = bilqr(A, b, c)
+  show(stats)
+
+  r = b - A * x
+  resid_primal = norm(r) / norm(b)
+  @printf("BiLQR: Primal relative residual: %8.1e\n", resid_primal)
+  @test(resid_primal ≤ bilqr_tol)
+  @test(stats.solved_primal)
+
+  s = c - A' * t
+  resid_dual = norm(s) / norm(c)
+  @printf("BiLQR: Dual relative residual: %8.1e\n", resid_dual)
+  @test(resid_dual ≤ bilqr_tol)
+  @test(stats.solved_dual)
+end
+
+test_bilqr()

--- a/test/test_mp.jl
+++ b/test/test_mp.jl
@@ -28,11 +28,13 @@ function test_mp()
         @test norm(A * x - b) ≤ 10 * (atol + norm(b) * rtol)
         if fn in (:trilqr, :bilqr)
           @test norm(A' * t - c) ≤ 10 * (atol + norm(c) * rtol)
+          @test eltype(t) == T
         end
       else
         @test norm(A * x - b) ≤ atol + norm(b) * rtol
         if fn in (:trilqr, :bilqr)
           @test norm(A' * t - c) ≤ atol + norm(c) * rtol
+          @test eltype(t) == T
         end
       end
       @test eltype(x) == T

--- a/test/test_trilqr.jl
+++ b/test/test_trilqr.jl
@@ -85,6 +85,25 @@ function test_trilqr()
   @printf("TriLQR: Dual relative residual: %8.1e\n", resid_dual)
   @test(resid_dual ≤ trilqr_tol)
   @test(stats.solved_dual)
+
+  # Test consistent Ax = b and inconsistent Aᵀt = c.
+  A, b, c = rectangular_adjoint()
+  (x, t, stats) = trilqr(A, b, c)
+  show(stats)
+
+  r = b - A * x
+  resid_primal = norm(r) / norm(b)
+  @printf("TriLQR: Primal relative residual: %8.1e\n", resid_primal)
+  @test(resid_primal ≤ trilqr_tol)
+  @test(stats.solved_primal)
+
+  s = c - A' * t
+  resid_dual = norm(s) / norm(c)
+  Aresid_dual = norm(A * s) / norm(A * c)
+  @printf("TriLQR: Dual relative residual: %8.1e\n", resid_dual)
+  @printf("TriLQR: Dual relative Aresidual: %8.1e\n", Aresid_dual)
+  @test(Aresid_dual ≤ trilqr_tol)
+  @test(stats.solved_dual)
 end
 
 test_trilqr()

--- a/test/test_trilqr.jl
+++ b/test/test_trilqr.jl
@@ -51,6 +51,40 @@ function test_trilqr()
   @printf("TriLQR: Dual relative residual: %8.1e\n", resid_dual)
   @test(resid_dual ≤ trilqr_tol)
   @test(stats.solved_dual)
+
+  # Test adjoint ODEs.
+  A, b, c = adjoint_ode()
+  (x, t, stats) = trilqr(A, b, c)
+  show(stats)
+
+  r = b - A * x
+  resid_primal = norm(r) / norm(b)
+  @printf("TriLQR: Primal relative residual: %8.1e\n", resid_primal)
+  @test(resid_primal ≤ trilqr_tol)
+  @test(stats.solved_primal)
+
+  s = c - A' * t
+  resid_dual = norm(s) / norm(c)
+  @printf("TriLQR: Dual relative residual: %8.1e\n", resid_dual)
+  @test(resid_dual ≤ trilqr_tol)
+  @test(stats.solved_dual)
+
+  # Test adjoint PDEs.
+  A, b, c = adjoint_pde()
+  (x, t, stats) = trilqr(A, b, c)
+  show(stats)
+
+  r = b - A * x
+  resid_primal = norm(r) / norm(b)
+  @printf("TriLQR: Primal relative residual: %8.1e\n", resid_primal)
+  @test(resid_primal ≤ trilqr_tol)
+  @test(stats.solved_primal)
+
+  s = c - A' * t
+  resid_dual = norm(s) / norm(c)
+  @printf("TriLQR: Dual relative residual: %8.1e\n", resid_dual)
+  @test(resid_dual ≤ trilqr_tol)
+  @test(stats.solved_dual)
 end
 
 test_trilqr()

--- a/test/test_trilqr.jl
+++ b/test/test_trilqr.jl
@@ -1,0 +1,56 @@
+function test_trilqr()
+  trilqr_tol = 1.0e-6
+
+  # Test underdetermined adjoint systems.
+  A, b, c = underdetermined_adjoint()
+  (x, t, stats) = trilqr(A, b, c)
+  show(stats)
+
+  r = b - A * x
+  resid_primal = norm(r) / norm(b)
+  @printf("TriLQR: Primal relative residual: %8.1e\n", resid_primal)
+  @test(resid_primal ≤ trilqr_tol)
+  @test(stats.solved_primal)
+
+  s = c - A' * t
+  resid_dual = norm(s) / norm(c)
+  @printf("TriLQR: Dual relative residual: %8.1e\n", resid_dual)
+  @test(resid_dual ≤ trilqr_tol)
+  @test(stats.solved_dual)
+
+  # Test square adjoint systems.
+  A, b, c = square_adjoint()
+  (x, t, stats) = trilqr(A, b, c)
+  show(stats)
+
+  r = b - A * x
+  resid_primal = norm(r) / norm(b)
+  @printf("TriLQR: Primal relative residual: %8.1e\n", resid_primal)
+  @test(resid_primal ≤ trilqr_tol)
+  @test(stats.solved_primal)
+
+  s = c - A' * t
+  resid_dual = norm(s) / norm(c)
+  @printf("TriLQR: Dual relative residual: %8.1e\n", resid_dual)
+  @test(resid_dual ≤ trilqr_tol)
+  @test(stats.solved_dual)
+
+  # Test overdetermined adjoint systems
+  A, b, c = overdetermined_adjoint()
+  (x, t, stats) = trilqr(A, b, c)
+  show(stats)
+
+  r = b - A * x
+  resid_primal = norm(r) / norm(b)
+  @printf("TriLQR: Primal relative residual: %8.1e\n", resid_primal)
+  @test(resid_primal ≤ trilqr_tol)
+  @test(stats.solved_primal)
+
+  s = c - A' * t
+  resid_dual = norm(s) / norm(c)
+  @printf("TriLQR: Dual relative residual: %8.1e\n", resid_dual)
+  @test(resid_dual ≤ trilqr_tol)
+  @test(stats.solved_dual)
+end
+
+test_trilqr()

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -115,7 +115,6 @@ function almost_singular(n :: Int=16)
   return A, b
 end
 
-<<<<<<< HEAD
 # System that cause a breakdown with the symmetric Lanczos process.
 function symmetric_breakdown()
   A = [0.0 1.0; 1.0 0.0]
@@ -132,7 +131,7 @@ function unsymmetric_breakdown()
   return A, b, c
 end
 
-# Underdetermined adjoint systems.
+# Underdetermined consistent adjoint systems.
 function underdetermined_adjoint(n :: Int=100, m :: Int=200)
   n < m || error("Square or overdetermined system!")
   A = [i == j ? 10.0 : i < j ? 1.0 : -1.0 for i=1:n, j=1:m]
@@ -141,7 +140,7 @@ function underdetermined_adjoint(n :: Int=100, m :: Int=200)
   return A, b, c
 end
 
-# Square adjoint systems.
+# Square consistent adjoint systems.
 function square_adjoint(n :: Int=100)
   A = [i == j ? 10.0 : i < j ? 1.0 : -1.0 for i=1:n, j=1:n]
   b = A * [1:n;]
@@ -149,7 +148,15 @@ function square_adjoint(n :: Int=100)
   return A, b, c
 end
 
-# Overdetermined adjoint systems.
+# Adjoint systems with Ax = b underdetermined consistent and Aᵀt = c overdetermined insconsistent.
+function rectangular_adjoint(n :: Int=10, m :: Int=25)
+  Aᵀ, c = over_inconsistent(m, n)
+  A = transpose(Aᵀ)
+  b = A * ones(m)
+  return A, b, c
+end
+
+# Overdetermined consistent adjoint systems.
 function overdetermined_adjoint(n :: Int=200, m :: Int=100)
   n > m || error("Underdetermined or square system!")
   A = [i == j ? 10.0 : i < j ? 1.0 : -1.0 for i=1:n, j=1:m]

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -158,6 +158,46 @@ function overdetermined_adjoint(n :: Int=200, m :: Int=100)
   return A, b, c
 end
 
+# Adjoint ODEs
+function adjoint_ode(n :: Int=50)
+  χ₁ = χ₂ = χ₃ = 1.0
+  # Primal ODE
+  # χ₁ * d²U(x)/dx² + χ₂ * dU(x)/dx + χ₃ * U(x) = f(x)
+  # U(0) = U(1) = 0
+  function f(x)
+    return (- χ₁ * π * π + χ₃) .* sin.(π.*x) .+ (χ₂ * π) .* cos.(π.*x)
+  end
+  # Dual ODE
+  # χ₁ * d²V(x)/dx² - χ₂ * dV(x)/dx + χ₃ *  V(x) = g(x)
+  # V(0) = V(1) = 0
+  function g(x)
+    exp.(x)
+  end
+  A, b, c = ODE(n, f, g, [χ₁, χ₂, χ₃])
+  return A, b, c
+end
+
+# Adjoint PDEs
+function adjoint_pde(n :: Int=50, m :: Int=50)
+  κ₁ = 5.0
+  κ₂ = 20.0
+  κ₃ = 0.0
+  # Primal PDE
+  # κ₁ * ( ∂²u(x,y)/∂x² + ∂²u(x,y)/∂y² )  + κ₂ * ( ∂u(x,y)/∂x + ∂u(x,y)/∂y ) = f(x,y), (x,y) ∈ Ω
+  # u(x,y) = 0, (x,y) ∈ ∂Ω
+  function f(x, y)
+    return (-2 * κ₁ * π * π + κ₃) * sin(π * x) * sin(π * y) + κ₂ * π * cos(π * x) * sin(π * y) + κ₂ * π * sin(π * x) * cos(π * y)
+  end
+  # Dual PDE
+  # κ₁ * ( ∂²v(x,y)/∂x² + ∂²v(x,y)/∂y² )  - κ₂ * ( ∂v(x,y)/∂x + ∂v(x,y)/∂y ) = g(x,y), (x,y) ∈ Ω
+  # v(x,y) = 0, (x,y) ∈ ∂Ω
+  function g(x, y)
+    return exp(x + y)
+  end
+  A, b, c = PDE(n, m, f, g, [κ₁, κ₁, κ₂, κ₂, κ₃])
+  return A, b, c
+end
+
 # Square and preconditioned problems.
 function square_preconditioned(n :: Int=10)
   A = ones(n, n) + (n-1) * I

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -115,6 +115,7 @@ function almost_singular(n :: Int=16)
   return A, b
 end
 
+<<<<<<< HEAD
 # System that cause a breakdown with the symmetric Lanczos process.
 function symmetric_breakdown()
   A = [0.0 1.0; 1.0 0.0]
@@ -131,12 +132,37 @@ function unsymmetric_breakdown()
   return A, b, c
 end
 
+# Underdetermined adjoint systems.
+function underdetermined_adjoint(n :: Int=100, m :: Int=200)
+  n < m || error("Square or overdetermined system!")
+  A = [i == j ? 10.0 : i < j ? 1.0 : -1.0 for i=1:n, j=1:m]
+  b = A * [1:m;]
+  c = A' * [-n:-1;]
+  return A, b, c
+end
+
+# Square adjoint systems.
+function square_adjoint(n :: Int=100)
+  A = [i == j ? 10.0 : i < j ? 1.0 : -1.0 for i=1:n, j=1:n]
+  b = A * [1:n;]
+  c = A' * [-n:-1;]
+  return A, b, c
+end
+
+# Overdetermined adjoint systems.
+function overdetermined_adjoint(n :: Int=200, m :: Int=100)
+  n > m || error("Underdetermined or square system!")
+  A = [i == j ? 10.0 : i < j ? 1.0 : -1.0 for i=1:n, j=1:m]
+  b = A * [1:m;]
+  c = A' * [-n:-1;]
+  return A, b, c
+end
+
 # Square and preconditioned problems.
 function square_preconditioned(n :: Int=10)
   A = ones(n, n) + (n-1) * I
   b = n * [1:n;]
-  O = zeros(n, n)
-  M = PreallocatedLinearOperator(1/n * (O + I))
+  M = PreallocatedLinearOperator(1/n * eye(n))
   return A, b, M
 end
 
@@ -145,8 +171,8 @@ function two_preconditioners(n :: Int=10, m :: Int=20)
   A = ones(n, n) + (n-1) * I
   b = ones(n)
   O = zeros(n, n)
-  M = PreallocatedLinearOperator(1/√n * (O + I))
-  N = PreallocatedLinearOperator(1/√m * (O + I))
+  M = PreallocatedLinearOperator(1/√n * eye(n))
+  N = PreallocatedLinearOperator(1/√m * eye(n))
   return A, b, M, N
 end
 

--- a/test/test_variants.jl
+++ b/test/test_variants.jl
@@ -4,7 +4,7 @@ function test_variants()
   for fn in (:cg_lanczos, :cg_lanczos_shift_seq, :cg, :cgls, :cgne,
              :cr, :craig, :craigmr, :crls, :crmr, :lslq, :lsmr, :bilq,
              :lsqr, :minres, :symmlq, :dqgmres, :diom, :cgs, :usymqr,
-             :minres_qlp, :qmr, :usymlq)
+             :minres_qlp, :qmr, :usymlq, :bilqr, :trilqr)
     @printf("%s ", string(fn))
     for TA in (Int32, Int64, Float32, Float64, BigFloat)
       for IA in (Int32, Int64)
@@ -12,7 +12,7 @@ function test_variants()
           for Ib in (Int32, Int64)
             A_dense = Matrix{TA}(I, 5, 5)
             A_sparse = convert(SparseMatrixCSC{TA,IA}, A_dense)
-            b_dense = ones(Tb,5)
+            b_dense = ones(Tb, 5)
             b_sparse = convert(SparseVector{Tb,Ib}, b_dense)
             if fn == :cg_lanczos_shift_seq
               shifts = [1:5;]
@@ -28,8 +28,8 @@ function test_variants()
               @eval $fn(adjoint($A_dense),  $b_sparse, $shifts)
               @eval $fn(adjoint($A_sparse), $b_dense,  $shifts)
               @eval $fn(adjoint($A_sparse), $b_sparse, $shifts)
-            elseif fn in (:usymlq, :usymqr)
-              c_dense = ones(Tb,5)
+            elseif fn in (:usymlq, :usymqr, :trilqr, :bilqr)
+              c_dense = ones(Tb, 5)
               c_sparse = convert(SparseVector{Tb,Ib}, c_dense)
               @eval $fn($A_dense,  $b_dense,  $c_dense )
               @eval $fn($A_dense,  $b_dense,  $c_sparse)


### PR DESCRIPTION
- BiLQR and TriLQR methods for solving adjoint systems Ax=b and Aᵀt = c
- ODE and PDE adjoint problems used as tests
- Generalized TriLQR for rectangular matrices
- Allows inconsistent dual systems in TriLQR (solved by USYMQR)
- Stop primal or dual system when it's solved and continues the other one
- Improve verbose mode and statuses in both methods
- Use BiLQ, QMR, USYMLQ and USYMQR residual norm estimates described in the BiLQR / TriLQR article
