### PR TITLE
Version 0.3.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,5 +1,6 @@
 name = "Krylov"
 uuid = "ba0b0d4f-ebba-5204-a429-3ac8c609bfb7"
+version = "0.3.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"


### PR DESCRIPTION
We have to limit `LinearOperators` version, but also there are 69 commits since the last release.
Otherwise, we could choose an older point to make release 0.3.1.