### PR TITLE
GPU Support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Krylov"
 uuid = "ba0b0d4f-ebba-5204-a429-3ac8c609bfb7"
-version = "0.4.1"
+version = "0.5.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -9,7 +9,7 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
-LinearOperators = "0.7.1, 1"
+LinearOperators = "~1.1"
 julia = "^1.3.0"
 
 [extras]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -4,4 +4,4 @@ Krylov = "ba0b0d4f-ebba-5204-a429-3ac8c609bfb7"
 LinearOperators = "5c8ed15e-5a4c-59e4-a42b-c7e8811fb125"
 
 [compat]
-LinearOperators = "0.7.1, 1"
+LinearOperators = "~1.1"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -15,4 +15,6 @@ Krylov.roots_quadratic
 Krylov.sym_givens
 Krylov.to_boundary
 Krylov.vec2str
+Krylov.kzeros
+Krylov.kones
 ```

--- a/src/bilq.jl
+++ b/src/bilq.jl
@@ -38,8 +38,11 @@ function bilq(A, b :: AbstractVector{T}; c :: AbstractVector{T}=b,
   # Compute the adjoint of A
   Aᵀ = A'
 
+  # Determine the storage type of b
+  S = typeof(b)
+
   # Initial solution x₀ and residual norm ‖r₀‖.
-  x = zeros(T, n)
+  x = kzeros(S, n)
   bNorm = @knrm2(n, b)  # ‖r₀‖
   bNorm == 0 && return (x, SimpleStats(true, false, [bNorm], T[], "x = 0 is a zero-residual solution"))
 
@@ -58,13 +61,13 @@ function bilq(A, b :: AbstractVector{T}; c :: AbstractVector{T}=b,
   # Set up workspace.
   βₖ = √(abs(bᵗc))           # β₁γ₁ = bᵀc
   γₖ = bᵗc / βₖ              # β₁γ₁ = bᵀc
-  vₖ₋₁ = zeros(T, n)         # v₀ = 0
-  uₖ₋₁ = zeros(T, n)         # u₀ = 0
+  vₖ₋₁ = kzeros(S, n)        # v₀ = 0
+  uₖ₋₁ = kzeros(S, n)        # u₀ = 0
   vₖ = b / βₖ                # v₁ = b / β₁
   uₖ = c / γₖ                # u₁ = c / γ₁
   cₖ₋₁ = cₖ = -one(T)        # Givens cosines used for the LQ factorization of Tₖ
   sₖ₋₁ = sₖ = zero(T)        # Givens sines used for the LQ factorization of Tₖ
-  d̅ = zeros(T, n)            # Last column of D̅ₖ = Vₖ(Qₖ)ᵀ
+  d̅ = kzeros(S, n)           # Last column of D̅ₖ = Vₖ(Qₖ)ᵀ
   ζₖ₋₁ = ζbarₖ = zero(T)     # ζₖ₋₁ and ζbarₖ are the last components of z̅ₖ = (L̅ₖ)⁻¹β₁e₁
   ζₖ₋₂ = ηₖ = zero(T)        # ζₖ₋₂ and ηₖ are used to update ζₖ₋₁ and ζbarₖ
   δbarₖ₋₁ = δbarₖ = zero(T)  # Coefficients of Lₖ₋₁ and L̅ₖ modified over the course of two iterations

--- a/src/bilqr.jl
+++ b/src/bilqr.jl
@@ -42,12 +42,15 @@ function bilqr(A, b :: AbstractVector{T}, c :: AbstractVector{T};
   # Compute the adjoint of A
   Aᵀ = A'
 
+  # Determine the storage type of b
+  S = typeof(b)
+
   # Initial solution x₀ and residual norm ‖r₀‖ = ‖b - Ax₀‖.
-  x = zeros(T, n)       # x₀
+  x = kzeros(S, n)      # x₀
   bNorm = @knrm2(n, b)  # rNorm = ‖r₀‖
 
   # Initial solution t₀ and residual norm ‖s₀‖ = ‖c - Aᵀt₀‖.
-  t = zeros(T, n)       # t₀
+  t = kzeros(S, n)      # t₀
   cNorm = @knrm2(n, c)  # sNorm = ‖s₀‖
 
   iter = 0
@@ -67,21 +70,21 @@ function bilqr(A, b :: AbstractVector{T}, c :: AbstractVector{T};
   # Set up workspace.
   βₖ = √(abs(bᵗc))           # β₁γ₁ = bᵀc
   γₖ = bᵗc / βₖ              # β₁γ₁ = bᵀc
-  vₖ₋₁ = zeros(T, n)         # v₀ = 0
-  uₖ₋₁ = zeros(T, n)         # u₀ = 0
+  vₖ₋₁ = kzeros(S, n)        # v₀ = 0
+  uₖ₋₁ = kzeros(S, n)        # u₀ = 0
   vₖ = b / βₖ                # v₁ = b / β₁
   uₖ = c / γₖ                # u₁ = c / γ₁
   cₖ₋₁ = cₖ = -one(T)        # Givens cosines used for the LQ factorization of Tₖ
   sₖ₋₁ = sₖ = zero(T)        # Givens sines used for the LQ factorization of Tₖ
-  d̅ = zeros(T, n)            # Last column of D̅ₖ = Vₖ(Qₖ)ᵀ
+  d̅ = kzeros(S, n)           # Last column of D̅ₖ = Vₖ(Qₖ)ᵀ
   ζₖ₋₁ = ζbarₖ = zero(T)     # ζₖ₋₁ and ζbarₖ are the last components of z̅ₖ = (L̅ₖ)⁻¹β₁e₁
   ζₖ₋₂ = ηₖ = zero(T)        # ζₖ₋₂ and ηₖ are used to update ζₖ₋₁ and ζbarₖ
   δbarₖ₋₁ = δbarₖ = zero(T)  # Coefficients of Lₖ₋₁ and L̅ₖ modified over the course of two iterations
   ψbarₖ₋₁ = ψₖ₋₁ = zero(T)   # ψₖ₋₁ and ψbarₖ are the last components of h̅ₖ = Qₖγ₁e₁
   norm_vₖ = bNorm / βₖ       # ‖vₖ‖ is used for residual norm estimates
   ϵₖ₋₃ = λₖ₋₂ = zero(T)      # Components of Lₖ₋₁
-  wₖ₋₃ = zeros(T, n)         # Column k-3 of Wₖ = Uₖ(Lₖ)⁻ᵀ
-  wₖ₋₂ = zeros(T, n)         # Column k-2 of Wₖ = Uₖ(Lₖ)⁻ᵀ
+  wₖ₋₃ = kzeros(S, n)        # Column k-3 of Wₖ = Uₖ(Lₖ)⁻ᵀ
+  wₖ₋₂ = kzeros(S, n)        # Column k-2 of Wₖ = Uₖ(Lₖ)⁻ᵀ
   τₖ = zero(T)               # τₖ is used for the dual residual norm estimate
 
   # Stopping criterion.

--- a/src/cg.jl
+++ b/src/cg.jl
@@ -33,8 +33,11 @@ function cg(A, b :: AbstractVector{T};
   eltype(A) == T || error("eltype(A) ≠ $T")
   isa(M, opEye) || (eltype(M) == T) || error("eltype(M) ≠ $T")
 
+  # Determine the storage type of b
+  S = typeof(b)
+
   # Initial state.
-  x = zeros(T, n)
+  x = kzeros(S, n)
   r = copy(b)
   z = M * r
   p = copy(z)

--- a/src/cgls.jl
+++ b/src/cgls.jl
@@ -53,7 +53,10 @@ function cgls(A, b :: AbstractVector{T};
   # Compute Aᵀ
   Aᵀ = A'
 
-  x = zeros(T, n)
+  # Determine the storage type of b
+  S = typeof(b)
+
+  x = kzeros(S, n)
   r = copy(b)
   bNorm = @knrm2(m, r)   # Marginally faster than norm(b)
   bNorm == 0 && return x, SimpleStats(true, false, [zero(T)], [zero(T)], "x = 0 is a zero-residual solution")

--- a/src/cgne.jl
+++ b/src/cgne.jl
@@ -69,7 +69,10 @@ function cgne(A, b :: AbstractVector{T};
   # Compute the adjoint of A
   Aᵀ = A'
 
-  x = zeros(T, n)
+  # Determine the storage type of b
+  S = typeof(b)
+
+  x = kzeros(S, n)
   r = copy(b)
   z = M * r
   rNorm = @knrm2(m, r)   # Marginally faster than norm(r)

--- a/src/cgs.jl
+++ b/src/cgs.jl
@@ -46,9 +46,12 @@ function cgs(A, b :: AbstractVector{T};
   eltype(A) == T || error("eltype(A) ≠ $T")
   isa(M, opEye) || (eltype(M) == T) || error("eltype(M) ≠ $T")
 
+  # Determine the storage type of b
+  S = typeof(b)
+
   # Initial solution x₀ and residual r₀.
-  x = zeros(T, n) # x₀
-  r = copy(b)     # r₀
+  x = kzeros(S, n)  # x₀
+  r = copy(b)       # r₀
   # Compute ρ₀ = ⟨ r₀,r₀ ⟩ and residual norm ‖r₀‖₂.
   ρ = @kdot(n, r, r)
   rNorm = sqrt(ρ)
@@ -62,9 +65,9 @@ function cgs(A, b :: AbstractVector{T};
   verbose && @printf("%5d  %7.1e\n", iter, rNorm)
 
   # Set up workspace.
-  u = copy(r)     # u₀
-  p = copy(r)     # p₀
-  q = zeros(T, n) # q₋₁
+  u = copy(r)       # u₀
+  p = copy(r)       # p₀
+  q = kzeros(S, n)  # q₋₁
 
   # Stopping criterion.
   solved = rNorm ≤ ε

--- a/src/cr.jl
+++ b/src/cr.jl
@@ -32,10 +32,13 @@ function cr(A, b :: AbstractVector{T};
   eltype(A) == T || error("eltype(A) ≠ $T")
   isa(M, opEye) || (eltype(M) == T) || error("eltype(M) ≠ $T")
 
+  # Determine the storage type of b
+  S = typeof(b)
+
   # Initial state.
-  x = zeros(T, n) # initial estimation x = 0
+  x = kzeros(S, n)  # initial estimation x = 0
   xNorm = zero(T)
-  r = copy(M * b) # initial residual r = M * (b - Ax) = M * b
+  r = copy(M * b)  # initial residual r = M * (b - Ax) = M * b
   Ar = A * r
   ρ = @kdot(n, r, Ar)
   ρ == 0 && return (x, SimpleStats(true, false, [zero(T)], T[], "x = 0 is a zero-residual solution"))

--- a/src/craig.jl
+++ b/src/craig.jl
@@ -80,8 +80,11 @@ function craig(A, b :: AbstractVector{T};
   # Compute the adjoint of A
   Aᵀ = A'
 
-  x = zeros(T, n)
-  y = zeros(T, m)
+  # Determine the storage type of b
+  S = typeof(b)
+
+  x = kzeros(S, n)
+  y = kzeros(S, m)
   Mu = copy(b)
   u = M * Mu
   β₁ = sqrt(@kdot(m, u, Mu))
@@ -98,10 +101,10 @@ function craig(A, b :: AbstractVector{T};
   @kscal!(m, one(T)/β₁, u)
   MisI || @kscal!(m, one(T)/β₁, Mu)
 
-  Nv = zeros(T, n)
-  w = zeros(T, m)  # Used to update y.
+  Nv = kzeros(S, n)
+  w = kzeros(S, m)  # Used to update y.
 
-  λ > 0 && (w2 = zeros(T, n))
+  λ > 0 && (w2 = kzeros(S, n))
 
   Anorm² = zero(T) # Estimate of ‖A‖²_F.
   Anorm  = zero(T)

--- a/src/craigmr.jl
+++ b/src/craigmr.jl
@@ -81,9 +81,12 @@ function craigmr(A, b :: AbstractVector{T};
   # Compute the adjoint of A
   Aᵀ = A'
 
+  # Determine the storage type of b
+  S = typeof(b)
+
   # Compute y such that AAᵀy = b. Then recover x = Aᵀy.
-  x = zeros(T, n)
-  y = zeros(T, m)
+  x = kzeros(S, n)
+  y = kzeros(S, m)
   Mu = copy(b)
   u = M * Mu
   β = sqrt(@kdot(m, u, Mu))
@@ -127,7 +130,7 @@ function craigmr(A, b :: AbstractVector{T};
 
   wbar = copy(u)
   @kscal!(m, one(T)/α, wbar)
-  w = zeros(T, m)
+  w = kzeros(S, m)
 
   status = "unknown"
   solved = rNorm ≤ ɛ_c

--- a/src/crls.jl
+++ b/src/crls.jl
@@ -52,7 +52,10 @@ function crls(A, b :: AbstractVector{T};
   # Compute the adjoint of A
   Aᵀ = A'
 
-  x = zeros(T, n)
+  # Determine the storage type of b
+  S = typeof(b)
+
+  x = kzeros(S, n)
   r  = copy(b)
   bNorm = @knrm2(m, r)  # norm(b - A * x0) if x0 ≠ 0.
   bNorm == 0 && return x, SimpleStats(true, false, [zero(T)], [zero(T)], "x = 0 is a zero-residual solution")

--- a/src/crmr.jl
+++ b/src/crmr.jl
@@ -68,8 +68,11 @@ function crmr(A, b :: AbstractVector{T};
   # Compute the adjoint of A
   Aᵀ = A'
 
-  x = zeros(T, n) # initial estimation x = 0
-  r = copy(M * b) # initial residual r = M * (b - Ax) = M * b
+  # Determine the storage type of b
+  S = typeof(b)
+
+  x = kzeros(S, n)  # initial estimation x = 0
+  r = copy(M * b)   # initial residual r = M * (b - Ax) = M * b
   bNorm = @knrm2(m, r)  # norm(b - A * x0) if x0 ≠ 0.
   bNorm == 0 && return x, SimpleStats(true, false, [zero(T)], [zero(T)], "x = 0 is a zero-residual solution")
   rNorm = bNorm  # + λ * ‖x0‖ if x0 ≠ 0 and λ > 0.

--- a/src/diom.jl
+++ b/src/diom.jl
@@ -40,8 +40,11 @@ function diom(A, b :: AbstractVector{T};
   isa(M, opEye) || (eltype(M) == T) || error("eltype(M) ≠ $T")
   isa(N, opEye) || (eltype(N) == T) || error("eltype(N) ≠ $T")
 
+  # Determine the storage type of b
+  S = typeof(b)
+
   # Initial solution x₀ and residual r₀.
-  x = zeros(T, n) # x₀
+  x = kzeros(S, n)  # x₀
   x_old = copy(x)
   r₀ = M * b      # M⁻¹(b - Ax₀)
   # Compute β.
@@ -57,9 +60,9 @@ function diom(A, b :: AbstractVector{T};
 
   # Set up workspace.
   mem = min(memory, itmax) # Memory.
-  V = [zeros(T, n) for i = 1 : mem] # Preconditioned Krylov vectors, orthogonal basis for {b, M⁻¹AN⁻¹b, (M⁻¹AN⁻¹)²b, ..., (M⁻¹AN⁻¹)ᵐ⁻¹b}.
-  P = [zeros(T, n) for i = 1 : mem] # Directions for x : Pₘ = Vₘ(Uₘ)⁻¹.
-  H = zeros(T, mem+2)               # Last column of the band hessenberg matrix Hₘ = LₘUₘ.
+  V = [kzeros(S, n) for i = 1 : mem]  # Preconditioned Krylov vectors, orthogonal basis for {b, M⁻¹AN⁻¹b, (M⁻¹AN⁻¹)²b, ..., (M⁻¹AN⁻¹)ᵐ⁻¹b}.
+  P = [kzeros(S, n) for i = 1 : mem]  # Directions for x : Pₘ = Vₘ(Uₘ)⁻¹.
+  H = zeros(T, mem+2)                 # Last column of the band hessenberg matrix Hₘ = LₘUₘ.
   # Each column has at most mem + 1 nonzero elements. hᵢ.ₘ is stored as H[m-i+2].
   # m-i+2 represents the indice of the diagonal where hᵢ.ₘ is located.
   # In addition of that, the last column of Uₘ is stored in H.

--- a/src/lslq.jl
+++ b/src/lslq.jl
@@ -114,12 +114,15 @@ function lslq(A, b :: AbstractVector{T};
   # Compute the adjoint of A
   Aᵀ = A'
 
+  # Determine the storage type of b
+  S = typeof(b)
+
   # If solving an SQD system, set regularization to 1.
   sqd && (λ = one(T))
   λ² = λ * λ
   ctol = conlim > 0 ? 1/conlim : zero(T)
 
-  x_lq = zeros(T, n)    # LSLQ point
+  x_lq = kzeros(S, n)   # LSLQ point
   err_lbnds = T[]
   err_ubnds_lq = T[]
   err_ubnds_cg = T[]
@@ -129,7 +132,7 @@ function lslq(A, b :: AbstractVector{T};
   Mu = copy(b)
   u = M * Mu
   β₁ = sqrt(@kdot(m, u, Mu))
-  β₁ == 0 && return (x_lq, zeros(T, n), err_lbnds, err_ubnds_lq, err_ubnds_cg,
+  β₁ == 0 && return (x_lq, kzeros(S, n), err_lbnds, err_ubnds_lq, err_ubnds_cg,
                        SimpleStats(true, false, [zero(T)], [zero(T)], "x = 0 is a zero-residual solution"))
   β = β₁
 
@@ -141,7 +144,7 @@ function lslq(A, b :: AbstractVector{T};
   α = sqrt(@kdot(n, v, Nv))  # = α₁
 
   # Aᵀb = 0 so x = 0 is a minimum least-squares solution
-  α == 0 && return (x_lq, zeros(T, n), err_lbnds, err_ubnds_lq, err_ubnds_cg,
+  α == 0 && return (x_lq, kzeros(S, n), err_lbnds, err_ubnds_lq, err_ubnds_cg,
                       SimpleStats(true, false, [β₁], [zero(T)], "x = 0 is a minimum least-squares solution"))
   @kscal!(n, one(T)/α, v)
   NisI || @kscal!(n, one(T)/α, Nv)

--- a/src/lsmr.jl
+++ b/src/lsmr.jl
@@ -70,6 +70,12 @@ function lsmr(A, b :: AbstractVector{T};
   size(b, 1) == m || error("Inconsistent problem size")
   verbose && @printf("LSMR: system of %d equations in %d variables\n", m, n)
 
+  # Compute the adjoint of A
+  Aᵀ = A'
+
+  # Determine the storage type of b
+  S = typeof(b)
+
   # Tests M == Iₙ and N == Iₘ
   MisI = isa(M, opEye)
   NisI = isa(N, opEye)
@@ -85,7 +91,7 @@ function lsmr(A, b :: AbstractVector{T};
   # If solving an SQD system, set regularization to 1.
   sqd && (λ = one(T))
   ctol = conlim > 0 ? 1/conlim : zero(T)
-  x = zeros(T, n)
+  x = kzeros(S, n)
 
   # Initialize Golub-Kahan process.
   # β₁ M u₁ = b.
@@ -145,7 +151,7 @@ function lsmr(A, b :: AbstractVector{T};
   NisI || @kscal!(n, one(T)/α, Nv)
 
   h = copy(v)
-  hbar = zeros(T, n)
+  hbar = kzeros(S, n)
 
   iter = 0
   itmax == 0 && (itmax = m + n)

--- a/src/lsqr.jl
+++ b/src/lsqr.jl
@@ -82,11 +82,14 @@ function lsqr(A, b :: AbstractVector{T};
   # Compute the adjoint of A
   Aᵀ = A'
 
+  # Determine the storage type of b
+  S = typeof(b)
+
   # If solving an SQD system, set regularization to 1.
   sqd && (λ = one(T))
   λ² = λ * λ
   ctol = conlim > 0 ? 1/conlim : zero(T)
-  x = zeros(T, n)
+  x = kzeros(S, n)
 
   # Initialize Golub-Kahan process.
   # β₁ M u₁ = b.

--- a/src/minres.jl
+++ b/src/minres.jl
@@ -58,8 +58,11 @@ function minres(A, b :: AbstractVector{T};
   eltype(A) == T || error("eltype(A) ≠ $T")
   isa(M, opEye) || (eltype(M) == T) || error("eltype(M) ≠ $T")
 
+  # Determine the storage type of b
+  S = typeof(b)
+
   ϵM = eps(T)
-  x = zeros(T, n)
+  x = kzeros(S, n)
   ctol = conlim > 0 ? 1 / conlim : zero(T)
 
   # Initialize Lanczos process.
@@ -84,8 +87,8 @@ function minres(A, b :: AbstractVector{T};
   γmin = T(Inf)
   cs = -one(T)
   sn = zero(T)
-  w1 = zeros(T, n)
-  w2 = zeros(T, n)
+  w1 = kzeros(S, n)
+  w2 = kzeros(S, n)
   r2 = copy(r1)
 
   ANorm² = zero(T)

--- a/src/minres_qlp.jl
+++ b/src/minres_qlp.jl
@@ -35,8 +35,11 @@ function minres_qlp(A, b :: AbstractVector{T};
   # Check type consistency
   eltype(A) == T || error("eltype(A) ≠ $T")
 
+  # Determine the storage type of b
+  S = typeof(b)
+
   # Initial state.
-  x = zeros(T, n)
+  x = kzeros(S, n)
   rNorm = @knrm2(n, b)
   rNorm == 0 && return x, SimpleStats(true, false, [rNorm], T[], "x = 0 is a zero-residual solution")
 
@@ -51,7 +54,7 @@ function minres_qlp(A, b :: AbstractVector{T};
   verbose && @printf("%5d  %7.1e  %7s\n", iter, rNorm, "✗ ✗ ✗ ✗")
 
   # Set up workspace.
-  vₖ₋₁  = zeros(T, n)
+  vₖ₋₁  = kzeros(S, n)
   βₖ    = rNorm
   vₖ    = b / βₖ
   ζbarₖ = βₖ
@@ -59,8 +62,8 @@ function minres_qlp(A, b :: AbstractVector{T};
   τₖ₋₂ = τₖ₋₁ = τₖ = zero(T)
   ψbarₖ₋₂ = zero(T)
   μbisₖ₋₂ = μbarₖ₋₁ = zero(T)
-  wₖ₋₁  = zeros(T, n)
-  wₖ    = zeros(T, n)
+  wₖ₋₁  = kzeros(S, n)
+  wₖ    = kzeros(S, n)
   cₖ₋₂  = cₖ₋₁ = cₖ = zero(T)  # Givens cosines used for the QR factorization of Tₖ₊₁.ₖ
   sₖ₋₂  = sₖ₋₁ = sₖ = zero(T)  # Givens sines used for the QR factorization of Tₖ₊₁.ₖ
 

--- a/src/qmr.jl
+++ b/src/qmr.jl
@@ -43,8 +43,11 @@ function qmr(A, b :: AbstractVector{T}; c :: AbstractVector{T}=b,
   # Compute the adjoint of A
   Aᵀ = A'
 
+  # Determine the storage type of b
+  S = typeof(b)
+
   # Initial solution x₀ and residual norm ‖r₀‖.
-  x = zeros(T, n)
+  x = kzeros(S, n)
   rNorm = @knrm2(n, b)  # rNorm = ‖r₀‖
   rNorm == 0 && return (x, SimpleStats(true, false, [rNorm], T[], "x = 0 is a zero-residual solution"))
 
@@ -63,14 +66,14 @@ function qmr(A, b :: AbstractVector{T}; c :: AbstractVector{T}=b,
   # Set up uorkspace.
   βₖ = √(abs(bᵗc))            # β₁γ₁ = bᵀc
   γₖ = bᵗc / βₖ               # β₁γ₁ = bᵀc
-  vₖ₋₁ = zeros(T, n)          # v₀ = 0
-  uₖ₋₁ = zeros(T, n)          # u₀ = 0
+  vₖ₋₁ = kzeros(S, n)         # v₀ = 0
+  uₖ₋₁ = kzeros(S, n)         # u₀ = 0
   vₖ = b / βₖ                 # v₁ = b / β₁
   uₖ = c / γₖ                 # u₁ = c / γ₁
   cₖ₋₂ = cₖ₋₁ = cₖ = zero(T)  # Givens cosines used for the QR factorization of Tₖ₊₁.ₖ
   sₖ₋₂ = sₖ₋₁ = sₖ = zero(T)  # Givens sines used for the QR factorization of Tₖ₊₁.ₖ
-  wₖ₋₂ = zeros(T, n)          # Column k-2 of Wₖ = Vₖ(Rₖ)⁻¹
-  wₖ₋₁ = zeros(T, n)          # Column k-1 of Wₖ = Vₖ(Rₖ)⁻¹
+  wₖ₋₂ = kzeros(S, n)         # Column k-2 of Wₖ = Vₖ(Rₖ)⁻¹
+  wₖ₋₁ = kzeros(S, n)         # Column k-1 of Wₖ = Vₖ(Rₖ)⁻¹
   ζbarₖ = βₖ                  # ζbarₖ is the last component of z̅ₖ = (Qₖ)ᵀβ₁e₁
   τₖ = @kdot(n, vₖ, vₖ)       # τₖ is used for the residual norm estimate
 

--- a/src/symmlq.jl
+++ b/src/symmlq.jl
@@ -36,6 +36,9 @@ function symmlq(A, b :: AbstractVector{T};
   size(b, 1) == m || error("Inconsistent problem size")
   verbose && @printf("SYMMLQ: system of size %d\n", n)
 
+  # Determine the storage type of b
+  S = typeof(b)
+
   # Test M == Iₘ
   MisI = isa(M, opEye)
 
@@ -44,7 +47,7 @@ function symmlq(A, b :: AbstractVector{T};
   MisI || (eltype(M) == T) || error("eltype(M) ≠ $T")
 
   ϵM = eps(T)
-  x = zeros(T, n)
+  x = kzeros(S, n)
   ctol = conlim > 0 ? 1 / conlim : zero(T)
 
   # Initialize Lanczos process.

--- a/src/trilqr.jl
+++ b/src/trilqr.jl
@@ -42,12 +42,15 @@ function trilqr(A, b :: AbstractVector{T}, c :: AbstractVector{T};
   # Compute the adjoint of A
   Aᵀ = A'
 
+  # Determine the storage type of b
+  S = typeof(b)
+
   # Initial solution x₀ and residual r₀ = b - Ax₀.
-  x = zeros(T, n)       # x₀
+  x = kzeros(S, n)      # x₀
   bNorm = @knrm2(m, b)  # rNorm = ‖r₀‖
 
   # Initial solution y₀ and residual s₀ = c - Aᵀy₀.
-  t = zeros(T, m)       # t₀
+  t = kzeros(S, m)      # t₀
   cNorm = @knrm2(n, c)  # sNorm = ‖s₀‖
 
   iter = 0
@@ -64,20 +67,20 @@ function trilqr(A, b :: AbstractVector{T}, c :: AbstractVector{T};
   # Set up workspace.
   βₖ = @knrm2(m, b)          # β₁ = ‖v₁‖
   γₖ = @knrm2(n, c)          # γ₁ = ‖u₁‖
-  vₖ₋₁ = zeros(T, m)         # v₀ = 0
-  uₖ₋₁ = zeros(T, n)         # u₀ = 0
+  vₖ₋₁ = kzeros(S, m)        # v₀ = 0
+  uₖ₋₁ = kzeros(S, n)        # u₀ = 0
   vₖ = b / βₖ                # v₁ = b / β₁
   uₖ = c / γₖ                # u₁ = c / γ₁
   cₖ₋₁ = cₖ = -one(T)        # Givens cosines used for the LQ factorization of Tₖ
   sₖ₋₁ = sₖ = zero(T)        # Givens sines used for the LQ factorization of Tₖ
-  d̅ = zeros(T, n)            # Last column of D̅ₖ = Uₖ(Qₖ)ᵀ
+  d̅ = kzeros(S, n)           # Last column of D̅ₖ = Uₖ(Qₖ)ᵀ
   ζₖ₋₁ = ζbarₖ = zero(T)     # ζₖ₋₁ and ζbarₖ are the last components of z̅ₖ = (L̅ₖ)⁻¹β₁e₁
   ζₖ₋₂ = ηₖ = zero(T)        # ζₖ₋₂ and ηₖ are used to update ζₖ₋₁ and ζbarₖ
   δbarₖ₋₁ = δbarₖ = zero(T)  # Coefficients of Lₖ₋₁ and L̅ₖ modified over the course of two iterations
   ψbarₖ₋₁ = ψₖ₋₁ = zero(T)   # ψₖ₋₁ and ψbarₖ are the last components of h̅ₖ = Qₖγ₁e₁
   ϵₖ₋₃ = λₖ₋₂ = zero(T)      # Components of Lₖ₋₁
-  wₖ₋₃ = zeros(T, m)         # Column k-3 of Wₖ = Vₖ(Lₖ)⁻ᵀ
-  wₖ₋₂ = zeros(T, m)         # Column k-2 of Wₖ = Vₖ(Lₖ)⁻ᵀ
+  wₖ₋₃ = kzeros(S, m)        # Column k-3 of Wₖ = Vₖ(Lₖ)⁻ᵀ
+  wₖ₋₂ = kzeros(S, m)        # Column k-2 of Wₖ = Vₖ(Lₖ)⁻ᵀ
 
   # Stopping criterion.
   inconsistent = false

--- a/src/usymlq.jl
+++ b/src/usymlq.jl
@@ -49,8 +49,11 @@ function usymlq(A, b :: AbstractVector{T}, c :: AbstractVector{T};
   # Compute the adjoint of A
   Aᵀ = A'
 
+  # Determine the storage type of b
+  S = typeof(b)
+
   # Initial solution x₀ and residual norm ‖r₀‖.
-  x = zeros(T, n)
+  x = kzeros(S, n)
   bNorm = @knrm2(m, b)  # ‖r₀‖
   bNorm == 0 && return (x, SimpleStats(true, false, [bNorm], T[], "x = 0 is a zero-residual solution"))
 
@@ -65,13 +68,13 @@ function usymlq(A, b :: AbstractVector{T}, c :: AbstractVector{T};
   # Set up workspace.
   βₖ = @knrm2(m, b)          # β₁ = ‖v₁‖
   γₖ = @knrm2(n, c)          # γ₁ = ‖u₁‖
-  vₖ₋₁ = zeros(T, m)         # v₀ = 0
-  uₖ₋₁ = zeros(T, n)         # u₀ = 0
+  vₖ₋₁ = kzeros(S, m)        # v₀ = 0
+  uₖ₋₁ = kzeros(S, n)        # u₀ = 0
   vₖ = b / βₖ                # v₁ = b / β₁
   uₖ = c / γₖ                # u₁ = c / γ₁
   cₖ₋₁ = cₖ = -one(T)        # Givens cosines used for the LQ factorization of Tₖ
   sₖ₋₁ = sₖ = zero(T)        # Givens sines used for the LQ factorization of Tₖ
-  d̅ = zeros(T, n)            # Last column of D̅ₖ = Uₖ(Qₖ)ᵀ
+  d̅ = kzeros(S, n)           # Last column of D̅ₖ = Uₖ(Qₖ)ᵀ
   ζₖ₋₁ = ζbarₖ = zero(T)     # ζₖ₋₁ and ζbarₖ are the last components of z̅ₖ = (L̅ₖ)⁻¹β₁e₁
   ζₖ₋₂ = ηₖ = zero(T)        # ζₖ₋₂ and ηₖ are used to update ζₖ₋₁ and ζbarₖ
   δbarₖ₋₁ = δbarₖ = zero(T)  # Coefficients of Lₖ₋₁ and Lₖ modified over the course of two iterations

--- a/src/usymqr.jl
+++ b/src/usymqr.jl
@@ -46,8 +46,11 @@ function usymqr(A, b :: AbstractVector{T}, c :: AbstractVector{T};
   # Compute the adjoint of A
   Aᵀ = A'
 
+  # Determine the storage type of b
+  S = typeof(b)
+
   # Initial solution x₀ and residual norm ‖r₀‖.
-  x = zeros(T, n)
+  x = kzeros(S, n)
   rNorm = @knrm2(m, b)
   rNorm == 0 && return x, SimpleStats(true, false, [rNorm], T[], "x = 0 is a zero-residual solution")
 
@@ -64,14 +67,14 @@ function usymqr(A, b :: AbstractVector{T}, c :: AbstractVector{T};
   # Set up workspace.
   βₖ = @knrm2(m, b)           # β₁ = ‖v₁‖
   γₖ = @knrm2(n, c)           # γ₁ = ‖u₁‖
-  vₖ₋₁ = zeros(T, m)          # v₀ = 0
-  uₖ₋₁ = zeros(T, n)          # u₀ = 0
+  vₖ₋₁ = kzeros(S, m)         # v₀ = 0
+  uₖ₋₁ = kzeros(S, n)         # u₀ = 0
   vₖ = b / βₖ                 # v₁ = b / β₁
   uₖ = c / γₖ                 # u₁ = c / γ₁
   cₖ₋₂ = cₖ₋₁ = cₖ = zero(T)  # Givens cosines used for the QR factorization of Tₖ₊₁.ₖ
   sₖ₋₂ = sₖ₋₁ = sₖ = zero(T)  # Givens sines used for the QR factorization of Tₖ₊₁.ₖ
-  wₖ₋₂ = zeros(T, n)          # Column k-2 of Wₖ = Uₖ(Rₖ)⁻¹
-  wₖ₋₁ = zeros(T, n)          # Column k-1 of Wₖ = Uₖ(Rₖ)⁻¹
+  wₖ₋₂ = kzeros(S, n)         # Column k-2 of Wₖ = Uₖ(Rₖ)⁻¹
+  wₖ₋₁ = kzeros(S, n)         # Column k-1 of Wₖ = Uₖ(Rₖ)⁻¹
   ζbarₖ = βₖ                  # ζbarₖ is the last component of z̅ₖ = (Qₖ)ᵀβ₁e₁
 
   # Stopping criterion.

--- a/src/variants.jl
+++ b/src/variants.jl
@@ -1,12 +1,12 @@
 using LinearAlgebra
 
 # Wrap preconditioners in a linear operator with preallocation
-function wrap_preconditioners(kwargs)
+function wrap_preconditioners(kwargs, S)
   if (haskey(kwargs, :M) && typeof(kwargs[:M]) <: AbstractMatrix) || (haskey(kwargs, :N) && typeof(kwargs[:N]) <: AbstractMatrix)
     k = keys(kwargs)
     # Matrix-vector products with Mᵀ and Nᵀ are not required, we can safely use one vector for products with M / Mᵀ and N / Nᵀ
     # One vector for products with M / Mᵀ and N / Nᵀ is used when the option symmetric is set to true with a PreallocatedLinearOperator
-    v = Tuple(typeof(arg) <: AbstractMatrix ? PreallocatedLinearOperator(arg, symmetric=true) : arg for arg in values(kwargs))
+    v = Tuple(typeof(arg) <: AbstractMatrix ? PreallocatedLinearOperator(arg, storagetype=S, symmetric=true) : arg for arg in values(kwargs))
     kwargs = Iterators.Pairs(NamedTuple{k, typeof(v)}(v), k)
   end
   return kwargs
@@ -16,10 +16,10 @@ end
 for fn in (:cgls, :cgne, :craig, :craigmr, :crls, :crmr, :lslq, :lsmr, :lsqr, :bilq, :qmr)
   @eval begin
     $fn(A :: AbstractMatrix{T}, b :: SparseVector{T}; kwargs...) where T <: AbstractFloat =
-      $fn(PreallocatedLinearOperator(A), convert(Vector{T}, b); wrap_preconditioners(kwargs)...)
+      $fn(PreallocatedLinearOperator(A), convert(Vector{T}, b); wrap_preconditioners(kwargs, Vector{T})...)
 
     $fn(A :: AbstractMatrix{T}, b :: AbstractVector{T}; kwargs...) where T <: AbstractFloat =
-      $fn(PreallocatedLinearOperator(A), b; wrap_preconditioners(kwargs)...)
+      $fn(PreallocatedLinearOperator(A, storagetype=typeof(b)), b; wrap_preconditioners(kwargs, typeof(b))...)
   end
 end
 
@@ -27,16 +27,16 @@ end
 for fn in (:usymlq, :usymqr, :trilqr, :bilqr)
   @eval begin
     $fn(A :: AbstractMatrix{T}, b :: SparseVector{T}, c :: SparseVector{T}; kwargs...) where T <: AbstractFloat =
-      $fn(PreallocatedLinearOperator(A), convert(Vector{T}, b), convert(Vector{T}, c); wrap_preconditioners(kwargs)...)
+      $fn(PreallocatedLinearOperator(A), convert(Vector{T}, b), convert(Vector{T}, c); wrap_preconditioners(kwargs, Vector{T})...)
 
     $fn(A :: AbstractMatrix{T}, b :: AbstractVector{T}, c :: SparseVector{T}; kwargs...) where T <: AbstractFloat =
-      $fn(PreallocatedLinearOperator(A), b, convert(Vector{T}, c); wrap_preconditioners(kwargs)...)
+      $fn(PreallocatedLinearOperator(A), b, convert(Vector{T}, c); wrap_preconditioners(kwargs, Vector{T})...)
 
     $fn(A :: AbstractMatrix{T}, b :: SparseVector{T}, c :: AbstractVector{T}; kwargs...) where T <: AbstractFloat =
-      $fn(PreallocatedLinearOperator(A), convert(Vector{T}, b), c; wrap_preconditioners(kwargs)...)
+      $fn(PreallocatedLinearOperator(A), convert(Vector{T}, b), c; wrap_preconditioners(kwargs, Vector{T})...)
 
     $fn(A :: AbstractMatrix{T}, b :: AbstractVector{T}, c :: AbstractVector{T}; kwargs...) where T <: AbstractFloat =
-      $fn(PreallocatedLinearOperator(A), b, c; wrap_preconditioners(kwargs)...)
+      $fn(PreallocatedLinearOperator(A, storagetype=typeof(b)), b, c; wrap_preconditioners(kwargs, typeof(b))...)
   end
 end
 
@@ -44,10 +44,10 @@ end
 for fn in (:cg_lanczos, :cg, :cr, :minres, :minres_qlp, :symmlq, :cgs, :diom, :dqgmres)
   @eval begin
     $fn(A :: AbstractMatrix{T}, b :: SparseVector{T}; kwargs...) where T <: AbstractFloat =
-      $fn(PreallocatedLinearOperator(A, symmetric=true), convert(Vector{T}, b); wrap_preconditioners(kwargs)...)
+      $fn(PreallocatedLinearOperator(A, symmetric=true), convert(Vector{T}, b); wrap_preconditioners(kwargs, Vector{T})...)
 
     $fn(A :: AbstractMatrix{T}, b :: AbstractVector{T}; kwargs...) where T <: AbstractFloat =
-      $fn(PreallocatedLinearOperator(A, symmetric=true), b; wrap_preconditioners(kwargs)...)
+      $fn(PreallocatedLinearOperator(A, storagetype=typeof(b), symmetric=true), b; wrap_preconditioners(kwargs, typeof(b))...)
   end
 end
 
@@ -55,9 +55,9 @@ end
 for fn in [:cg_lanczos_shift_seq]
   @eval begin
     $fn(A :: AbstractMatrix{T}, b :: SparseVector{T}, shifts :: AbstractVector{T}; kwargs...) where T <: AbstractFloat =
-      $fn(PreallocatedLinearOperator(A, symmetric=true), convert(Vector{T}, b), shifts; wrap_preconditioners(kwargs)...)
+      $fn(PreallocatedLinearOperator(A, symmetric=true), convert(Vector{T}, b), shifts; wrap_preconditioners(kwargs, Vector{T})...)
 
     $fn(A :: AbstractMatrix{T}, b :: AbstractVector{T}, shifts :: AbstractVector{T}; kwargs...) where T <: AbstractFloat =
-      $fn(PreallocatedLinearOperator(A, symmetric=true), b, shifts; wrap_preconditioners(kwargs)...)
+      $fn(PreallocatedLinearOperator(A, storagetype=typeof(b), symmetric=true), b, shifts; wrap_preconditioners(kwargs, typeof(b))...)
   end
 end

--- a/test/test_aux.jl
+++ b/test/test_aux.jl
@@ -77,6 +77,10 @@ function test_aux()
   @test minimum(Krylov.to_boundary(x, d, 5.0)) ≈ -1.8099751242241782
   @test maximum(Krylov.to_boundary(x, d, 5.0, flip=true)) ≈ 1.8099751242241782
   @test minimum(Krylov.to_boundary(x, d, 5.0, flip=true)) ≈ -2.209975124224178
+
+  # test kzeros and kones
+  Krylov.kzeros(Vector{Float64}, 10) == zeros(10)
+  Krylov.kones(Vector{Float64}, 10) == ones(10)
 end
 
 test_aux()

--- a/test/test_cgls.jl
+++ b/test/test_cgls.jl
@@ -21,7 +21,7 @@ function test_cgls()
   # Test with preconditioning.
   Random.seed!(0)
   A = rand(10, 6); b = rand(10)
-  M = InverseLBFGSOperator(10, 4)
+  M = InverseLBFGSOperator(10, mem=4)
   for _ = 1 : 6
     s = rand(10)
     y = rand(10)

--- a/test/test_crls.jl
+++ b/test/test_crls.jl
@@ -22,7 +22,7 @@ function test_crls()
   # Test with preconditioning.
   Random.seed!(0)
   A = rand(10, 6); b = rand(10)
-  M = InverseLBFGSOperator(10, 4)
+  M = InverseLBFGSOperator(10, mem=4)
   for _ = 1 : 6
     s = rand(10)
     y = rand(10)


### PR DESCRIPTION
@dpo, @abelsiqueira 
It's only a draft but you should understand why I update `LinearOperators.jl`.

I tested all methods on GPU this morning (Pascal P-100) and everything works like a charm :saxophone: 
I used `allowscalar(false)` option (disallow scalar operations on GPU arrays) which means that the code in Krylov.jl is already well optimized for GPU.

I just need to benchmarks some auxiliary functions, It seems that generic Julia `axpy!`, `scal!`, `axpby!` are faster than the BLAS ones. 