### PR TITLE
Wrap automatically preconditioners in a LinearOperator

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,6 +1,7 @@
 ## Types
 
 ```@docs
+Krylov.Preconditioner
 Krylov.KrylovStats
 Krylov.SimpleStats
 Krylov.LanczosStats

--- a/src/Krylov.jl
+++ b/src/Krylov.jl
@@ -45,6 +45,13 @@ mutable struct AdjointStats{T} <: KrylovStats{T}
   status :: String
 end
 
+"
+    Preconditioner{T} = Union{AbstractLinearOperator{T}, opEye}
+
+Abstract type accepted for preconditioners
+"
+Preconditioner{T} = Union{AbstractLinearOperator{T}, opEye}
+
 import Base.show
 
 function show(io :: IO, stats :: SimpleStats)

--- a/src/cg.jl
+++ b/src/cg.jl
@@ -21,7 +21,7 @@ assumed to be symmetric and positive definite.
 M also indicates the weighted norm in which residuals are measured.
 """
 function cg(A :: AbstractLinearOperator{T}, b :: AbstractVector{T};
-            M :: AbstractLinearOperator=opEye(), atol :: T=√eps(T),
+            M :: Preconditioner{T}=opEye(), atol :: T=√eps(T),
             rtol :: T=√eps(T), itmax :: Int=0, radius :: T=zero(T),
             verbose :: Bool=false) where T <: AbstractFloat
 

--- a/src/cg_lanczos.jl
+++ b/src/cg_lanczos.jl
@@ -24,7 +24,7 @@ A preconditioner M may be provided in the form of a linear operator and is
 assumed to be symmetric and positive definite.
 """
 function cg_lanczos(A :: AbstractLinearOperator{T}, b :: AbstractVector{T};
-                    M :: AbstractLinearOperator=opEye(),
+                    M :: Preconditioner{T}=opEye(),
                     atol :: T=√eps(T), rtol :: T=√eps(T), itmax :: Int=0,
                     check_curvature :: Bool=false, verbose :: Bool=false) where T <: AbstractFloat
 
@@ -128,7 +128,7 @@ A preconditioner M may be provided in the form of a linear operator and is
 assumed to be symmetric and positive definite.
 """
 function cg_lanczos_shift_seq(A :: AbstractLinearOperator{T}, b :: AbstractVector{T},
-                              shifts :: AbstractVector{T}; M :: AbstractLinearOperator=opEye(),
+                              shifts :: AbstractVector{T}; M :: Preconditioner{T}=opEye(),
                               atol :: T=√eps(T), rtol :: T=√eps(T), itmax :: Int=0,
                               check_curvature :: Bool=false, verbose :: Bool=false) where T <: AbstractFloat
 

--- a/src/cgls.jl
+++ b/src/cgls.jl
@@ -39,7 +39,7 @@ It is formally equivalent to LSQR, though can be slightly less accurate,
 but simpler to implement.
 """
 function cgls(A :: AbstractLinearOperator{T}, b :: AbstractVector{T};
-              M :: AbstractLinearOperator=opEye(), λ :: T=zero(T),
+              M :: Preconditioner{T}=opEye(), λ :: T=zero(T),
               atol :: T=√eps(T), rtol :: T=√eps(T), radius :: T=zero(T),
               itmax :: Int=0, verbose :: Bool=false) where T <: AbstractFloat
 

--- a/src/cgne.jl
+++ b/src/cgne.jl
@@ -55,7 +55,7 @@ but simpler to implement. Only the x-part of the solution is returned.
 A preconditioner M may be provided in the form of a linear operator.
 """
 function cgne(A :: AbstractLinearOperator{T}, b :: AbstractVector{T};
-              M :: AbstractLinearOperator=opEye(), λ :: T=zero(T),
+              M :: Preconditioner{T}=opEye(), λ :: T=zero(T),
               atol :: T=√eps(T), rtol :: T=√eps(T), itmax :: Int=0,
               verbose :: Bool=false) where T <: AbstractFloat
 

--- a/src/cgs.jl
+++ b/src/cgs.jl
@@ -34,7 +34,7 @@ TFQMR and BICGSTAB were developed to remedy this difficulty.»
 This implementation allows a right preconditioner M.
 """
 function cgs(A :: AbstractLinearOperator{T}, b :: AbstractVector{T};
-             M :: AbstractLinearOperator=opEye(),
+             M :: Preconditioner{T}=opEye(),
              atol :: T=√eps(T), rtol :: T=√eps(T),
              itmax :: Int=0, verbose :: Bool=false) where T <: AbstractFloat
 

--- a/src/cr.jl
+++ b/src/cr.jl
@@ -18,7 +18,7 @@ M also indicates the weighted norm in which residuals are measured.
 In a linesearch context, 'linesearch' must be set to 'true'.
 """
 function cr(A :: AbstractLinearOperator{T}, b :: AbstractVector{T};
-            M :: AbstractLinearOperator=opEye(), atol :: T=√eps(T),
+            M :: Preconditioner{T}=opEye(), atol :: T=√eps(T),
             rtol :: T=√eps(T), γ :: T=√eps(T), itmax :: Int=0,
             radius :: T=zero(T), verbose :: Bool=false, linesearch :: Bool=false) where T <: AbstractFloat
 

--- a/src/craig.jl
+++ b/src/craig.jl
@@ -60,8 +60,8 @@ which is equivalent to applying CG to (M + AN⁻¹Aᵀ)y = b.
 In this implementation, both the x and y-parts of the solution are returned.
 """
 function craig(A :: AbstractLinearOperator{T}, b :: AbstractVector{T};
-               M :: AbstractLinearOperator=opEye(),
-               N :: AbstractLinearOperator=opEye(),
+               M :: Preconditioner{T}=opEye(),
+               N :: Preconditioner{T}=opEye(),
                λ :: T=zero(T),
                atol :: T=√eps(T), btol :: T=√eps(T), rtol :: T=√eps(T),
                conlim :: T=1/√eps(T), itmax :: Int=0,

--- a/src/craigmr.jl
+++ b/src/craigmr.jl
@@ -62,8 +62,8 @@ and intricate to implement. Both the x- and y-parts of the solution are
 returned.
 """
 function craigmr(A :: AbstractLinearOperator{T}, b :: AbstractVector{T};
-                 M :: AbstractLinearOperator=opEye(),
-                 N :: AbstractLinearOperator=opEye(),
+                 M :: Preconditioner{T}=opEye(),
+                 N :: Preconditioner{T}=opEye(),
                  λ :: T=zero(T), atol :: T=√eps(T), rtol :: T=√eps(T),
                  itmax :: Int=0, verbose :: Bool=false) where T <: AbstractFloat
 

--- a/src/crls.jl
+++ b/src/crls.jl
@@ -38,7 +38,7 @@ It is formally equivalent to LSMR, though can be substantially less accurate,
 but simpler to implement.
 """
 function crls(A :: AbstractLinearOperator{T}, b :: AbstractVector{T};
-              M :: AbstractLinearOperator=opEye(), λ :: T=zero(T),
+              M :: Preconditioner{T}=opEye(), λ :: T=zero(T),
               atol :: T=√eps(T), rtol :: T=√eps(T), radius :: T=zero(T),
               itmax :: Int=0, verbose :: Bool=false) where T <: AbstractFloat
 

--- a/src/crmr.jl
+++ b/src/crmr.jl
@@ -54,7 +54,7 @@ but simpler to implement. Only the x-part of the solution is returned.
 A preconditioner M may be provided in the form of a linear operator.
 """
 function crmr(A :: AbstractLinearOperator{T}, b :: AbstractVector{T};
-              M :: AbstractLinearOperator=opEye(), λ :: T=zero(T),
+              M :: Preconditioner{T}=opEye(), λ :: T=zero(T),
               atol :: T=√eps(T), rtol :: T=√eps(T),
               itmax :: Int=0, verbose :: Bool=false) where T <: AbstractFloat
 

--- a/src/diom.jl
+++ b/src/diom.jl
@@ -27,8 +27,8 @@ This implementation allows a left preconditioner M and a right preconditioner N.
 - Split preconditioning : M⁻¹AN⁻¹u = M⁻¹b with x = N⁻¹u
 """
 function diom(A :: AbstractLinearOperator{T}, b :: AbstractVector{T};
-              M :: AbstractLinearOperator=opEye(),
-              N :: AbstractLinearOperator=opEye(),
+              M :: Preconditioner{T}=opEye(),
+              N :: Preconditioner{T}=opEye(),
               atol :: T=√eps(T), rtol :: T=√eps(T), itmax :: Int=0,
               memory :: Int=20, pivoting :: Bool=false, verbose :: Bool=false) where T <: AbstractFloat
 

--- a/src/dqgmres.jl
+++ b/src/dqgmres.jl
@@ -25,8 +25,8 @@ This implementation allows a left preconditioner M and a right preconditioner N.
 - Split preconditioning : M⁻¹AN⁻¹u = M⁻¹b with x = N⁻¹u
 """
 function dqgmres(A :: AbstractLinearOperator{T}, b :: AbstractVector{T};
-                 M :: AbstractLinearOperator=opEye(),
-                 N :: AbstractLinearOperator=opEye(),
+                 M :: Preconditioner{T}=opEye(),
+                 N :: Preconditioner{T}=opEye(),
                  atol :: T=√eps(T), rtol :: T=√eps(T), itmax :: Int=0,
                  memory :: Int=20, verbose :: Bool=false) where T <: AbstractFloat
 

--- a/src/lslq.jl
+++ b/src/lslq.jl
@@ -93,8 +93,8 @@ The iterations stop as soon as one of the following conditions holds true:
 * R. Estrin, D. Orban and M. A. Saunders, *LSLQ: An Iterative Method for Linear Least-Squares with an Error Minimization Property*, Cahier du GERAD G-2017-xx, GERAD, Montreal, 2017.
 """
 function lslq(A :: AbstractLinearOperator{T}, b :: AbstractVector{T};
-              M :: AbstractLinearOperator=opEye(),
-              N :: AbstractLinearOperator=opEye(),
+              M :: Preconditioner{T}=opEye(),
+              N :: Preconditioner{T}=opEye(),
               sqd :: Bool=false, λ :: T=zero(T), σ :: T=zero(T),
               atol :: T=√eps(T), btol :: T=√eps(T), etol :: T=√eps(T),
               window :: Int=5, utol :: T=√eps(T), itmax :: Int=0,

--- a/src/lsmr.jl
+++ b/src/lsmr.jl
@@ -59,8 +59,8 @@ In this case, `N` can still be specified and indicates the norm
 in which `x` should be measured.
 """
 function lsmr(A :: AbstractLinearOperator{T}, b :: AbstractVector{T};
-              M :: AbstractLinearOperator=opEye(),
-              N :: AbstractLinearOperator=opEye(),
+              M :: Preconditioner{T}=opEye(),
+              N :: Preconditioner{T}=opEye(),
               sqd :: Bool=false,
               λ :: T=zero(T), axtol :: T=√eps(T), btol :: T=√eps(T),
               atol :: T=zero(T), rtol :: T=zero(T),

--- a/src/lsqr.jl
+++ b/src/lsqr.jl
@@ -59,8 +59,8 @@ In this case, `N` can still be specified and indicates the norm
 in which `x` should be measured.
 """
 function lsqr(A :: AbstractLinearOperator{T}, b :: AbstractVector{T};
-              M :: AbstractLinearOperator=opEye(),
-              N :: AbstractLinearOperator=opEye(),
+              M :: Preconditioner{T}=opEye(),
+              N :: Preconditioner{T}=opEye(),
               sqd :: Bool=false,
               λ :: T=zero(T), axtol :: T=√eps(T), btol :: T=√eps(T),
               atol :: T=zero(T), rtol :: T=zero(T),

--- a/src/minres.jl
+++ b/src/minres.jl
@@ -44,7 +44,7 @@ A preconditioner M may be provided in the form of a linear operator and is
 assumed to be symmetric and positive definite.
 """
 function minres(A :: AbstractLinearOperator{T}, b :: AbstractVector{T};
-                M :: AbstractLinearOperator=opEye(), λ :: T=zero(T),
+                M :: Preconditioner{T}=opEye(), λ :: T=zero(T),
                 atol :: T=√eps(T)/100, rtol :: T=√eps(T)/100, etol :: T=√eps(T),
                 window :: Int=5, itmax :: Int=0, conlim :: T=1/√eps(T),
                 verbose :: Bool=false) where T <: AbstractFloat

--- a/src/symmlq.jl
+++ b/src/symmlq.jl
@@ -26,7 +26,7 @@ A preconditioner M may be provided in the form of a linear operator and is
 assumed to be symmetric and positive definite.
 """
 function symmlq(A :: AbstractLinearOperator{T}, b :: AbstractVector{T};
-                M :: AbstractLinearOperator=opEye(),
+                M :: Preconditioner{T}=opEye(),
                 λ :: T=zero(T), transfer_to_cg :: Bool=true,
                 λest :: T=zero(T), atol :: T=√eps(T), rtol :: T=√eps(T),
                 etol :: T=√eps(T), window :: Int=0, itmax :: Int=0,

--- a/src/variants.jl
+++ b/src/variants.jl
@@ -1,13 +1,23 @@
 using LinearAlgebra
 
-# Variants where A is a matrix without specific properties
-for fn in (:cgls, :cgne, :craig, :craigmr, :crls, :crmr, :lslq, :lsmr, :lsqr, :dqgmres, :diom, :cgs, :bilq, :qmr)
+# Wrap preconditioners in a linear operator with preallocation
+function wrap_preconditioners(kwargs)
+  if (haskey(kwargs, :M) && typeof(kwargs[:M]) <: AbstractMatrix) || (haskey(kwargs, :N) && typeof(kwargs[:N]) <: AbstractMatrix)
+    k = keys(kwargs)
+    v = Tuple(typeof(arg) <: AbstractMatrix ? PreallocatedLinearOperator(arg) : arg for arg in values(kwargs))
+    kwargs = Iterators.Pairs(NamedTuple{k, typeof(v)}(v), k)
+  end
+  return kwargs
+end
+
+# Variants where matrix-vector products with A and Aᵀ are required
+for fn in (:cgls, :cgne, :craig, :craigmr, :crls, :crmr, :lslq, :lsmr, :lsqr, :bilq, :qmr)
   @eval begin
     $fn(A :: AbstractMatrix{T}, b :: SparseVector{T}, args...; kwargs...) where T <: AbstractFloat =
-      $fn(PreallocatedLinearOperator(A), convert(Vector{T}, b), args...; kwargs...)
+      $fn(PreallocatedLinearOperator(A), convert(Vector{T}, b), args...; wrap_preconditioners(kwargs)...)
 
     $fn(A :: AbstractMatrix{T}, b :: AbstractVector{T}, args...; kwargs...) where T <: AbstractFloat =
-      $fn(PreallocatedLinearOperator(A), b, args...; kwargs...)
+      $fn(PreallocatedLinearOperator(A), b, args...; wrap_preconditioners(kwargs)...)
   end
 end
 
@@ -15,26 +25,26 @@ end
 for fn in (:usymlq, :usymqr, :trilqr, :bilqr)
   @eval begin
     $fn(A :: AbstractMatrix{T}, b :: SparseVector{T}, c :: SparseVector{T}, args...; kwargs...) where T <: AbstractFloat =
-      $fn(PreallocatedLinearOperator(A), convert(Vector{T}, b), convert(Vector{T}, c), args...; kwargs...)
+      $fn(PreallocatedLinearOperator(A), convert(Vector{T}, b), convert(Vector{T}, c), args...; wrap_preconditioners(kwargs)...)
 
     $fn(A :: AbstractMatrix{T}, b :: AbstractVector{T}, c :: SparseVector{T}, args...; kwargs...) where T <: AbstractFloat =
-      $fn(PreallocatedLinearOperator(A), b, convert(Vector{T}, c), args...; kwargs...)
+      $fn(PreallocatedLinearOperator(A), b, convert(Vector{T}, c), args...; wrap_preconditioners(kwargs)...)
 
     $fn(A :: AbstractMatrix{T}, b :: SparseVector{T}, c :: AbstractVector{T}, args...; kwargs...) where T <: AbstractFloat =
-      $fn(PreallocatedLinearOperator(A), convert(Vector{T}, b), c, args...; kwargs...)
+      $fn(PreallocatedLinearOperator(A), convert(Vector{T}, b), c, args...; wrap_preconditioners(kwargs)...)
 
     $fn(A :: AbstractMatrix{T}, b :: AbstractVector{T}, c :: AbstractVector{T}, args...; kwargs...) where T <: AbstractFloat =
-      $fn(PreallocatedLinearOperator(A), b, c, args...; kwargs...)
+      $fn(PreallocatedLinearOperator(A), b, c, args...; wrap_preconditioners(kwargs)...)
   end
 end
 
-# Variants where A must be symmetric
-for fn in (:cg_lanczos, :cg_lanczos_shift_seq, :cg, :cr, :minres, :minres_qlp, :symmlq)
+# Variants where matrix-vector products with A are only required
+for fn in (:cg_lanczos, :cg_lanczos_shift_seq, :cg, :cr, :minres, :minres_qlp, :symmlq, :cgs, :diom, :dqgmres)
   @eval begin
     $fn(A :: AbstractMatrix{T}, b :: SparseVector{T}, args...; kwargs...) where T <: AbstractFloat =
-      $fn(PreallocatedLinearOperator(A, symmetric=true), convert(Vector{T}, b), args...; kwargs...)
+      $fn(PreallocatedLinearOperator(A, symmetric=true), convert(Vector{T}, b), args...; wrap_preconditioners(kwargs)...)
 
     $fn(A :: AbstractMatrix{T}, b :: AbstractVector{T}, args...; kwargs...) where T <: AbstractFloat =
-      $fn(PreallocatedLinearOperator(A, symmetric=true), b, args...; kwargs...)
+      $fn(PreallocatedLinearOperator(A, symmetric=true), b, args...; wrap_preconditioners(kwargs)...)
   end
 end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -194,7 +194,7 @@ end
 function square_preconditioned(n :: Int=10)
   A = ones(n, n) + (n-1) * I
   b = 10.0 * [1:n;]
-  M = PreallocatedLinearOperator(1/n * eye(n))
+  M = 1/n * eye(n)
   return A, b, M
 end
 
@@ -203,8 +203,8 @@ function two_preconditioners(n :: Int=10, m :: Int=20)
   A = ones(n, n) + (n-1) * I
   b = ones(n)
   O = zeros(n, n)
-  M = PreallocatedLinearOperator(1/√n * eye(n))
-  N = PreallocatedLinearOperator(1/√m * eye(n))
+  M = 1/√n * eye(n)
+  N = 1/√m * eye(n)
   return A, b, M, N
 end
 


### PR DESCRIPTION
@abelsiqueira 
- Preconditioners are wrapped automatically in a LinearOperator
- `cgs`, `diom` and `dqgmres` don't allocate anymore a vector for products with transpose(A)
