### PR TITLE
hotfix documentation

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -3,7 +3,6 @@ using Documenter, Krylov
 makedocs(
   modules = [Krylov],
   doctest = true,
-  linkcheck = true,
   strict = true,
   format = Documenter.HTML(assets = ["assets/style.css"], prettyurls = get(ENV, "CI", nothing) == "true"),
   sitename = "Krylov.jl",

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -2,7 +2,7 @@
 
 This package provides implementations of certain of the most useful Krylov method for a variety of problems:
 
-1. Square or rectangular full-rank systems
+1 - Square or rectangular full-rank systems
 
 ```math
   Ax = b
@@ -12,7 +12,7 @@ should be solved when **_b_** lies in the range space of **_A_**. This situation
   * **_A_** is square and nonsingular,
   * **_A_** is tall and has full column rank and **_b_** lies in the range of **_A_**.
 
-2. Linear least-squares problems
+2 - Linear least-squares problems
 
 ```math
   \min \|b - Ax\|
@@ -30,7 +30,7 @@ If there are infinitely many such **_x_** (because **_A_** is column rank-defici
   \min \|x\| \quad \text{subject to} \quad x \in \argmin \|b - Ax\|.
 ```
 
-3. Linear least-norm problems
+3 - Linear least-norm problems
 
 ```math
   \min \|x\| \quad \text{subject to} \quad Ax = b
@@ -43,7 +43,7 @@ This situation mainly occurs when
 
 Overdetermined sytems are less common but also occur.
 
-4. Adjoint systems
+4 - Adjoint systems
 
 ```math
   Ax = b \quad \text{and} \quad A^T y = c
@@ -51,7 +51,7 @@ Overdetermined sytems are less common but also occur.
 
 where **_A_** can have any shape.
 
-5. saddle-point or symmetric quasi-definite (SQD) systems
+5 - Saddle-point or symmetric quasi-definite (SQD) systems
 
 ```math
   \begin{bmatrix} M & \phantom{-}A \\ A^T & -N \end{bmatrix} \begin{bmatrix} x \\ y \end{bmatrix} = \left(\begin{bmatrix} b \\ 0 \end{bmatrix},\begin{bmatrix} 0 \\ c \end{bmatrix},\begin{bmatrix} b \\ c \end{bmatrix}\right)

--- a/src/bilq.jl
+++ b/src/bilq.jl
@@ -12,7 +12,8 @@
 
 export bilq
 
-"""Solve the square linear system Ax = b using the BiLQ method.
+"""
+Solve the square linear system Ax = b using the BiLQ method.
 
 BiLQ is based on the Lanczos biorthogonalization process.
 When A is symmetric and b = c, BiLQ is equivalent to SYMMLQ.

--- a/src/bilqr.jl
+++ b/src/bilqr.jl
@@ -12,7 +12,8 @@
 
 export bilqr
 
-"""Combine BiLQ and QMR to solve adjoint systems.
+"""
+Combine BiLQ and QMR to solve adjoint systems.
 
     [0  A] [t] = [b]
     [Aᵀ 0] [x]   [c]

--- a/src/cg.jl
+++ b/src/cg.jl
@@ -11,7 +11,8 @@
 export cg
 
 
-"""The conjugate gradient method to solve the symmetric linear system Ax=b.
+"""
+The conjugate gradient method to solve the symmetric linear system Ax=b.
 
 The method does _not_ abort if A is not definite.
 

--- a/src/cg_lanczos.jl
+++ b/src/cg_lanczos.jl
@@ -12,7 +12,8 @@
 export cg_lanczos, cg_lanczos_shift_seq
 
 
-"""The Lanczos version of the conjugate gradient method to solve the
+"""
+The Lanczos version of the conjugate gradient method to solve the
 symmetric linear system
 
     Ax = b
@@ -115,7 +116,8 @@ function cg_lanczos(A :: AbstractLinearOperator{T}, b :: AbstractVector{T};
 end
 
 
-"""The Lanczos version of the conjugate gradient method to solve a family
+"""
+The Lanczos version of the conjugate gradient method to solve a family
 of shifted systems
 
     (A + αI) x = b  (α = α₁, ..., αₙ)

--- a/src/cgls.jl
+++ b/src/cgls.jl
@@ -22,7 +22,8 @@
 export cgls
 
 
-"""Solve the regularized linear least-squares problem
+"""
+Solve the regularized linear least-squares problem
 
     minimize ‖b - Ax‖₂² + λ ‖x‖₂²
 

--- a/src/cgne.jl
+++ b/src/cgne.jl
@@ -29,7 +29,8 @@
 export cgne
 
 
-"""Solve the consistent linear system
+"""
+Solve the consistent linear system
 
     Ax + √λs = b
 

--- a/src/cgs.jl
+++ b/src/cgs.jl
@@ -13,7 +13,8 @@
 
 export cgs
 
-"""Solve the consistent linear system Ax = b using conjugate gradient squared algorithm.
+"""
+Solve the consistent linear system Ax = b using conjugate gradient squared algorithm.
 
 From "Iterative Methods for Sparse Linear Systems (Y. Saad)" :
 

--- a/src/cr.jl
+++ b/src/cr.jl
@@ -7,7 +7,8 @@
 
 export cr
 
-"""A truncated version of Stiefel’s Conjugate Residual method to solve the symmetric linear system Ax=b.
+"""
+A truncated version of Stiefel’s Conjugate Residual method to solve the symmetric linear system Ax=b.
 The matrix A must be positive semi-definite.
 
 A preconditioner M may be provided in the form of a linear operator and is

--- a/src/craig.jl
+++ b/src/craig.jl
@@ -33,7 +33,8 @@
 export craig
 
 
-"""Find the least-norm solution of the consistent linear system
+"""
+Find the least-norm solution of the consistent linear system
 
     Ax + √λs = b
 

--- a/src/craigmr.jl
+++ b/src/craigmr.jl
@@ -28,7 +28,8 @@
 export craigmr
 
 
-"""Solve the consistent linear system
+"""
+Solve the consistent linear system
 
     Ax + √λs = b
 

--- a/src/crls.jl
+++ b/src/crls.jl
@@ -21,7 +21,8 @@
 export crls
 
 
-"""Solve the linear least-squares problem
+"""
+Solve the linear least-squares problem
 
     minimize ‖b - Ax‖₂² + λ ‖x‖₂²
 

--- a/src/crmr.jl
+++ b/src/crmr.jl
@@ -28,7 +28,8 @@
 export crmr
 
 
-"""Solve the consistent linear system
+"""
+Solve the consistent linear system
 
     Ax + √λs = b
 

--- a/src/diom.jl
+++ b/src/diom.jl
@@ -13,7 +13,8 @@
 
 export diom
 
-"""Solve the consistent linear system Ax = b using direct incomplete orthogonalization method.
+"""
+Solve the consistent linear system Ax = b using direct incomplete orthogonalization method.
 
 DIOM is similar to CG with partial reorthogonalization.
 

--- a/src/dqgmres.jl
+++ b/src/dqgmres.jl
@@ -13,7 +13,8 @@
 
 export dqgmres
 
-"""Solve the consistent linear system Ax = b using DQGMRES method.
+"""
+Solve the consistent linear system Ax = b using DQGMRES method.
 
 DQGMRES algorithm is based on the incomplete Arnoldi orthogonalization process
 and computes a sequence of approximate solutions with the quasi-minimal residual property.

--- a/src/krylov_aux.jl
+++ b/src/krylov_aux.jl
@@ -1,4 +1,5 @@
-"""Numerically stable symmetric Givens reflection.
+"""
+Numerically stable symmetric Givens reflection.
 Given `a` and `b`, return `(c, s, ρ)` such that
 
     [ c  s ] [ a ] = [ ρ ]
@@ -41,7 +42,8 @@ function sym_givens(a :: T, b :: T) where T <: AbstractFloat
 end
 
 
-"""Find the real roots of the quadratic
+"""
+Find the real roots of the quadratic
 
     q(x) = q₂ x² + q₁ x + q₀,
 
@@ -89,7 +91,8 @@ function roots_quadratic(q₂ :: T, q₁ :: T, q₀ :: T;
 end
 
 
-"""Given a trust-region radius `radius`, a vector `x` lying inside the
+"""
+Given a trust-region radius `radius`, a vector `x` lying inside the
 trust-region and a direction `d`, return `σ1` and `σ2` such that
 
     ‖x + σi d‖ = radius, i = 1, 2

--- a/src/lsmr.jl
+++ b/src/lsmr.jl
@@ -25,7 +25,8 @@
 export lsmr
 
 
-"""Solve the regularized linear least-squares problem
+"""
+Solve the regularized linear least-squares problem
 
     minimize ‖b - Ax‖₂² + λ² ‖x‖₂²
 

--- a/src/lsqr.jl
+++ b/src/lsqr.jl
@@ -25,7 +25,8 @@
 export lsqr
 
 
-"""Solve the regularized linear least-squares problem
+"""
+Solve the regularized linear least-squares problem
 
     minimize ‖b - Ax‖₂² + λ² ‖x‖₂²
 

--- a/src/minres.jl
+++ b/src/minres.jl
@@ -22,7 +22,8 @@
 export minres
 
 
-"""Solve the shifted linear least-squares problem
+"""
+Solve the shifted linear least-squares problem
 
     minimize ‖b - (A + λ I)x‖₂²
 

--- a/src/qmr.jl
+++ b/src/qmr.jl
@@ -19,7 +19,9 @@
 # Montreal, May 2019.
 
 export qmr
-"""Solve the square linear system Ax = b using the QMR method.
+
+"""
+Solve the square linear system Ax = b using the QMR method.
 
 QMR is based on the Lanczos biorthogonalization process.
 When A is symmetric and b = c, QMR is equivalent to MINRES.

--- a/src/symmlq.jl
+++ b/src/symmlq.jl
@@ -12,7 +12,8 @@
 export symmlq
 
 
-"""Solve the shifted linear system
+"""
+Solve the shifted linear system
 
     (A + λ I) x = b
 

--- a/src/trilqr.jl
+++ b/src/trilqr.jl
@@ -12,7 +12,8 @@
 
 export trilqr
 
-"""Combine USYMLQ and USYMQR to solve adjoint systems.
+"""
+Combine USYMLQ and USYMQR to solve adjoint systems.
 
     [0  A] [t] = [b]
     [Aᵀ 0] [x]   [c]

--- a/src/usymlq.jl
+++ b/src/usymlq.jl
@@ -19,7 +19,8 @@
 
 export usymlq
 
-"""Solve the linear system Ax = b using the USYMLQ method.
+"""
+Solve the linear system Ax = b using the USYMLQ method.
 
 USYMLQ is based on a tridiagonalization process for unsymmetric matrices.
 The error norm ‖x - x*‖ monotonously decreases in USYMLQ.

--- a/src/usymqr.jl
+++ b/src/usymqr.jl
@@ -19,7 +19,8 @@
 
 export usymqr
 
-"""Solve the linear system Ax = b using the USYMQR method.
+"""
+Solve the linear system Ax = b using the USYMQR method.
 
 USYMQR is based on a tridiagonalization process for unsymmetric matrices.
 The residual norm ‖b - Ax‖ monotonously decreases in USYMQR.


### PR DESCRIPTION
Documenter automatically convert 1. 2. 3. into 1. 1. 1... I wasn't able to solve that so I used 1 - 2- 3- instead.

I also remarked that links to source weren't working. I solved this problem in the same time.
It's useful if a user want to see what parameters are needed by the Krylov solvers.
![Capture du 2020-01-13 16-46-28](https://user-images.githubusercontent.com/35051714/72269702-528e4700-3624-11ea-91a2-ddab7f8dbedb.png)
