### PR TITLE
Improve performance on GPU

### DIFF
--- a/src/cgs.jl
+++ b/src/cgs.jl
@@ -92,7 +92,8 @@ function cgs(A, b :: AbstractVector{T}; c :: AbstractVector{T}=b,
     v = M * t                     # vₖ = M⁻¹tₖ
     σ = @kdot(n, v, c)            # σₖ = ⟨ M⁻¹AN⁻¹pₖ,̅r₀ ⟩
     α = ρ / σ                     # αₖ = ρₖ / σₖ
-    @. q = u - α * v              # qₖ = uₖ - αₖ * M⁻¹AN⁻¹pₖ
+    @kcopy!(n, u, q)              # qₖ = uₖ
+    @kaxpy!(n, -α, v, q)          # qₖ = qₖ - αₖ * M⁻¹AN⁻¹pₖ
     @kaxpy!(n, one(T), q, u)      # uₖ₊½ = uₖ + qₖ
     z = N * u                     # zₖ = N⁻¹uₖ₊½
     @kaxpy!(n, α, z, x)           # xₖ₊₁ = xₖ + αₖ * N⁻¹(uₖ + qₖ)
@@ -101,7 +102,8 @@ function cgs(A, b :: AbstractVector{T}; c :: AbstractVector{T}=b,
     @kaxpy!(n, -α, w, r)          # rₖ₊₁ = rₖ - αₖ * M⁻¹AN⁻¹(uₖ + qₖ)
     ρ_next = @kdot(n, r, c)       # ρₖ₊₁ = ⟨ rₖ₊₁,̅r₀ ⟩
     β = ρ_next / ρ                # βₖ = ρₖ₊₁ / ρₖ
-    @. u = r + β * q              # uₖ₊₁ = rₖ₊₁ + βₖ * qₖ
+    @kcopy!(n, r, u)              # uₖ₊₁ = rₖ₊₁
+    @kaxpy!(n, β, q, u)           # uₖ₊₁ = uₖ₊₁ + βₖ * qₖ
     @kaxpby!(n, one(T), q, β, p)  # pₐᵤₓ = qₖ + βₖ * pₖ
     @kaxpby!(n, one(T), u, β, p)  # pₖ₊₁ = uₖ₊₁ + βₖ * pₐᵤₓ
 

--- a/src/krylov_utils.jl
+++ b/src/krylov_utils.jl
@@ -150,10 +150,10 @@ Create an AbstractVector of storage type `S` of length `n` only composed of one.
 @inline krylov_scal!(n :: Int, s :: T, x :: AbstractVector{T}, dx :: Int) where T <: Number = (x .*= s)
 
 @inline krylov_axpy!(n :: Int, s :: T, x :: Vector{T}, dx :: Int, y :: Vector{T}, dy :: Int) where T <: BLAS.BlasReal = BLAS.axpy!(n, s, x, dx, y, dy)
-@inline krylov_axpy!(n :: Int, s :: T, x :: AbstractVector{T}, dx :: Int, y :: AbstractVector{T}, dy :: Int) where T <: Number = (y .+= s .* x)
+@inline krylov_axpy!(n :: Int, s :: T, x :: AbstractVector{T}, dx :: Int, y :: AbstractVector{T}, dy :: Int) where T <: Number = axpy!(s, x, y)
 
 @inline krylov_axpby!(n :: Int, s :: T, x :: Vector{T}, dx :: Int, t :: T, y :: Vector{T}, dy :: Int) where T <: BLAS.BlasReal = BLAS.axpby!(n, s, x, dx, t, y, dy)
-@inline krylov_axpby!(n :: Int, s :: T, x :: AbstractVector{T}, dx :: Int, t :: T, y :: AbstractVector{T}, dy :: Int) where T <: Number = (y .= s .* x .+ t.* y)
+@inline krylov_axpby!(n :: Int, s :: T, x :: AbstractVector{T}, dx :: Int, t :: T, y :: AbstractVector{T}, dy :: Int) where T <: Number = axpby!(s, x, t, y)
 
 function krylov_ref!(n :: Int, x :: AbstractVector{T}, dx :: Int, y :: AbstractVector{T}, dy :: Int, c :: T , s :: T) where T <: Number
   # assume dx = dy

--- a/src/krylov_utils.jl
+++ b/src/krylov_utils.jl
@@ -155,6 +155,9 @@ Create an AbstractVector of storage type `S` of length `n` only composed of one.
 @inline krylov_axpby!(n :: Int, s :: T, x :: Vector{T}, dx :: Int, t :: T, y :: Vector{T}, dy :: Int) where T <: BLAS.BlasReal = BLAS.axpby!(n, s, x, dx, t, y, dy)
 @inline krylov_axpby!(n :: Int, s :: T, x :: AbstractVector{T}, dx :: Int, t :: T, y :: AbstractVector{T}, dy :: Int) where T <: Number = axpby!(s, x, t, y)
 
+@inline krylov_copy!(n :: Int, x :: Vector{T}, dx :: Int, y :: Vector{T}, dy :: Int) where T <: BLAS.BlasReal = BLAS.blascopy!(n, x, dx, y, dy)
+@inline krylov_copy!(n :: Int, x :: AbstractVector{T}, dx :: Int, y :: AbstractVector{T}, dy :: Int) where T <: Number = copyto!(y, x)
+
 function krylov_ref!(n :: Int, x :: AbstractVector{T}, dx :: Int, y :: AbstractVector{T}, dy :: Int, c :: T , s :: T) where T <: Number
   # assume dx = dy
   @inbounds @simd for i = 1:dx:n
@@ -186,6 +189,10 @@ end
 
 macro kaxpby!(n, s, x, t, y)
   return esc(:(krylov_axpby!($n, $s, $x, 1, $t, $y, 1)))
+end
+
+macro kcopy!(n, x, y)
+  return esc(:(krylov_copy!($n, $x, 1, $y, 1)))
 end
 
 macro kswap(x, y)


### PR DESCRIPTION
I only updated `BICGSTAB` and  `CGS` for the moment.
In the future, we should remove all occurrence of broadcast in the other solvers.

```julia
using Random, LinearAlgebra, CUDA, Krylov, BenchmarkTools
CUDA.allowscalar(false)
Random.seed!(0)
n = 2^12
A = Matrix(Symmetric(rand(n, n)))
cA = CuArray(A)
b = ones(n)
cb = CuArray(b)
@benchmark bicgstab($cA, $cb)
```

Before this pull request:
```julia
BenchmarkTools.Trial: 
  memory estimate:  121.50 MiB
  allocs estimate:  2654329
  --------------
  minimum time:     6.909 s (0.18% GC)
  median time:      6.909 s (0.18% GC)
  mean time:        6.909 s (0.18% GC)
  maximum time:     6.909 s (0.18% GC)
  --------------
  samples:          1
  evals/sample:     1
```

Now: 
```julia
BenchmarkTools.Trial: 
  memory estimate:  6.25 MiB
  allocs estimate:  368761
  --------------
  minimum time:     6.460 s (0.00% GC)
  median time:      6.460 s (0.00% GC)
  mean time:        6.460 s (0.00% GC)
  maximum time:     6.460 s (0.00% GC)
  --------------
  samples:          1
  evals/sample:     1
 ```
