### PR TITLE
Add regularization in CRAIGMR

### DIFF
--- a/src/craig.jl
+++ b/src/craig.jl
@@ -53,21 +53,21 @@ multipliers of the least-norm problem
 
     minimize ‖x‖  s.t.  Ax = b.
 
-Preconditioners M⁻¹ and N⁻¹ may be provided in the form of linear operators and are
-assumed to be symmetric and positive definite.
 If `sqd = true`, CRAIG solves the symmetric and quasi-definite system
 
-    [ -N   Aᵀ ] [ x ]   [ 0 ]
-    [  A   M  ] [ y ] = [ b ],
+    [ -F   Aᵀ ] [ x ]   [ 0 ]
+    [  A   E  ] [ y ] = [ b ],
 
-which is equivalent to applying CG to `(AN⁻¹Aᵀ + M)y = b` with `Nx = Aᵀy`.
+where E and F are symmetric and positive definite.
+CRAIG is then equivalent to applying CG to `(AF⁻¹Aᵀ + E)y = b` with `Fx = Aᵀy`.
+Preconditioners M = E⁻¹ ≻ 0 and N = F⁻¹ ≻ 0 may be provided in the form of linear operators.
 
 If `sqd = false`, CRAIG solves the symmetric and indefinite system
 
-    [ -N   Aᵀ ] [ x ]   [ 0 ]
+    [ -F   Aᵀ ] [ x ]   [ 0 ]
     [  A   0  ] [ y ] = [ b ].
 
-In this case, M⁻¹ can still be specified and indicates the weighted norm in which residuals are measured.
+In this case, M can still be specified and indicates the weighted norm in which residuals are measured.
 
 In this implementation, both the x and y-parts of the solution are returned.
 

--- a/src/craig.jl
+++ b/src/craig.jl
@@ -6,7 +6,7 @@
 #
 # The method seeks to solve the minimum-norm problem
 #
-#  min ‖x‖  s.t.  Ax = b,
+#  min ‖x‖₂  s.t.  Ax = b,
 #
 # and is equivalent to applying the conjugate gradient method
 # to the linear system
@@ -41,7 +41,7 @@ export craig, craig!
 
 Find the least-norm solution of the consistent linear system
 
-    Ax + λs = b
+    Ax + λ²y = b
 
 using the Golub-Kahan implementation of Craig's method, where λ ≥ 0 is a
 regularization parameter. This method is equivalent to CGNE but is more
@@ -51,7 +51,7 @@ For a system in the form Ax = b, Craig's method is equivalent to applying
 CG to AAᵀy = b and recovering x = Aᵀy. Note that y are the Lagrange
 multipliers of the least-norm problem
 
-    minimize ‖x‖  s.t.  Ax = b.
+    minimize ‖x‖₂  s.t.  Ax = b.
 
 If `sqd = true`, CRAIG solves the symmetric and quasi-definite system
 
@@ -59,6 +59,11 @@ If `sqd = true`, CRAIG solves the symmetric and quasi-definite system
     [  A   E  ] [ y ] = [ b ],
 
 where E and F are symmetric and positive definite.
+The system above represents the optimality conditions of
+
+    min ‖x‖_F + ‖y‖_E  s.t.  Ax + Ey = b.
+
+For a symmetric and positive definite matrix `K`, the K-norm of a vector `x` is `‖x‖²_K = xᵀKx`.
 CRAIG is then equivalent to applying CG to `(AF⁻¹Aᵀ + E)y = b` with `Fx = Aᵀy`.
 Preconditioners M = E⁻¹ ≻ 0 and N = F⁻¹ ≻ 0 may be provided in the form of linear operators.
 
@@ -67,7 +72,11 @@ If `sqd = false`, CRAIG solves the symmetric and indefinite system
     [ -F   Aᵀ ] [ x ]   [ 0 ]
     [  A   0  ] [ y ] = [ b ].
 
-In this case, M can still be specified and indicates the weighted norm in which residuals are measured.
+The system above represents the optimality conditions of
+
+    minimize ‖x‖_F  s.t.  Ax = b.
+
+In this case, `M` can still be specified and indicates the weighted norm in which residuals are measured.
 
 In this implementation, both the x and y-parts of the solution are returned.
 

--- a/src/craig.jl
+++ b/src/craig.jl
@@ -6,7 +6,7 @@
 #
 # The method seeks to solve the minimum-norm problem
 #
-#  min ‖x‖₂  s.t.  Ax = b,
+#  min ‖x‖  s.t.  Ax = b,
 #
 # and is equivalent to applying the conjugate gradient method
 # to the linear system
@@ -51,7 +51,7 @@ For a system in the form Ax = b, Craig's method is equivalent to applying
 CG to AAᵀy = b and recovering x = Aᵀy. Note that y are the Lagrange
 multipliers of the least-norm problem
 
-    minimize ‖x‖₂  s.t.  Ax = b.
+    minimize ‖x‖  s.t.  Ax = b.
 
 If `sqd = true`, CRAIG solves the symmetric and quasi-definite system
 

--- a/src/craigmr.jl
+++ b/src/craigmr.jl
@@ -5,7 +5,7 @@
 #
 # The method seeks to solve the minimum-norm problem
 #
-#  min ‖x‖²  s.t. Ax = b,
+#  min ‖x‖  s.t.  Ax = b,
 #
 # and is equivalent to applying the conjugate residual method
 # to the linear system
@@ -29,18 +29,18 @@ export craigmr, craigmr!
 
 """
     (x, y, stats) = craigmr(A, b::AbstractVector{T};
-                            M=I, N=I, λ::T=zero(T), atol::T=√eps(T),
+                            M=I, N=I, sqd::Bool=false, λ::T=zero(T), atol::T=√eps(T),
                             rtol::T=√eps(T), itmax::Int=0, verbose::Int=0, history::Bool=false) where T <: AbstractFloat
 
 Solve the consistent linear system
 
-    Ax + √λs = b
+    Ax + λs = b
 
-using the CRAIG-MR method, where λ ≥ 0 is a regularization parameter.
+using the CRAIGMR method, where λ ≥ 0 is a regularization parameter.
 This method is equivalent to applying the Conjugate Residuals method
 to the normal equations of the second kind
 
-    (AAᵀ + λI) y = b
+    (AAᵀ + λ²I)y = b
 
 but is more stable. When λ = 0, this method solves the minimum-norm problem
 
@@ -48,16 +48,23 @@ but is more stable. When λ = 0, this method solves the minimum-norm problem
 
 When λ > 0, this method solves the problem
 
-    min ‖(x,s)‖₂  s.t. Ax + √λs = b.
+    min ‖(x,s)‖₂  s.t.  Ax + λs = b.
 
-Preconditioners M⁻¹ and N⁻¹ may be provided in the form of linear operators and are
-assumed to be symmetric and positive definite.
-Afterward CRAIGMR solves the symmetric and quasi-definite system
+If `sqd = true`, CRAIGMR solves the symmetric and quasi-definite system
 
-    [ -N   Aᵀ ] [ x ]   [ 0 ]
-    [  A   M  ] [ y ] = [ b ],
+    [ -F   Aᵀ ] [ x ]   [ 0 ]
+    [  A   E  ] [ y ] = [ b ],
 
-which is equivalent to applying MINRES to (M + AN⁻¹Aᵀ)y = b.
+where E and F are symmetric and positive definite.
+CRAIGMR is then equivalent to applying MINRES to `(AF⁻¹Aᵀ + E)y = b` with `Fx = Aᵀy`.
+Preconditioners M = E⁻¹ ≻ 0 and N = F⁻¹ ≻ 0 may be provided in the form of linear operators.
+
+If `sqd = false`, CRAIGMR solves the symmetric and indefinite system
+
+    [ -F   Aᵀ ] [ x ]   [ 0 ]
+    [  A   0  ] [ y ] = [ b ].
+
+In this case, M can still be specified and indicates the weighted norm in which residuals are measured.
 
 CRAIGMR produces monotonic residuals ‖r‖₂.
 It is formally equivalent to CRMR, though can be slightly more accurate,
@@ -83,7 +90,7 @@ where `args` and `kwargs` are arguments and keyword arguments of [`craigmr`](@re
 See [`CraigmrSolver`](@ref) for more details about the `solver`.
 """
 function craigmr!(solver :: CraigmrSolver{T,S}, A, b :: AbstractVector{T};
-                  M=I, N=I, λ :: T=zero(T), atol :: T=√eps(T),
+                  M=I, N=I, sqd :: Bool=false, λ :: T=zero(T), atol :: T=√eps(T),
                   rtol :: T=√eps(T), itmax :: Int=0, verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, S <: DenseVector{T}}
 
   m, n = size(A)
@@ -103,11 +110,15 @@ function craigmr!(solver :: CraigmrSolver{T,S}, A, b :: AbstractVector{T};
   # Compute the adjoint of A
   Aᵀ = A'
 
+  # When solving a SQD system, set regularization parameter λ = 1.
+  sqd && (λ = one(T))
+
   # Set up workspace.
   allocate_if(!MisI, solver, :u, S, m)
   allocate_if(!NisI, solver, :v, S, n)
+  allocate_if(λ > 0, solver, :q, S, n)
   x, Nv, Aᵀu, y, Mu = solver.x, solver.Nv, solver.Aᵀu, solver.y, solver.Mu
-  w, wbar, Av, stats = solver.w, solver.wbar, solver.Av, solver.stats
+  w, wbar, Av, q, stats = solver.w, solver.wbar, solver.Av, solver.q, solver.stats
   rNorms, ArNorms = stats.residuals, stats.Aresiduals
   reset!(stats)
   u = MisI ? Mu : solver.u
@@ -155,9 +166,22 @@ function craigmr!(solver :: CraigmrSolver{T,S}, A, b :: AbstractVector{T};
   @kscal!(n, one(T)/α, v)
   NisI || @kscal!(n, one(T)/α, Nv)
 
+  # Regularization.
+  λₖ  = λ             # λ₁ = λ
+  cpₖ = spₖ = one(T)  # Givens sines and cosines used to zero out λₖ
+  cdₖ = sdₖ = one(T)  # Givens sines and cosines used to define λₖ₊₁
+  λ > 0 && (q .= v)   # Additional vector needed to update x, by definition q₀ = 0
+
+  if λ > 0
+    (cpₖ, spₖ, αhat) = sym_givens(α, λₖ)
+    @kscal!(n, spₖ, q)  # q̄₁ = sp₁ * v₁
+  else
+    αhat = α
+  end
+
   # Initialize other constants.
   ζbar = β
-  ρbar = α
+  ρbar = αhat
   θ = zero(T)
   rNorm = ζbar
   history && push!(rNorms, rNorm)
@@ -168,8 +192,9 @@ function craigmr!(solver :: CraigmrSolver{T,S}, A, b :: AbstractVector{T};
   ɛ_i = atol + rtol * ArNorm  # Stopping tolerance for inconsistent systems.
 
   wbar .= u
-  @kscal!(m, one(T)/α, wbar)
+  @kscal!(m, one(T)/αhat, wbar)
   w .= zero(T)
+  d .= zero(T)
 
   status = "unknown"
   solved = rNorm ≤ ɛ_c
@@ -192,6 +217,13 @@ function craigmr!(solver :: CraigmrSolver{T,S}, A, b :: AbstractVector{T};
 
     Anorm² = Anorm² + β * β  # = ‖B_{k-1}‖²
 
+    if λ > 0
+      βhat = cpₖ * β
+      λₐᵤₓ = spₖ * β
+    else
+      βhat = β
+    end
+
     # Continue QR factorization
     #
     # Q [ Lₖ  β₁ e₁ ] = [ Rₖ   zₖ  ] :
@@ -205,14 +237,35 @@ function craigmr!(solver :: CraigmrSolver{T,S}, A, b :: AbstractVector{T};
     #
     # [ c  s ] [ ζbar ] = [ ζ     ]
     # [ s -c ] [  0   ]   [ ζbar⁺ ]
-    (c, s, ρ) = sym_givens(ρbar, β)
+    (c, s, ρ) = sym_givens(ρbar, βhat)
     ζ = c * ζbar
     ζbar = s * ζbar
     rNorm = abs(ζbar)
     history && push!(rNorms, rNorm)
 
     @kaxpby!(m, one(T)/ρ, wbar, -θ/ρ, w)  # w = (wbar - θ * w) / ρ
-    @kaxpy!(m, ζ, w, y)             # y = y + ζ * w
+    @kaxpy!(m, ζ, w, y)                   # y = y + ζ * w
+
+    if λ > 0
+      # DₖRₖ = V̅ₖ with v̅ₖ = cpₖvₖ + spₖqₖ₋₁
+      if iter == 1
+        @kaxpy!(n, one(T)/ρ, cpₖ * v, d)
+      else
+        @kaxpby!(n, one(T)/ρ, cpₖ * v, -θ/ρ, d)
+        @kaxpy!(n, one(T)/ρ, spₖ * q, d)
+        @kaxpby!(n, spₖ, v, -cpₖ, q)  # q̄ₖ ← spₖ * vₖ - cpₖ * qₖ₋₁
+      end
+    else
+      # DₖRₖ = Vₖ
+      if iter == 1
+        @kaxpy!(n, one(T)/ρ, v, d)
+      else
+        @kaxpby!(n, one(T)/ρ, v, -θ/ρ, d)
+      end
+    end
+
+    # xₖ = Dₖzₖ
+    @kaxpy!(n, ζ, d, x)
 
     # 2. αₖ₊₁Nvₖ₊₁ = Aᵀuₖ₊₁ - βₖ₊₁Nvₖ
     mul!(Aᵀu, Aᵀ, u)
@@ -225,25 +278,27 @@ function craigmr!(solver :: CraigmrSolver{T,S}, A, b :: AbstractVector{T};
 
     display(iter, verbose) && @printf("%5d  %7.1e  %7.1e  %7.1e  %7.1e  %8.1e  %8.1e  %7.1e\n", 1 + 2 * iter, rNorm, ArNorm, β, α, c, s, Anorm²)
 
+    if λ > 0
+      (cdₖ, sdₖ, λₖ₊₁) = sym_givens(λ, λₐᵤₓ)
+      @kscal!(n, sdₖ, q)  # qₖ ← sdₖ * q̄ₖ
+      (cpₖ, spₖ, αhat) = sym_givens(α, λₖ₊₁)
+    else
+      αhat = α
+    end
+
     if α ≠ 0
       @kscal!(n, one(T)/α, v)
       NisI || @kscal!(n, one(T)/α, Nv)
-      @kaxpby!(m, one(T)/α, u, -β/α, wbar)  # wbar = (u - beta * wbar) / alpha
+      @kaxpby!(m, one(T) / αhat, u, -βhat / αhat, wbar)  # wbar = (u - beta * wbar) / alpha
     end
-    θ = s * α
-    ρbar = -c * α
+    θ    =  s * αhat
+    ρbar = -c * αhat
 
     solved = rNorm ≤ ɛ_c
     inconsistent = (rNorm > 100 * ɛ_c) & (ArNorm ≤ ɛ_i)
     tired  = iter ≥ itmax
   end
   (verbose > 0) && @printf("\n")
-
-  Aᵀy = Aᵀu
-  mul!(Aᵀy, Aᵀ, y)
-  N⁻¹Aᵀy = NisI ? Aᵀy : solver.v
-  mul!(N⁻¹Aᵀy, N, Aᵀy)
-  @. x = N⁻¹Aᵀy
 
   status = tired ? "maximum number of iterations exceeded" : (solved ? "found approximate minimum-norm solution" : "found approximate minimum least-squares solution")
 

--- a/src/craigmr.jl
+++ b/src/craigmr.jl
@@ -5,7 +5,7 @@
 #
 # The method seeks to solve the minimum-norm problem
 #
-#  min ‖x‖₂  s.t.  x ∈ argmin ‖Ax - b‖₂,
+#  min ‖x‖  s.t.  x ∈ argmin ‖Ax - b‖,
 #
 # and is equivalent to applying the conjugate residual method
 # to the linear system
@@ -44,7 +44,7 @@ to the normal equations of the second kind
 
 but is more stable. When λ = 0, this method solves the minimum-norm problem
 
-    min ‖x‖₂  s.t.  x ∈ argmin ‖Ax - b‖₂.
+    min ‖x‖  s.t.  x ∈ argmin ‖Ax - b‖.
 
 When λ > 0, this method solves the problem
 
@@ -126,7 +126,7 @@ function craigmr!(solver :: CraigmrSolver{T,S}, A, b :: AbstractVector{T};
   allocate_if(!MisI, solver, :u, S, m)
   allocate_if(!NisI, solver, :v, S, n)
   allocate_if(λ > 0, solver, :q, S, n)
-  x, Nv, Aᵀu, y, Mu = solver.x, solver.Nv, solver.Aᵀu, solver.y, solver.Mu
+  x, Nv, Aᵀu, d, y, Mu = solver.x, solver.Nv, solver.Aᵀu, solver.d, solver.y, solver.Mu
   w, wbar, Av, q, stats = solver.w, solver.wbar, solver.Av, solver.q, solver.stats
   rNorms, ArNorms = stats.residuals, stats.Aresiduals
   reset!(stats)

--- a/src/craigmr.jl
+++ b/src/craigmr.jl
@@ -5,7 +5,7 @@
 #
 # The method seeks to solve the minimum-norm problem
 #
-#  min ‖x‖  s.t.  Ax = b,
+#  min ‖x‖₂  s.t.  x ∈ argmin ‖Ax - b‖₂,
 #
 # and is equivalent to applying the conjugate residual method
 # to the linear system
@@ -34,13 +34,13 @@ export craigmr, craigmr!
 
 Solve the consistent linear system
 
-    Ax + λs = b
+    Ax + λ²y = b
 
 using the CRAIGMR method, where λ ≥ 0 is a regularization parameter.
 This method is equivalent to applying the Conjugate Residuals method
 to the normal equations of the second kind
 
-    (AAᵀ + λ²I)y = b
+    (AAᵀ + λ²I) y = b
 
 but is more stable. When λ = 0, this method solves the minimum-norm problem
 
@@ -48,7 +48,7 @@ but is more stable. When λ = 0, this method solves the minimum-norm problem
 
 When λ > 0, this method solves the problem
 
-    min ‖(x,s)‖₂  s.t.  Ax + λs = b.
+    min ‖(x,y)‖₂  s.t.  Ax + λ²y = b.
 
 If `sqd = true`, CRAIGMR solves the symmetric and quasi-definite system
 
@@ -56,6 +56,11 @@ If `sqd = true`, CRAIGMR solves the symmetric and quasi-definite system
     [  A   E  ] [ y ] = [ b ],
 
 where E and F are symmetric and positive definite.
+The system above represents the optimality conditions of
+
+    min ‖x‖_F + ‖y‖_E  s.t.  Ax + Ey = b.
+
+For a symmetric and positive definite matrix `K`, the K-norm of a vector `x` is `‖x‖²_K = xᵀKx`.
 CRAIGMR is then equivalent to applying MINRES to `(AF⁻¹Aᵀ + E)y = b` with `Fx = Aᵀy`.
 Preconditioners M = E⁻¹ ≻ 0 and N = F⁻¹ ≻ 0 may be provided in the form of linear operators.
 
@@ -64,7 +69,11 @@ If `sqd = false`, CRAIGMR solves the symmetric and indefinite system
     [ -F   Aᵀ ] [ x ]   [ 0 ]
     [  A   0  ] [ y ] = [ b ].
 
-In this case, M can still be specified and indicates the weighted norm in which residuals are measured.
+The system above represents the optimality conditions of
+
+    min ‖x‖_F  s.t.  Ax = b.
+
+In this case, `M` can still be specified and indicates the weighted norm in which residuals are measured.
 
 CRAIGMR produces monotonic residuals ‖r‖₂.
 It is formally equivalent to CRMR, though can be slightly more accurate,

--- a/src/krylov_solvers.jl
+++ b/src/krylov_solvers.jl
@@ -1303,6 +1303,7 @@ mutable struct CraigmrSolver{T,S} <: KrylovSolver{T,S}
   x     :: S
   Nv    :: S
   Aᵀu   :: S
+  d     :: S
   y     :: S
   Mu    :: S
   w     :: S
@@ -1328,7 +1329,7 @@ mutable struct CraigmrSolver{T,S} <: KrylovSolver{T,S}
     v    = S(undef, 0)
     q    = S(undef, 0)
     stats = SimpleStats(false, false, T[], T[], T[], "unknown")
-    solver = new{T,S}(x, Nv, Aᵀu, y, Mu, w, wbar, Av, u, v, q, stats)
+    solver = new{T,S}(x, Nv, Aᵀu, d, y, Mu, w, wbar, Av, u, v, q, stats)
     return solver
   end
 

--- a/src/krylov_solvers.jl
+++ b/src/krylov_solvers.jl
@@ -1310,6 +1310,7 @@ mutable struct CraigmrSolver{T,S} <: KrylovSolver{T,S}
   Av    :: S
   u     :: S
   v     :: S
+  q     :: S
   stats :: SimpleStats{T}
 
   function CraigmrSolver(n, m, S)
@@ -1317,6 +1318,7 @@ mutable struct CraigmrSolver{T,S} <: KrylovSolver{T,S}
     x    = S(undef, m)
     Nv   = S(undef, m)
     Aᵀu  = S(undef, m)
+    d    = S(undef, m)
     y    = S(undef, n)
     Mu   = S(undef, n)
     w    = S(undef, n)
@@ -1324,8 +1326,9 @@ mutable struct CraigmrSolver{T,S} <: KrylovSolver{T,S}
     Av   = S(undef, n)
     u    = S(undef, 0)
     v    = S(undef, 0)
+    q    = S(undef, 0)
     stats = SimpleStats(false, false, T[], T[], T[], "unknown")
-    solver = new{T,S}(x, Nv, Aᵀu, y, Mu, w, wbar, Av, u, v, stats)
+    solver = new{T,S}(x, Nv, Aᵀu, y, Mu, w, wbar, Av, u, v, q, stats)
     return solver
   end
 

--- a/src/lnlq.jl
+++ b/src/lnlq.jl
@@ -4,7 +4,7 @@
 #
 # The method seeks to solve the minimum-norm problem
 #
-#  min ‖x‖  s.t.  Ax = b,
+#  min ‖x‖₂  s.t.  Ax = b,
 #
 # and is equivalent to applying the SYMMLQ method
 # to the linear system
@@ -32,7 +32,7 @@ export lnlq, lnlq!
 
 Find the least-norm solution of the consistent linear system
 
-    Ax + λs = b
+    Ax + λ²y = b
 
 using the LNLQ method, where λ ≥ 0 is a regularization parameter.
 
@@ -40,7 +40,7 @@ For a system in the form Ax = b, LNLQ method is equivalent to applying
 SYMMLQ to AAᵀy = b and recovering x = Aᵀy but is more stable.
 Note that y are the Lagrange multipliers of the least-norm problem
 
-    minimize ‖x‖  s.t.  Ax = b.
+    minimize ‖x‖₂  s.t.  Ax = b.
 
 If `sqd = true`, LNLQ solves the symmetric and quasi-definite system
 
@@ -48,6 +48,11 @@ If `sqd = true`, LNLQ solves the symmetric and quasi-definite system
     [  A   E  ] [ y ] = [ b ],
 
 where E and F are symmetric and positive definite.
+The system above represents the optimality conditions of
+
+    min ‖x‖_F + ‖y‖_E  s.t.  Ax + Ey = b.
+
+For a symmetric and positive definite matrix `K`, the K-norm of a vector `x` is `‖x‖²_K = xᵀKx`.
 LNLQ is then equivalent to applying SYMMLQ to `(AF⁻¹Aᵀ + E)y = b` with `Fx = Aᵀy`.
 Preconditioners M = E⁻¹ ≻ 0 and N = F⁻¹ ≻ 0 may be provided in the form of linear operators.
 
@@ -56,7 +61,11 @@ If `sqd = false`, LNLQ solves the symmetric and indefinite system
     [ -F   Aᵀ ] [ x ]   [ 0 ]
     [  A   0  ] [ y ] = [ b ].
 
-In this case, M can still be specified and indicates the weighted norm in which residuals are measured.
+The system above represents the optimality conditions of
+
+    minimize ‖x‖_F  s.t.  Ax = b.
+
+In this case, `M` can still be specified and indicates the weighted norm in which residuals are measured.
 
 In this implementation, both the x and y-parts of the solution are returned.
 

--- a/src/lnlq.jl
+++ b/src/lnlq.jl
@@ -4,7 +4,7 @@
 #
 # The method seeks to solve the minimum-norm problem
 #
-#  min ‖x‖₂  s.t.  Ax = b,
+#  min ‖x‖  s.t.  Ax = b,
 #
 # and is equivalent to applying the SYMMLQ method
 # to the linear system
@@ -40,7 +40,7 @@ For a system in the form Ax = b, LNLQ method is equivalent to applying
 SYMMLQ to AAᵀy = b and recovering x = Aᵀy but is more stable.
 Note that y are the Lagrange multipliers of the least-norm problem
 
-    minimize ‖x‖₂  s.t.  Ax = b.
+    minimize ‖x‖  s.t.  Ax = b.
 
 If `sqd = true`, LNLQ solves the symmetric and quasi-definite system
 

--- a/test/test_alloc.jl
+++ b/test/test_alloc.jl
@@ -223,9 +223,9 @@ function test_alloc()
   @test (VERSION < v"1.5") || (inplace_bicgstab_bytes == 0)
 
   # CRAIGMR needs:
-  # - 3 n-vectors: x, v, Aᵀu
+  # - 4 n-vectors: x, v, Aᵀu, d
   # - 5 m-vectors: y, u, w, wbar, Av
-  storage_craigmr(n, m) = 3 * n + 5 * m
+  storage_craigmr(n, m) = 4 * n + 5 * m
   storage_craigmr_bytes(n, m) = 8 * storage_craigmr(n, m)
 
   expected_craigmr_bytes = storage_craigmr_bytes(n, m)

--- a/test/test_solvers.jl
+++ b/test/test_solvers.jl
@@ -628,6 +628,7 @@
     │                   x│           Vector{Float64}│                64│
     │                  Nv│           Vector{Float64}│                64│
     │                 Aᵀu│           Vector{Float64}│                64│
+    │                   d│           Vector{Float64}│                64│
     │                   y│           Vector{Float64}│                32│
     │                  Mu│           Vector{Float64}│                32│
     │                   w│           Vector{Float64}│                32│
@@ -635,6 +636,7 @@
     │                  Av│           Vector{Float64}│                32│
     │                   u│           Vector{Float64}│                 0│
     │                   v│           Vector{Float64}│                 0│
+    │                   q│           Vector{Float64}│                 0│
     └────────────────────┴──────────────────────────┴──────────────────┘
     Simple stats
     solved: true


### PR DESCRIPTION
I found a way to update x without computing Aᵀy, even if λ > 0 in CRAIGMR! With this pull request, #171 and #128 everything is now generalized for saddle-point / SQD systems.