### PR TITLE
Suitable residual norm estimate in CR when a preconditioner is supplied

### DIFF
--- a/src/cg.jl
+++ b/src/cg.jl
@@ -18,6 +18,7 @@ The method does _not_ abort if A is not definite.
 
 A preconditioner M may be provided in the form of a linear operator and is
 assumed to be symmetric and positive definite.
+M also indicates the weighted norm in which residuals are measured.
 """
 function cg(A :: AbstractLinearOperator{T}, b :: AbstractVector{T};
             M :: AbstractLinearOperator=opEye(), atol :: T=√eps(T),

--- a/src/cr.jl
+++ b/src/cr.jl
@@ -13,6 +13,8 @@ The matrix A must be positive semi-definite.
 
 A preconditioner M may be provided in the form of a linear operator and is
 assumed to be symmetric and positive definite.
+M also indicates the weighted norm in which residuals are measured.
+
 In a linesearch context, 'linesearch' must be set to 'true'.
 """
 function cr(A :: AbstractLinearOperator{T}, b :: AbstractVector{T};
@@ -43,7 +45,7 @@ function cr(A :: AbstractLinearOperator{T}, b :: AbstractVector{T};
   iter = 0
   itmax == 0 && (itmax = 2 * n)
 
-  rNorm = @knrm2(n, r) # ‖r‖
+  rNorm = sqrt(@kdot(n, r, b)) # ‖r‖
   rNorms = [rNorm] # Values of ‖r‖
   rNorm² = rNorm * rNorm
   pNorm = rNorm

--- a/test/test_cg.jl
+++ b/test/test_cg.jl
@@ -63,10 +63,10 @@ function test_cg()
 
   # Test with Jacobi (or diagonal) preconditioner
   A, b, M = square_preconditioned()
-  (x, stats) = cg(A, b, M=M, itmax=10);
+  (x, stats) = cg(A, b, M=M)
   show(stats)
   r = b - A * x;
-  resid = norm(r) / norm(b);
+  resid = sqrt(dot(r, M * r)) / norm(b)
   @printf("CG: Relative residual: %8.1e\n", resid);
   @test(resid <= cg_tol);
   @test(stats.solved);

--- a/test/test_cr.jl
+++ b/test/test_cr.jl
@@ -78,13 +78,13 @@ function test_cr()
 
   # Test with Jacobi (or diagonal) preconditioner
   A, b, M = square_preconditioned()
-  (x, stats) = cr(A, b, M=M, itmax=10);
+  (x, stats) = cr(A, b, M=M)
   show(stats)
   r = b - A * x;
-  resid = norm(r) / norm(b);
+  resid = sqrt(dot(r, M * r)) / norm(b)
   @printf("CR: Relative residual: %8.1e\n", resid);
   @test(resid <= cr_tol);
-  # @test(stats.solved);
+  @test(stats.solved)
 end
 
 test_cr()


### PR DESCRIPTION
fix #120 
The problem came from the initialization of `rNorm`.