### PR TITLE
Take the absolute value of \gamma_next when taking its square root in cg

### DIFF
--- a/src/cg.jl
+++ b/src/cg.jl
@@ -50,7 +50,7 @@ function cg(A, b :: AbstractVector{T};
   itmax == 0 && (itmax = 2 * n)
 
   pAp = zero(T)
-  rNorm = sqrt(γ)
+  rNorm = sqrt(abs(γ))
   pNorm² = γ
   rNorms = [rNorm;]
   ε = atol + rtol * rNorm
@@ -99,7 +99,7 @@ function cg(A, b :: AbstractVector{T};
     @kaxpy!(n, -α, Ap, r)
     z = M * r
     γ_next = @kdot(n, r, z)
-    rNorm = sqrt(γ_next)
+    rNorm = sqrt(abs(γ_next))
     push!(rNorms, rNorm)
 
     solved = (rNorm ≤ ε) || on_boundary


### PR DESCRIPTION
I am using Krylov's cg in a package and in a small example for a unit test I am getting that `\gamma_next`, lines 101-102 of `src/cg.jl` is negative, about `-1e-35`. This value arrises due to machine error as `\gamma_next` in my example is essentially zero at this particular iteration of the cg. A sensible fix that would avoid this machine error causing problems would be to take the absolute value of `\gamma_next` before taking its square root. 