### PR TITLE
Add values of default arguments in docstrings

### DIFF
--- a/src/bicgstab.jl
+++ b/src/bicgstab.jl
@@ -16,7 +16,9 @@
 export bicgstab
 
 """
-    (x, stats) = bicgstab(A, b; c, M, N, atol, rtol, itmax, verbose)
+    (x, stats) = bicgstab(A, b::AbstractVector{T}; c::AbstractVector{T}=b,
+                          M=opEye(), N=opEye(), atol::T=√eps(T), rtol::T=√eps(T),
+                          itmax::Int=0, verbose::Bool=false) where T <: AbstractFloat
 
 Solve the square linear system Ax = b using the BICGSTAB method.
 
@@ -34,8 +36,8 @@ Additional details can be displayed if the `verbose` mode is enabled.
 This implementation allows a left preconditioner `M` and a right preconditioner `N`.
 """
 function bicgstab(A, b :: AbstractVector{T}; c :: AbstractVector{T}=b,
-                   M=opEye(), N=opEye(), atol :: T=√eps(T), rtol :: T=√eps(T),
-                   itmax :: Int=0, verbose :: Bool=false) where T <: AbstractFloat
+                  M=opEye(), N=opEye(), atol :: T=√eps(T), rtol :: T=√eps(T),
+                  itmax :: Int=0, verbose :: Bool=false) where T <: AbstractFloat
 
   n, m = size(A)
   m == n || error("System must be square")
@@ -89,7 +91,7 @@ function bicgstab(A, b :: AbstractVector{T}; c :: AbstractVector{T}=b,
   while !(solved || tired || breakdown)
     # Update iteration index and ρ.
     iter = iter + 1
-    ρ = next_ρ 
+    ρ = next_ρ
 
     y = N * p                            # yₖ = N⁻¹pₖ
     q = A * y                            # qₖ = Ayₖ

--- a/src/bilq.jl
+++ b/src/bilq.jl
@@ -13,7 +13,9 @@
 export bilq
 
 """
-    (x, stats) = bilq(A, b; c, atol, rtol, transfer_to_bicg, itmax, verbose)
+    (x, stats) = bilq(A, b::AbstractVector{T}; c::AbstractVector{T}=b,
+                      atol::T=√eps(T), rtol::T=√eps(T), transfer_to_bicg::Bool=true,
+                      itmax::Int=0, verbose::Bool=false) where T <: AbstractFloat
 
 Solve the square linear system Ax = b using the BiLQ method.
 

--- a/src/bilqr.jl
+++ b/src/bilqr.jl
@@ -13,7 +13,9 @@
 export bilqr
 
 """
-    (x, t, stats) = bilqr(A, b, c; atol, rtol, transfer_to_bicg, itmax, verbose)
+    (x, t, stats) = bilqr(A, b::AbstractVector{T}, c::AbstractVector{T};
+                          atol::T=√eps(T), rtol::T=√eps(T), transfer_to_bicg::Bool=true,
+                          itmax::Int=0, verbose::Bool=false) where T <: AbstractFloat
 
 Combine BiLQ and QMR to solve adjoint systems.
 

--- a/src/cg.jl
+++ b/src/cg.jl
@@ -12,7 +12,10 @@ export cg
 
 
 """
-    (x, stats) = cg(A, b; M, atol, rtol, itmax, radius, linesearch, verbose)
+    (x, stats) = cg(A, b::AbstractVector{T};
+                    M=opEye(), atol::T=√eps(T), rtol::T=√eps(T),
+                    itmax::Int=0, radius::T=zero(T), linesearch::Bool=false,
+                    verbose::Bool=false) where T <: AbstractFloat
 
 The conjugate gradient method to solve the symmetric linear system Ax=b.
 
@@ -21,6 +24,10 @@ The method does _not_ abort if A is not definite.
 A preconditioner M may be provided in the form of a linear operator and is
 assumed to be symmetric and positive definite.
 M also indicates the weighted norm in which residuals are measured.
+
+If `itmax=0`, the default number of iterations is set to `2 * n`,
+with `n = length(b)`.
+
 """
 function cg(A, b :: AbstractVector{T};
             M=opEye(), atol :: T=√eps(T), rtol :: T=√eps(T),

--- a/src/cg_lanczos.jl
+++ b/src/cg_lanczos.jl
@@ -13,7 +13,9 @@ export cg_lanczos, cg_lanczos_shift_seq
 
 
 """
-    (x, stats) = cg_lanczos(A, b; M, atol, rtol, itmax, check_curvature, verbose)
+    (x, stats) = cg_lanczos(A, b::AbstractVector{T};
+                            M=opEye(), atol::T=√eps(T), rtol::T=√eps(T), itmax::Int=0,
+                            check_curvature::Bool=false, verbose::Bool=false) where T <: AbstractFloat
 
 The Lanczos version of the conjugate gradient method to solve the
 symmetric linear system
@@ -125,7 +127,9 @@ end
 
 
 """
-    (x, stats) = cg_lanczos_shift_seq(A, b, shifts; M, atol, rtol, itmax, check_curvature, verbose)
+    (x, stats) = cg_lanczos_shift_seq(A, b::AbstractVector{T}, shifts::AbstractVector{T};
+                                      M=opEye(), atol::T=√eps(T), rtol::T=√eps(T), itmax::Int=0,
+                                      check_curvature::Bool=false, verbose::Bool=false) where T <: AbstractFloat
 
 The Lanczos version of the conjugate gradient method to solve a family
 of shifted systems

--- a/src/cgls.jl
+++ b/src/cgls.jl
@@ -23,7 +23,9 @@ export cgls
 
 
 """
-    (x, stats) = cgls(A, b; M, λ, atol, rtol, radius, itmax, verbose)
+    (x, stats) = cgls(A, b::AbstractVector{T};
+                      M=opEye(), λ::T=zero(T), atol::T=√eps(T), rtol::T=√eps(T),
+                      radius::T=zero(T), itmax::Int=0, verbose::Bool=false) where T <: AbstractFloat
 
 Solve the regularized linear least-squares problem
 

--- a/src/cgne.jl
+++ b/src/cgne.jl
@@ -30,7 +30,9 @@ export cgne
 
 
 """
-    (x, stats) = cgne(A, b; M, λ, atol, rtol, itmax, verbose)
+    (x, stats) = cgne(A, b::AbstractVector{T};
+                      M=opEye(), λ::T=zero(T), atol::T=√eps(T), rtol::T=√eps(T),
+                      itmax::Int=0, verbose::Bool=false) where T <: AbstractFloat
 
 Solve the consistent linear system
 

--- a/src/cgs.jl
+++ b/src/cgs.jl
@@ -14,7 +14,9 @@
 export cgs
 
 """
-    (x, stats) = cgs(A, b; c, M, N, atol, rtol, itmax, verbose)
+    (x, stats) = cgs(A, b::AbstractVector{T}; c::AbstractVector{T}=b,
+                     M=opEye(), N=opEye(), atol::T=√eps(T), rtol::T=√eps(T),
+                     itmax::Int=0, verbose::Bool=false) where T <: AbstractFloat
 
 Solve the consistent linear system Ax = b using conjugate gradient squared algorithm.
 

--- a/src/cr.jl
+++ b/src/cr.jl
@@ -8,7 +8,9 @@
 export cr
 
 """
-    (x, stats) = cr(A, b; M, atol, rtol, γ, itmax, radius, verbose, linesearch)
+    (x, stats) = cr(A, b::AbstractVector{T};
+                    M=opEye(), atol::T=√eps(T), rtol::T=√eps(T), γ::T=√eps(T), itmax::Int=0,
+                    radius::T=zero(T), verbose::Bool=false, linesearch::Bool=false) where T <: AbstractFloat
 
 A truncated version of Stiefel’s Conjugate Residual method to solve the symmetric linear system Ax=b.
 The matrix A must be positive semi-definite.
@@ -18,6 +20,10 @@ assumed to be symmetric and positive definite.
 M also indicates the weighted norm in which residuals are measured.
 
 In a linesearch context, 'linesearch' must be set to 'true'.
+
+If `itmax=0`, the default number of iterations is set to `2 * n`,
+with `n = length(b)`.
+
 """
 function cr(A, b :: AbstractVector{T};
             M=opEye(), atol :: T=√eps(T), rtol :: T=√eps(T), γ :: T=√eps(T), itmax :: Int=0,

--- a/src/craig.jl
+++ b/src/craig.jl
@@ -34,7 +34,10 @@ export craig
 
 
 """
-    (x, y, stats) = craig(A, b; M, N, sqd, λ, atol, btol, rtol, conlim, itmax, verbose, transfer_to_lsqr)
+    (x, y, stats) = craig(A, b::AbstractVector{T};
+                          M=opEye(), N=opEye(), sqd::Bool=false, λ::T=zero(T), atol::T=√eps(T),
+                          btol::T=√eps(T), rtol::T=√eps(T), conlim::T=1/√eps(T), itmax::Int=0,
+                          verbose::Bool=false, transfer_to_lsqr::Bool=false) where T <: AbstractFloat
 
 Find the least-norm solution of the consistent linear system
 

--- a/src/craigmr.jl
+++ b/src/craigmr.jl
@@ -29,7 +29,9 @@ export craigmr
 
 
 """
-    (x, y, stats) = craigmr(A, b; M, N, λ, atol, rtol, itmax, verbose)
+    (x, y, stats) = craigmr(A, b::AbstractVector{T};
+                            M=opEye(), N=opEye(), λ::T=zero(T), atol::T=√eps(T),
+                            rtol::T=√eps(T), itmax::Int=0, verbose::Bool=false) where T <: AbstractFloat
 
 Solve the consistent linear system
 

--- a/src/crls.jl
+++ b/src/crls.jl
@@ -22,7 +22,9 @@ export crls
 
 
 """
-    (x, stats) = crls(A, b; M, λ, atol, rtol, radius, itmax, verbose)
+    (x, stats) = crls(A, b::AbstractVector{T};
+                      M=opEye(), λ::T=zero(T), atol::T=√eps(T), rtol::T=√eps(T),
+                      radius::T=zero(T), itmax::Int=0, verbose::Bool=false) where T <: AbstractFloat
 
 Solve the linear least-squares problem
 

--- a/src/crmr.jl
+++ b/src/crmr.jl
@@ -29,7 +29,9 @@ export crmr
 
 
 """
-    (x, stats) = crmr(A, b; M, λ, atol, rtol, itmax, verbose)
+    (x, stats) = crmr(A, b::AbstractVector{T};
+                      M=opEye(), λ::T=zero(T), atol::T=√eps(T),
+                      rtol::T=√eps(T), itmax::Int=0, verbose::Bool=false) where T <: AbstractFloat
 
 Solve the consistent linear system
 

--- a/src/diom.jl
+++ b/src/diom.jl
@@ -14,7 +14,9 @@
 export diom
 
 """
-    (x, stats) = diom(A, b; M, N, atol, rtol, itmax, memory, pivoting, verbose)
+    (x, stats) = diom(A, b::AbstractVector{T};
+                      M=opEye(), N=opEye(), atol::T=√eps(T), rtol::T=√eps(T), itmax::Int=0,
+                      memory::Int=20, pivoting::Bool=false, verbose::Bool=false) where T <: AbstractFloat
 
 Solve the consistent linear system Ax = b using direct incomplete orthogonalization method.
 

--- a/src/dqgmres.jl
+++ b/src/dqgmres.jl
@@ -14,7 +14,9 @@
 export dqgmres
 
 """
-    (x, stats) = dqgmres(A, b; M, N, atol, rtol, itmax, memory, verbose)
+    (x, stats) = dqgmres(A, b::AbstractVector{T};
+                         M=opEye(), N=opEye(), atol::T=√eps(T), rtol::T=√eps(T),
+                         itmax::Int=0, memory::Int=20, verbose::Bool=false) where T <: AbstractFloat
 
 Solve the consistent linear system Ax = b using DQGMRES method.
 

--- a/src/lslq.jl
+++ b/src/lslq.jl
@@ -5,7 +5,12 @@ export lslq
 
 
 """
-    (x_lq, x_cg, err_lbnds, err_ubnds_lq, err_ubnds_cg, stats) = lslq(A, b; M, N, sqd, λ, atol, btol, etol, window, utol, itmax, σ, conlim, verbose)
+    (x_lq, x_cg, err_lbnds, err_ubnds_lq, err_ubnds_cg, stats) =
+        lslq(A, b::AbstractVector{T};
+             M=opEye(), N=opEye(), sqd::Bool=false, λ::T=zero(T),
+             atol::T=√eps(T), btol::T=√eps(T), etol::T=√eps(T),
+             window::Int=5, utol::T=√eps(T), itmax::Int=0,
+             σ::T=zero(T), conlim::T=1/√eps(T), verbose::Bool=false) where T <: AbstractFloat
 
 Solve the regularized linear least-squares problem
 

--- a/src/lsmr.jl
+++ b/src/lsmr.jl
@@ -26,7 +26,13 @@ export lsmr
 
 
 """
-    (x, stats) = lsmr(A, b; M, N, sqd, λ, axtol, btol, atol, rtol, etol, window, itmax, conlim, radius, verbose)
+    (x, stats) = lsmr(A, b::AbstractVector{T};
+                      M=opEye(), N=opEye(), sqd::Bool=false,
+                      λ::T=zero(T), axtol::T=√eps(T), btol::T=√eps(T),
+                      atol::T=zero(T), rtol::T=zero(T),
+                      etol::T=√eps(T), window::Int=5,
+                      itmax::Int=0, conlim::T=1/√eps(T),
+                      radius::T=zero(T), verbose::Bool=false) where T <: AbstractFloat
 
 Solve the regularized linear least-squares problem
 

--- a/src/lsqr.jl
+++ b/src/lsqr.jl
@@ -26,7 +26,13 @@ export lsqr
 
 
 """
-    (x, stats) = lsqr(A, b; M, N, sqd, λ, axtol, btol, atol, rtol, etol, window, itmax, conlim, radius, verbose)
+    (x, stats) = lsqr(A, b::AbstractVector{T};
+                      M=opEye(), N=opEye(), sqd::Bool=false,
+                      λ::T=zero(T), axtol::T=√eps(T), btol::T=√eps(T),
+                      atol::T=zero(T), rtol::T=zero(T),
+                      etol::T=√eps(T), window::Int=5,
+                      itmax::Int=0, conlim::T=1/√eps(T),
+                      radius::T=zero(T), verbose::Bool=false) where T <: AbstractFloat
 
 Solve the regularized linear least-squares problem
 

--- a/src/minres.jl
+++ b/src/minres.jl
@@ -23,7 +23,11 @@ export minres
 
 
 """
-    (x, stats) = minres(A, b; M, λ, atol, rtol, etol, window, itmax, conlim, verbose)
+    (x, stats) = minres(A, b::AbstractVector{T};
+                        M=opEye(), λ::T=zero(T), atol::T=√eps(T)/100,
+                        rtol::T=√eps(T)/100, etol::T=√eps(T),
+                        window::Int=5, itmax::Int=0, conlim::T=1/√eps(T),
+                        verbose::Bool=false) where T <: AbstractFloat
 
 Solve the shifted linear least-squares problem
 

--- a/src/minres_qlp.jl
+++ b/src/minres_qlp.jl
@@ -17,7 +17,9 @@
 export minres_qlp
 
 """
-    (x, stats) = minrres_qlp(A, b; M, atol, rtol, λ, itmax, verbose)
+    (x, stats) = minres_qlp(A, b::AbstractVector{T};
+                            M=opEye(), atol::T=√eps(T), rtol::T=√eps(T), λ::T=zero(T),
+                            itmax::Int=0, verbose::Bool=false) where T <: AbstractFloat
 
 MINRES-QLP is the only method based on the Lanczos process that returns the minimum-norm
 solution on singular inconsistent systems (A + λI)x = b, where λ is a shift parameter.

--- a/src/qmr.jl
+++ b/src/qmr.jl
@@ -21,7 +21,9 @@
 export qmr
 
 """
-    (x, stats) = qmr(A, b; c, atol, rtol, itmax, verbose)
+    (x, stats) = qmr(A, b::AbstractVector{T}; c::AbstractVector{T}=b,
+                     atol::T=√eps(T), rtol::T=√eps(T),
+                     itmax::Int=0, verbose::Bool=false) where T <: AbstractFloat
 
 Solve the square linear system Ax = b using the QMR method.
 

--- a/src/symmlq.jl
+++ b/src/symmlq.jl
@@ -13,7 +13,11 @@ export symmlq
 
 
 """
-    (x, stats) = symmlq(A, b; M, λ, transfer_to_cg, λest, atol, rtol, etol, window, itmax, conlim, verbose)
+    (x, stats) = symmlq(A, b::AbstractVector{T};
+                        M=opEye(), λ::T=zero(T), transfer_to_cg::Bool=true,
+                        λest::T=zero(T), atol::T=√eps(T), rtol::T=√eps(T),
+                        etol::T=√eps(T), window::Int=0, itmax::Int=0,
+                        conlim::T=1/√eps(T), verbose::Bool=false) where T <: AbstractFloat
 
 Solve the shifted linear system
 

--- a/src/tricg.jl
+++ b/src/tricg.jl
@@ -12,7 +12,10 @@
 export tricg
 
 """
-    (x, y, stats) = tricg(A, b, c; M, N, atol, rtol, spd, snd, flip, τ, ν, itmax, verbose)
+    (x, y, stats) = tricg(A, b::AbstractVector{T}, c::AbstractVector{T};
+                          M=opEye(), N=opEye(), atol::T=√eps(T), rtol::T=√eps(T),
+                          spd::Bool=false, snd::Bool=false, flip::Bool=false,
+                          τ::T=one(T), ν::T=-one(T), itmax::Int=0, verbose::Bool=false) where T <: AbstractFloat
 
 TriCG solves the symmetric linear system
 
@@ -78,7 +81,7 @@ function tricg(A, b :: AbstractVector{T}, c :: AbstractVector{T};
 
   iter = 0
   itmax == 0 && (itmax = m+n)
-  
+
   # Initialize preconditioned orthogonal tridiagonalization process.
   M⁻¹vₖ₋₁ = kzeros(S, m)  # v₀ = 0
   N⁻¹uₖ₋₁ = kzeros(S, n)  # u₀ = 0

--- a/src/trilqr.jl
+++ b/src/trilqr.jl
@@ -13,7 +13,9 @@
 export trilqr
 
 """
-    (x, t, stats) = trilqr(A, b, c; atol, rtol, transfer_to_usymcg, itmax, verbose)
+    (x, t, stats) = trilqr(A, b::AbstractVector{T}, c::AbstractVector{T};
+                           atol::T=√eps(T), rtol::T=√eps(T), transfer_to_usymcg::Bool=true,
+                           itmax::Int=0, verbose::Bool=false) where T <: AbstractFloat
 
 Combine USYMLQ and USYMQR to solve adjoint systems.
 

--- a/src/trimr.jl
+++ b/src/trimr.jl
@@ -12,7 +12,10 @@
 export trimr
 
 """
-    (x, y, stats) = trimr(A, b, c; M, N, atol, rtol, spd, snd, flip, sp, τ, ν, itmax, verbose)
+    (x, y, stats) = trimr(A, b::AbstractVector{T}, c::AbstractVector{T};
+                          M=opEye(), N=opEye(), atol::T=√eps(T), rtol::T=√eps(T),
+                          spd::Bool=false, snd::Bool=false, flip::Bool=false, sp::Bool=false,
+                          τ::T=one(T), ν::T=-one(T), itmax::Int=0, verbose::Bool=false) where T <: AbstractFloat
 
 TriMR solves the symmetric linear system
 
@@ -82,7 +85,7 @@ function trimr(A, b :: AbstractVector{T}, c :: AbstractVector{T};
 
   iter = 0
   itmax == 0 && (itmax = m+n)
-  
+
   # Initialize preconditioned orthogonal tridiagonalization process.
   M⁻¹vₖ₋₁ = kzeros(S, m)  # v₀ = 0
   N⁻¹uₖ₋₁ = kzeros(S, n)  # u₀ = 0

--- a/src/usymlq.jl
+++ b/src/usymlq.jl
@@ -20,7 +20,9 @@
 export usymlq
 
 """
-    (x, stats) = usymlq(A, b, c; atol, rtol, transfer_to_usymcg, itmax, verbose)
+    (x, stats) = usymlq(A, b::AbstractVector{T}, c::AbstractVector{T};
+                        atol::T=√eps(T), rtol::T=√eps(T), transfer_to_usymcg::Bool=true,
+                        itmax::Int=0, verbose::Bool=false) where T <: AbstractFloat
 
 Solve the linear system Ax = b using the USYMLQ method.
 

--- a/src/usymqr.jl
+++ b/src/usymqr.jl
@@ -20,7 +20,9 @@
 export usymqr
 
 """
-    (x, stats) = usymqr(A, b, c; atol, rtol, itmax, verbose)
+    (x, stats) = usymqr(A, b::AbstractVector{T}, c::AbstractVector{T};
+                        atol::T=√eps(T), rtol::T=√eps(T),
+                        itmax::Int=0, verbose::Bool=false) where T <: AbstractFloat
 
 Solve the linear system Ax = b using the USYMQR method.
 


### PR DESCRIPTION
That allows to read the default values of the arguments with the `help?>`  function, directly in Julia's REPL. 

*Note:* By default, `maxit` is set to `2 * length(b)` whenever `maxit=0`. Should we specify this value directly in the args?