### PR TITLE
Use mul! function

### DIFF
--- a/src/bicgstab.jl
+++ b/src/bicgstab.jl
@@ -105,16 +105,16 @@ function bicgstab!(solver :: BicgstabSolver{T,S}, A, b :: AbstractVector{T}; c :
     iter = iter + 1
     ρ = next_ρ
 
-    y = N * p                            # yₖ = N⁻¹pₖ
-    q = A * y                            # qₖ = Ayₖ
-    Mq = M * q; @kcopy!(n, Mq, v)        # vₖ = M⁻¹qₖ
+    mul!(y, N, p)                        # yₖ = N⁻¹pₖ
+    mul!(q, A, y)                        # qₖ = Ayₖ
+    mul!(Mq, M, q); @kcopy!(n, Mq, v)    # vₖ = M⁻¹qₖ
     α = ρ / @kdot(n, v, c)               # αₖ = ⟨rₖ₋₁,r̅₀⟩ / ⟨vₖ,r̅₀⟩
     @kcopy!(n, r, s)                     # sₖ = rₖ₋₁
     @kaxpy!(n, -α, v, s)                 # sₖ = sₖ - αₖvₖ
     @kaxpy!(n, α, y, x)                  # xₐᵤₓ = xₖ₋₁ + αₖyₖ
-    z = N * s                            # zₖ = N⁻¹sₖ
-    d = A * z                            # dₖ = Azₖ
-    t = M * d                            # tₖ = M⁻¹dₖ
+    mul!(z, N, s)                        # zₖ = N⁻¹sₖ
+    mul!(d, A, z)                        # dₖ = Azₖ
+    mul!(t, M, d)                        # tₖ = M⁻¹dₖ
     ω = @kdot(n, t, s) / @kdot(n, t, t)  # ⟨tₖ,sₖ⟩ / ⟨tₖ,tₖ⟩
     @kaxpy!(n, ω, z, x)                  # xₖ = xₐᵤₓ + ωₖzₖ
     @kcopy!(n, s, r)                     # rₖ = sₖ

--- a/src/bilq.jl
+++ b/src/bilq.jl
@@ -52,7 +52,7 @@ function bilq!(solver :: BilqSolver{T,S}, A, b :: AbstractVector{T}; c :: Abstra
   Aᵀ = A'
 
   # Set up workspace.
-  uₖ₋₁, uₖ, vₖ₋₁, vₖ, x, d̅ = solver.uₖ₋₁, solver.uₖ, solver.vₖ₋₁, solver.vₖ, solver.x, solver.d̅
+  uₖ₋₁, uₖ, q, vₖ₋₁, vₖ, p, x, d̅ = solver.uₖ₋₁, solver.uₖ, solver.q, solver.vₖ₋₁, solver.vₖ, solver.p, solver.x, solver.d̅
 
   # Initial solution x₀ and residual norm ‖r₀‖.
   x .= zero(T)
@@ -100,8 +100,8 @@ function bilq!(solver :: BilqSolver{T,S}, A, b :: AbstractVector{T}; c :: Abstra
     # AVₖ  = VₖTₖ    + βₖ₊₁vₖ₊₁(eₖ)ᵀ = Vₖ₊₁Tₖ₊₁.ₖ
     # AᵀUₖ = Uₖ(Tₖ)ᵀ + γₖ₊₁uₖ₊₁(eₖ)ᵀ = Uₖ₊₁(Tₖ.ₖ₊₁)ᵀ
 
-    q = A  * vₖ  # Forms vₖ₊₁ : q ← Avₖ
-    p = Aᵀ * uₖ  # Forms uₖ₊₁ : p ← Aᵀuₖ
+    mul!(q, A , vₖ)  # Forms vₖ₊₁ : q ← Avₖ
+    mul!(p, Aᵀ, uₖ)  # Forms uₖ₊₁ : p ← Aᵀuₖ
 
     @kaxpy!(n, -γₖ, vₖ₋₁, q)  # q ← q - γₖ * vₖ₋₁
     @kaxpy!(n, -βₖ, uₖ₋₁, p)  # p ← p - βₖ * uₖ₋₁

--- a/src/bilqr.jl
+++ b/src/bilqr.jl
@@ -56,7 +56,8 @@ function bilqr!(solver :: BilqrSolver{T,S}, A, b :: AbstractVector{T}, c :: Abst
   Aᵀ = A'
 
   # Set up workspace.
-  uₖ₋₁, uₖ, vₖ₋₁, vₖ, x, t, d̅, wₖ₋₃, wₖ₋₂ = solver.uₖ₋₁, solver.uₖ, solver.vₖ₋₁, solver.vₖ, solver.x, solver.t, solver.d̅, solver.wₖ₋₃, solver.wₖ₋₂
+  uₖ₋₁, uₖ, q, vₖ₋₁, vₖ, p = solver.uₖ₋₁, solver.uₖ, solver.q, solver.vₖ₋₁, solver.vₖ, solver.p
+  x, t, d̅, wₖ₋₃, wₖ₋₂ = solver.x, solver.t, solver.d̅, solver.wₖ₋₃, solver.wₖ₋₂
 
   # Initial solution x₀ and residual norm ‖r₀‖ = ‖b - Ax₀‖.
   x .= zero(T)          # x₀
@@ -119,8 +120,8 @@ function bilqr!(solver :: BilqrSolver{T,S}, A, b :: AbstractVector{T}, c :: Abst
     # AVₖ  = VₖTₖ    + βₖ₊₁vₖ₊₁(eₖ)ᵀ = Vₖ₊₁Tₖ₊₁.ₖ
     # AᵀUₖ = Uₖ(Tₖ)ᵀ + γₖ₊₁uₖ₊₁(eₖ)ᵀ = Uₖ₊₁(Tₖ.ₖ₊₁)ᵀ
 
-    q = A  * vₖ  # Forms vₖ₊₁ : q ← Avₖ
-    p = Aᵀ * uₖ  # Forms uₖ₊₁ : p ← Aᵀuₖ
+    mul!(q, A , vₖ)  # Forms vₖ₊₁ : q ← Avₖ
+    mul!(p, Aᵀ, uₖ)  # Forms uₖ₊₁ : p ← Aᵀuₖ
 
     @kaxpy!(n, -γₖ, vₖ₋₁, q)  # q ← q - γₖ * vₖ₋₁
     @kaxpy!(n, -βₖ, uₖ₋₁, p)  # p ← p - βₖ * uₖ₋₁

--- a/src/cg.jl
+++ b/src/cg.jl
@@ -59,11 +59,11 @@ function cg!(solver :: CgSolver{T,S}, A, b :: AbstractVector{T};
   isa(M, opEye) || (eltype(M) == T) || error("eltype(M) ≠ $T")
 
   # Set up workspace.
-  x, r, p = solver.x, solver.r, solver.p
+  x, r, p, Ap, z = solver.x, solver.r, solver.p, solver.Ap, solver.z
 
   x .= zero(T)
   r .= b
-  z = M * r
+  mul!(z, M, r)
   p .= z
   γ = @kdot(n, r, z)
   γ == 0 && return x, SimpleStats(true, false, [zero(T)], T[], "x = 0 is a zero-residual solution")
@@ -88,7 +88,7 @@ function cg!(solver :: CgSolver{T,S}, A, b :: AbstractVector{T};
   status = "unknown"
 
   while !(solved || tired || zero_curvature)
-    Ap = A * p
+    mul!(Ap, A, p)
     pAp = @kdot(n, p, Ap)
     if (pAp ≤ eps(T) * pNorm²) && (radius == 0)
       if abs(pAp) ≤ eps(T) * pNorm²
@@ -119,7 +119,7 @@ function cg!(solver :: CgSolver{T,S}, A, b :: AbstractVector{T};
 
     @kaxpy!(n,  α,  p, x)
     @kaxpy!(n, -α, Ap, r)
-    z = M * r
+    mul!(z, M, r)
     γ_next = @kdot(n, r, z)
     rNorm = sqrt(γ_next)
     history && push!(rNorms, rNorm)

--- a/src/cg_lanczos.jl
+++ b/src/cg_lanczos.jl
@@ -61,7 +61,7 @@ function cg_lanczos!(solver :: CgLanczosSolver{T,S}, A, b :: AbstractVector{T};
   # Initial state.
   x .= zero(T)              # x₀
   Mv .= b                   # Mv₁ ← b
-  v = M * Mv                # v₁ = M⁻¹ * Mv₁
+  mul!(v, M, Mv)            # v₁ = M⁻¹ * Mv₁
   β = sqrt(@kdot(n, v, Mv)) # β₁ = v₁ᵀ M v₁
   β == 0 && return x, LanczosStats(true, [zero(T)], false, zero(T), zero(T), "x = 0 is a zero-residual solution")
   p .= v
@@ -98,7 +98,7 @@ function cg_lanczos!(solver :: CgLanczosSolver{T,S}, A, b :: AbstractVector{T};
   while ! (solved || tired || (check_curvature & indefinite))
     # Form next Lanczos vector.
     # βₖ₊₁Mvₖ₊₁ = Avₖ - δₖMvₖ - βₖMvₖ₋₁
-    Mv_next = A * v          # Mvₖ₊₁ ← Avₖ
+    mul!(Mv_next, A, v)      # Mvₖ₊₁ ← Avₖ
     δ = @kdot(n, v, Mv_next) # δₖ = vₖᵀ A vₖ
 
     # Check curvature. Exit fast if requested.
@@ -113,7 +113,7 @@ function cg_lanczos!(solver :: CgLanczosSolver{T,S}, A, b :: AbstractVector{T};
       @. Mv_prev = Mv                  # Mvₖ₋₁ ← Mvₖ
     end
     @. Mv = Mv_next                    # Mvₖ ← Mvₖ₊₁
-    v = M * Mv                         # vₖ₊₁ = M⁻¹ * Mvₖ₊₁
+    mul!(v, M, Mv)                     # vₖ₊₁ = M⁻¹ * Mvₖ₊₁
     β = sqrt(@kdot(n, v, Mv))          # βₖ₊₁ = vₖ₊₁ᵀ M vₖ₊₁
     @kscal!(n, one(T)/β, v)            # vₖ₊₁  ←  vₖ₊₁ / βₖ₊₁
     MisI || @kscal!(n, one(T)/β, Mv)   # Mvₖ₊₁ ← Mvₖ₊₁ / βₖ₊₁
@@ -190,7 +190,7 @@ function cg_lanczos_shift_seq!(solver :: CgLanczosShiftSolver{T,S}, A, b :: Abst
     x[i] .= zero(T)                       # x₀
   end
   Mv .= b                                 # Mv₁ ← b
-  v = M * Mv                              # v₁ = M⁻¹ * Mv₁
+  mul!(v, M, Mv)                          # v₁ = M⁻¹ * Mv₁
   β = sqrt(@kdot(n, v, Mv))               # β₁ = v₁ᵀ M v₁
   β == 0 && return x, LanczosStats(true, [zero(T)], false, zero(T), zero(T), "x = 0 is a zero-residual solution")
 
@@ -244,7 +244,7 @@ function cg_lanczos_shift_seq!(solver :: CgLanczosShiftSolver{T,S}, A, b :: Abst
   while ! (solved || tired)
     # Form next Lanczos vector.
     # βₖ₊₁Mvₖ₊₁ = Avₖ - δₖMvₖ - βₖMvₖ₋₁
-    Mv_next = A * v                    # Mvₖ₊₁ ← Avₖ
+    mul!(Mv_next, A, v)                # Mvₖ₊₁ ← Avₖ
     δ = @kdot(n, v, Mv_next)           # δₖ = vₖᵀ A vₖ
     @kaxpy!(n, -δ, Mv, Mv_next)        # Mvₖ₊₁ ← Mvₖ₊₁ - δₖMvₖ
     if iter > 0
@@ -252,7 +252,7 @@ function cg_lanczos_shift_seq!(solver :: CgLanczosShiftSolver{T,S}, A, b :: Abst
       @. Mv_prev = Mv                  # Mvₖ₋₁ ← Mvₖ
     end
     @. Mv = Mv_next                    # Mvₖ ← Mvₖ₊₁
-    v = M * Mv                         # vₖ₊₁ = M⁻¹ * Mvₖ₊₁
+    mul!(v, M, Mv)                     # vₖ₊₁ = M⁻¹ * Mvₖ₊₁
     β = sqrt(@kdot(n, v, Mv))          # βₖ₊₁ = vₖ₊₁ᵀ M vₖ₊₁
     @kscal!(n, one(T)/β, v)            # vₖ₊₁  ←  vₖ₊₁ / βₖ₊₁
     MisI || @kscal!(n, one(T)/β, Mv)   # Mvₖ₊₁ ← Mvₖ₊₁ / βₖ₊₁

--- a/src/cgls.jl
+++ b/src/cgls.jl
@@ -82,8 +82,8 @@ function cgls!(solver :: CglsSolver{T,S}, A, b :: AbstractVector{T};
   r .= b
   bNorm = @knrm2(m, r)   # Marginally faster than norm(b)
   bNorm == 0 && return x, SimpleStats(true, false, [zero(T)], [zero(T)], "x = 0 is a zero-residual solution")
-  Mr = M * r
-  s = Aᵀ * Mr
+  mul!(Mr, M, r)
+  mul!(s, Aᵀ, Mr)
   p .= s
   γ = @kdot(n, s, s)  # Faster than γ = dot(s, s)
   iter = 0
@@ -103,8 +103,8 @@ function cgls!(solver :: CglsSolver{T,S}, A, b :: AbstractVector{T};
   tired = iter ≥ itmax
 
   while ! (solved || tired)
-    q = A * p
-    Mq = M * q
+    mul!(q, A, p)
+    mul!(Mq, M, q)
     δ = @kdot(m, q, Mq)   # Faster than α = γ / dot(q, q)
     λ > 0 && (δ += λ * @kdot(n, p, p))
     α = γ / δ
@@ -118,8 +118,8 @@ function cgls!(solver :: CglsSolver{T,S}, A, b :: AbstractVector{T};
 
     @kaxpy!(n,  α, p, x)     # Faster than x = x + α * p
     @kaxpy!(m, -α, q, r)     # Faster than r = r - α * q
-    Mr = M * r
-    s = Aᵀ * Mr
+    mul!(Mr, M, r)
+    mul!(s, Aᵀ, Mr)
     λ > 0 && @kaxpy!(n, -λ, x, s)   # s = A' * r - λ * x
     γ_next = @kdot(n, s, s)  # Faster than γ_next = dot(s, s)
     β = γ_next / γ

--- a/src/cgne.jl
+++ b/src/cgne.jl
@@ -89,7 +89,7 @@ function cgne!(solver :: CgneSolver{T,S}, A, b :: AbstractVector{T};
 
   x .= zero(T)
   r .= b
-  z = M * r
+  mul!(z, M, r)
   rNorm = @knrm2(m, r)   # Marginally faster than norm(r)
   rNorm == 0 && return x, SimpleStats(true, false, [rNorm], T[], "x = 0 is a zero-residual solution")
   λ > 0 && (s = copy(r))
@@ -122,17 +122,17 @@ function cgne!(solver :: CgneSolver{T,S}, A, b :: AbstractVector{T};
   tired = iter ≥ itmax
 
   while ! (solved || inconsistent || tired)
-    q = A * p
+    mul!(q, A, p)
     λ > 0 && @kaxpy!(m, λ, s, q)
     δ = @kdot(n, p, p)   # Faster than dot(p, p)
     λ > 0 && (δ += λ * @kdot(m, s, s))
     α = γ / δ
     @kaxpy!(n,  α, p, x)     # Faster than x = x + α * p
     @kaxpy!(m, -α, q, r)     # Faster than r = r - α * q
-    z = M * r
+    mul!(z, M, r)
     γ_next = @kdot(m, r, z)  # Faster than γ_next = dot(r, z)
     β = γ_next / γ
-    Aᵀz = Aᵀ * z
+    mul!(Aᵀz, Aᵀ, z)
     @kaxpby!(n, one(T), Aᵀz, β, p)  # Faster than p = Aᵀz + β * p
     pNorm = @knrm2(n, p)
     if λ > 0

--- a/src/cgs.jl
+++ b/src/cgs.jl
@@ -93,18 +93,18 @@ function cgs!(solver :: CgsSolver{T,S}, A, b :: AbstractVector{T}; c :: Abstract
 
   while !(solved || tired || breakdown)
 
-    y = N * p                     # yₖ = N⁻¹pₖ
-    t = A * y                     # tₖ = Ayₖ
-    v = M * t                     # vₖ = M⁻¹tₖ
+    mul!(y, N, p)                 # yₖ = N⁻¹pₖ
+    mul!(t, A, y)                 # tₖ = Ayₖ
+    mul!(v, M, t)                 # vₖ = M⁻¹tₖ
     σ = @kdot(n, v, c)            # σₖ = ⟨ M⁻¹AN⁻¹pₖ,̅r₀ ⟩
     α = ρ / σ                     # αₖ = ρₖ / σₖ
     @kcopy!(n, u, q)              # qₖ = uₖ
     @kaxpy!(n, -α, v, q)          # qₖ = qₖ - αₖ * M⁻¹AN⁻¹pₖ
     @kaxpy!(n, one(T), q, u)      # uₖ₊½ = uₖ + qₖ
-    z = N * u                     # zₖ = N⁻¹uₖ₊½
+    mul!(z, N, u)                 # zₖ = N⁻¹uₖ₊½
     @kaxpy!(n, α, z, x)           # xₖ₊₁ = xₖ + αₖ * N⁻¹(uₖ + qₖ)
-    s = A * z                     # sₖ = Azₖ
-    w = M * s                     # wₖ = M⁻¹sₖ
+    mul!(s, A, z)                 # sₖ = Azₖ
+    mul!(w, M, s)                 # wₖ = M⁻¹sₖ
     @kaxpy!(n, -α, w, r)          # rₖ₊₁ = rₖ - αₖ * M⁻¹AN⁻¹(uₖ + qₖ)
     ρ_next = @kdot(n, r, c)       # ρₖ₊₁ = ⟨ rₖ₊₁,̅r₀ ⟩
     β = ρ_next / ρ                # βₖ = ρₖ₊₁ / ρₖ

--- a/src/cr.jl
+++ b/src/cr.jl
@@ -57,8 +57,8 @@ function cr!(solver :: CrSolver{T,S}, A, b :: AbstractVector{T};
   # Initial state.
   x .= zero(T)  # initial estimation x = 0
   xNorm = zero(T)
-  r .= M * b  # initial residual r = M * (b - Ax) = M * b
-  Ar = A * r
+  mul!(r, M, b)  # initial residual r = M * (b - Ax) = M * b
+  mul!(Ar, A, r)
   ρ = @kdot(n, r, Ar)
   ρ == 0 && return (x, SimpleStats(true, false, [zero(T)], T[], "x = 0 is a zero-residual solution"))
   p .= r
@@ -102,7 +102,7 @@ function cr!(solver :: CrSolver{T,S}, A, b :: AbstractVector{T};
     elseif pAp ≤ 0 && radius == 0
       error("Indefinite system and no trust region")
     end
-    Mq = M * q
+    mul!(Mq, M, q)
 
     if radius > 0
       (verbose > 0) && @printf("radius = %8.1e > 0 and ‖x‖ = %8.1e\n", radius, xNorm)
@@ -216,7 +216,7 @@ function cr!(solver :: CrSolver{T,S}, A, b :: AbstractVector{T};
     rNorm² = abs(rNorm² - α * ρ)
     rNorm = sqrt(rNorm²)
     history && push!(rNorms, rNorm)
-    Ar = A * r
+    mul!(Ar, A, r)
     ArNorm = @knrm2(n, Ar)
     history && push!(ArNorms, ArNorm)
 

--- a/src/craig.jl
+++ b/src/craig.jl
@@ -114,7 +114,7 @@ function craig!(solver :: CraigSolver{T,S}, A, b :: AbstractVector{T};
   y .= zero(T)
 
   Mu .= b
-  u = M * Mu
+  mul!(u, M, Mu)
   β₁ = sqrt(@kdot(m, u, Mu))
   β₁ == 0 && return x, y, SimpleStats(true, false, [zero(T)], T[], "x = 0 is a zero-residual solution")
   β₁² = β₁^2
@@ -170,9 +170,9 @@ function craig!(solver :: CraigSolver{T,S}, A, b :: AbstractVector{T};
   while ! (solved || inconsistent || ill_cond || tired)
     # Generate the next Golub-Kahan vectors
     # 1. αₖ₊₁Nvₖ₊₁ = Aᵀuₖ₊₁ - βₖ₊₁Nvₖ
-    Aᵀu = Aᵀ * u
+    mul!(Aᵀu, Aᵀ, u)
     @kaxpby!(n, one(T), Aᵀu, -β, Nv)
-    v = N * Nv
+    mul!(v, N, Nv)
     α = sqrt(@kdot(n, v, Nv))
     if α == 0
       inconsistent = true
@@ -213,9 +213,9 @@ function craig!(solver :: CraigSolver{T,S}, A, b :: AbstractVector{T};
     Dnorm² += @knrm2(m, w)
 
     # 2. βₖ₊₁Muₖ₊₁ = Avₖ - αₖMuₖ
-    Av = A * v
+    mul!(Av, A, v)
     @kaxpby!(m, one(T), Av, -α, Mu)
-    u = M * Mu
+    mul!(u, M, Mu)
     β = sqrt(@kdot(m, u, Mu))
     if β ≠ 0
       @kscal!(m, one(T)/β, u)

--- a/src/craigmr.jl
+++ b/src/craigmr.jl
@@ -111,9 +111,9 @@ function craigmr!(solver :: CraigmrSolver{T,S}, A, b :: AbstractVector{T};
   @kscal!(m, one(T)/β, u)
   MisI || @kscal!(m, one(T)/β, Mu)
   # α₁Nv₁ = Aᵀu₁.
-  Aᵀu = Aᵀ * u
+  mul!(Aᵀu, Aᵀ, u)
   Nv .= Aᵀu
-  v = N * Nv
+  mul!(v, N, Nv)
   α = sqrt(@kdot(n, v, Nv))
   Anorm² = α * α
 
@@ -154,9 +154,9 @@ function craigmr!(solver :: CraigmrSolver{T,S}, A, b :: AbstractVector{T};
 
     # Generate next Golub-Kahan vectors.
     # 1. βₖ₊₁Muₖ₊₁ = Avₖ - αₖMuₖ
-    Av = A * v
+    mul!(Av, A, v)
     @kaxpby!(m, one(T), Av, -α, Mu)
-    u = M * Mu
+    mul!(u, M, Mu)
     β = sqrt(@kdot(m, u, Mu))
     if β ≠ 0
       @kscal!(m, one(T)/β, u)
@@ -188,9 +188,9 @@ function craigmr!(solver :: CraigmrSolver{T,S}, A, b :: AbstractVector{T};
     @kaxpy!(m, ζ, w, y)             # y = y + ζ * w
 
     # 2. αₖ₊₁Nvₖ₊₁ = Aᵀuₖ₊₁ - βₖ₊₁Nvₖ
-    Aᵀu = Aᵀ * u
+    mul!(Aᵀu, Aᵀ, u)
     @kaxpby!(n, one(T), Aᵀu, -β, Nv)
-    v = N * Nv
+    mul!(v, N, Nv)
     α = sqrt(@kdot(n, v, Nv))
     Anorm² = Anorm² + α * α  # = ‖Lₖ‖
     ArNorm = α * β * abs(ζ/ρ)

--- a/src/diom.jl
+++ b/src/diom.jl
@@ -57,7 +57,7 @@ function diom!(solver :: DiomSolver{T,S}, A, b :: AbstractVector{T};
   # Initial solution x₀ and residual r₀.
   x .= zero(T)  # x₀
   x_old .= x
-  r₀ = M * b  # M⁻¹(b - Ax₀)
+  mul!(r₀, M, b)  # M⁻¹(b - Ax₀)
   # Compute β.
   rNorm = @knrm2(n, r₀) # β = ‖r₀‖₂
   rNorm == 0 && return x, SimpleStats(true, false, [rNorm], T[], "x = 0 is a zero-residual solution")
@@ -101,9 +101,9 @@ function diom!(solver :: DiomSolver{T,S}, A, b :: AbstractVector{T};
     next_pos = mod(iter, mem) + 1 # Position corresponding to vₘ₊₁ in the circular stack V.
 
     # Incomplete Arnoldi procedure.
-    z = N * V[pos] # N⁻¹vₘ, forms pₘ
-    t = A * z      # AN⁻¹vₘ
-    w = M * t      # M⁻¹AN⁻¹vₘ, forms vₘ₊₁
+    mul!(z, N, V[pos])  # N⁻¹vₘ, forms pₘ
+    mul!(t, A, z)       # AN⁻¹vₘ
+    mul!(w, M, t)       # M⁻¹AN⁻¹vₘ, forms vₘ₊₁
     for i = max(1, iter-mem+1) : iter
       ipos = mod(i-1, mem) + 1 # Position corresponding to vᵢ in the circular stack V.
       diag = iter - i + 2

--- a/src/dqgmres.jl
+++ b/src/dqgmres.jl
@@ -54,7 +54,7 @@ function dqgmres!(solver :: DqgmresSolver{T,S}, A, b :: AbstractVector{T};
 
   # Initial solution x₀ and residual r₀.
   x .= zero(T)  # x₀
-  r₀ = M * b    # M⁻¹(b - Ax₀)
+  mul!(r₀, M, b)  # M⁻¹(b - Ax₀)
   # Compute β
   rNorm = @knrm2(n, r₀) # β = ‖r₀‖₂
   rNorm == 0 && return x, SimpleStats(true, false, [rNorm], T[], "x = 0 is a zero-residual solution")
@@ -101,9 +101,9 @@ function dqgmres!(solver :: DqgmresSolver{T,S}, A, b :: AbstractVector{T};
     next_pos = mod(iter, mem) + 1 # Position corresponding to vₘ₊₁ in the circular stack V.
 
     # Incomplete Arnoldi procedure.
-    z = N * V[pos] # N⁻¹vₘ, forms pₘ
-    t = A * z      # AN⁻¹vₘ
-    w = M * t      # M⁻¹AN⁻¹vₘ, forms vₘ₊₁
+    mul!(z, N, V[pos])  # N⁻¹vₘ, forms pₘ
+    mul!(t, A, z)       # AN⁻¹vₘ
+    mul!(w, M, t)       # M⁻¹AN⁻¹vₘ, forms vₘ₊₁
     for i = max(1, iter-mem+1) : iter
       ipos = mod(i-1, mem) + 1 # Position corresponding to vᵢ in the circular stack V.
       diag = iter - i + 2

--- a/src/krylov_utils.jl
+++ b/src/krylov_utils.jl
@@ -228,6 +228,8 @@ function krylov_ref!(n :: Integer, x :: AbstractVector{T}, dx :: Integer, y :: A
   return x, y
 end
 
+@inline kmul!(y, A, x) = isa(A, AbstractLinearOperator) ? y = A * x : mul!(y, A, x)
+
 # the macros are just for readability, so we don't have to write the increments (always equal to 1)
 
 macro kdot(n, x, y)

--- a/src/lnlq.jl
+++ b/src/lnlq.jl
@@ -120,7 +120,7 @@ function lnlq!(solver :: LnlqSolver{T,S}, A, b :: AbstractVector{T};
   # Initialize generalized Golub-Kahan bidiagonalization.
   # β₁Mu₁ = b.
   Mu .= b
-  u  = M * Mu                 # u₁ = M⁻¹ * Mu₁
+  mul!(u, M, Mu)              # u₁ = M⁻¹ * Mu₁
   βₖ = sqrt(@kdot(m, u, Mu))  # β₁ = ‖u₁‖_M
   if βₖ ≠ 0
     @kscal!(m, 1 / βₖ, u)
@@ -128,9 +128,9 @@ function lnlq!(solver :: LnlqSolver{T,S}, A, b :: AbstractVector{T};
   end
 
   # α₁Nv₁ = Aᵀu₁.
-  Aᵀu = Aᵀ * u
+  mul!(Aᵀu, Aᵀ, u)
   Nv .= Aᵀu
-  v   = N * Nv                 # v₁ = N⁻¹ * Nv₁
+  mul!(v, N, Nv)               # v₁ = N⁻¹ * Nv₁
   αₖ  = sqrt(@kdot(n, v, Nv))  # α₁ = ‖v₁‖_N
   if αₖ ≠ 0
     @kscal!(n, 1 / αₖ, v)
@@ -219,9 +219,9 @@ function lnlq!(solver :: LnlqSolver{T,S}, A, b :: AbstractVector{T};
     #      [ βₖ₊₁(eₖ)ᵀ ]
 
     # βₖ₊₁Muₖ₊₁ = Avₖ - αₖMuₖ
-    Av = A * v
+    mul!(Av, A, v)
     @kaxpby!(m, one(T), Av, -αₖ, Mu)
-    u = M * Mu                    # uₖ₊₁ = M⁻¹ * Muₖ₊₁
+    mul!(u, M, Mu)                # uₖ₊₁ = M⁻¹ * Muₖ₊₁
     βₖ₊₁ = sqrt(@kdot(m, u, Mu))  # βₖ₊₁ = ‖uₖ₊₁‖_M
     if βₖ₊₁ ≠ 0
       @kscal!(m, 1 / βₖ₊₁, u)
@@ -229,9 +229,9 @@ function lnlq!(solver :: LnlqSolver{T,S}, A, b :: AbstractVector{T};
     end
 
     # αₖ₊₁Nvₖ₊₁ = Aᵀuₖ₊₁ - βₖ₊₁Nvₖ
-    Aᵀu = Aᵀ * u
+    mul!(Aᵀu, Aᵀ, u)
     @kaxpby!(n, one(T), Aᵀu, -βₖ₊₁, Nv)
-    v = N * Nv                    # vₖ₊₁ = N⁻¹ * Nvₖ₊₁
+    mul!(v, N, Nv)                # vₖ₊₁ = N⁻¹ * Nvₖ₊₁
     αₖ₊₁ = sqrt(@kdot(n, v, Nv))  # αₖ₊₁ = ‖vₖ₊₁‖_N
     if αₖ₊₁ ≠ 0
       @kscal!(n, 1 / αₖ₊₁, v)

--- a/src/lslq.jl
+++ b/src/lslq.jl
@@ -147,7 +147,7 @@ function lslq!(solver :: LslqSolver{T,S}, A, b :: AbstractVector{T};
   # Initialize Golub-Kahan process.
   # β₁ M u₁ = b.
   Mu .= b
-  u = M * Mu
+  mul!(u, M, Mu)
   β₁ = sqrt(@kdot(m, u, Mu))
   β₁ == 0 && return (x_lq, kzeros(S, n), err_lbnds, err_ubnds_lq, err_ubnds_cg,
                        SimpleStats(true, false, [zero(T)], [zero(T)], "x = 0 is a zero-residual solution"))
@@ -155,9 +155,9 @@ function lslq!(solver :: LslqSolver{T,S}, A, b :: AbstractVector{T};
 
   @kscal!(m, one(T)/β₁, u)
   MisI || @kscal!(m, one(T)/β₁, Mu)
-  Aᵀu = Aᵀ * u
+  mul!(Aᵀu, Aᵀ, u)
   Nv .= Aᵀu
-  v = N * Nv
+  mul!(v, N, Nv)
   α = sqrt(@kdot(n, v, Nv))  # = α₁
 
   # Aᵀb = 0 so x = 0 is a minimum least-squares solution
@@ -222,18 +222,18 @@ function lslq!(solver :: LslqSolver{T,S}, A, b :: AbstractVector{T};
 
     # Generate next Golub-Kahan vectors.
     # 1. βₖ₊₁Muₖ₊₁ = Avₖ - αₖMuₖ
-    Av = A * v
+    mul!(Av, A, v)
     @kaxpby!(m, one(T), Av, -α, Mu)
-    u = M * Mu
+    mul!(u, M, Mu)
     β = sqrt(@kdot(m, u, Mu))
     if β ≠ 0
       @kscal!(m, one(T)/β, u)
       MisI || @kscal!(m, one(T)/β, Mu)
 
       # 2. αₖ₊₁Nvₖ₊₁ = Aᵀuₖ₊₁ - βₖ₊₁Nvₖ
-      Aᵀu = Aᵀ * u
+      mul!(Aᵀu, Aᵀ, u)
       @kaxpby!(n, one(T), Aᵀu, -β, Nv)
-      v = N * Nv
+      mul!(v, N, Nv)
       α = sqrt(@kdot(n, v, Nv))
       if α ≠ 0
         @kscal!(n, one(T)/α, v)

--- a/src/lsmr.jl
+++ b/src/lsmr.jl
@@ -116,16 +116,16 @@ function lsmr!(solver :: LsmrSolver{T,S}, A, b :: AbstractVector{T};
   # Initialize Golub-Kahan process.
   # β₁ M u₁ = b.
   Mu .= b
-  u = M * Mu
+  mul!(u, M, Mu)
   β₁ = sqrt(@kdot(m, u, Mu))
   β₁ == 0 && return (x, SimpleStats(true, false, [zero(T)], [zero(T)], "x = 0 is a zero-residual solution"))
   β = β₁
 
   @kscal!(m, one(T)/β₁, u)
   MisI || @kscal!(m, one(T)/β₁, Mu)
-  Aᵀu = Aᵀ * u
+  mul!(Aᵀu, Aᵀ, u)
   Nv .= Aᵀu
-  v = N * Nv
+  mul!(v, N, Nv)
   α = sqrt(@kdot(n, v, Nv))
 
   ζbar = α * β
@@ -187,18 +187,18 @@ function lsmr!(solver :: LsmrSolver{T,S}, A, b :: AbstractVector{T};
 
     # Generate next Golub-Kahan vectors.
     # 1. βₖ₊₁Muₖ₊₁ = Avₖ - αₖMuₖ
-    Av = A * v
+    mul!(Av, A, v)
     @kaxpby!(m, one(T), Av, -α, Mu)
-    u = M * Mu
+    mul!(u, M, Mu)
     β = sqrt(@kdot(m, u, Mu))
     if β ≠ 0
       @kscal!(m, one(T)/β, u)
       MisI || @kscal!(m, one(T)/β, Mu)
 
       # 2. αₖ₊₁Nvₖ₊₁ = Aᵀuₖ₊₁ - βₖ₊₁Nvₖ
-      Aᵀu = Aᵀ * u
+      mul!(Aᵀu, Aᵀ, u)
       @kaxpby!(n, one(T), Aᵀu, -β, Nv)
-      v = N * Nv
+      mul!(v, N, Nv)
       α = sqrt(@kdot(n, v, Nv))
       if α ≠ 0
         @kscal!(n, one(T)/α, v)

--- a/src/lsqr.jl
+++ b/src/lsqr.jl
@@ -114,16 +114,16 @@ function lsqr!(solver :: LsqrSolver{T,S}, A, b :: AbstractVector{T};
   # Initialize Golub-Kahan process.
   # β₁ M u₁ = b.
   Mu .= b
-  u = M * Mu
+  mul!(u, M, Mu)
   β₁ = sqrt(@kdot(m, u, Mu))
   β₁ == 0 && return (x, SimpleStats(true, false, [zero(T)], [zero(T)], "x = 0 is a zero-residual solution"))
   β = β₁
 
   @kscal!(m, one(T)/β₁, u)
   MisI || @kscal!(m, one(T)/β₁, Mu)
-  Aᵀu = Aᵀ * u
+  mul!(Aᵀu, Aᵀ, u)
   Nv .= Aᵀu
-  v = N * Nv
+  mul!(v, N, Nv)
   Anorm² = @kdot(n, v, Nv)
   Anorm = sqrt(Anorm²)
   α = Anorm
@@ -180,9 +180,9 @@ function lsqr!(solver :: LsqrSolver{T,S}, A, b :: AbstractVector{T};
 
     # Generate next Golub-Kahan vectors.
     # 1. βₖ₊₁Muₖ₊₁ = Avₖ - αₖMuₖ
-    Av = A * v
+    mul!(Av, A, v)
     @kaxpby!(m, one(T), Av, -α, Mu)
-    u = M * Mu
+    mul!(u, M, Mu)
     β = sqrt(@kdot(m, u, Mu))
     if β ≠ 0
       @kscal!(m, one(T)/β, u)
@@ -191,9 +191,9 @@ function lsqr!(solver :: LsqrSolver{T,S}, A, b :: AbstractVector{T};
       λ > 0 && (Anorm² += λ²)
 
       # 2. αₖ₊₁Nvₖ₊₁ = Aᵀuₖ₊₁ - βₖ₊₁Nvₖ
-      Aᵀu = Aᵀ * u
+      mul!(Aᵀu, Aᵀ, u)
       @kaxpby!(n, one(T), Aᵀu, -β, Nv)
-      v = N * Nv
+      mul!(v, N, Nv)
       α = sqrt(@kdot(n, v, Nv))
       if α ≠ 0
         @kscal!(n, one(T)/α, v)

--- a/src/qmr.jl
+++ b/src/qmr.jl
@@ -59,7 +59,7 @@ function qmr!(solver :: QmrSolver{T,S}, A, b :: AbstractVector{T}; c :: Abstract
   Aᵀ = A'
 
   # Set up workspace.
-  uₖ₋₁, uₖ, vₖ₋₁, vₖ, x, wₖ₋₂, wₖ₋₁ = solver.uₖ₋₁, solver.uₖ, solver.vₖ₋₁, solver.vₖ, solver.x, solver.wₖ₋₂, solver.wₖ₋₁
+  uₖ₋₁, uₖ, q, vₖ₋₁, vₖ, p, x, wₖ₋₂, wₖ₋₁ = solver.uₖ₋₁, solver.uₖ, solver.q, solver.vₖ₋₁, solver.vₖ, solver.p, solver.x, solver.wₖ₋₂, solver.wₖ₋₁
 
   # Initial solution x₀ and residual norm ‖r₀‖.
   x .= zero(T)
@@ -105,8 +105,8 @@ function qmr!(solver :: QmrSolver{T,S}, A, b :: AbstractVector{T}; c :: Abstract
     # AVₖ  = VₖTₖ    + βₖ₊₁vₖ₊₁(eₖ)ᵀ = Vₖ₊₁Tₖ₊₁.ₖ
     # AᵀUₖ = Uₖ(Tₖ)ᵀ + γₖ₊₁uₖ₊₁(eₖ)ᵀ = Uₖ₊₁(Tₖ.ₖ₊₁)ᵀ
 
-    q = A  * vₖ  # Forms vₖ₊₁ : q ← Avₖ
-    p = Aᵀ * uₖ  # Forms uₖ₊₁ : p ← Aᵀuₖ
+    mul!(q, A , vₖ)  # Forms vₖ₊₁ : q ← Avₖ
+    mul!(p, Aᵀ, uₖ)  # Forms uₖ₊₁ : p ← Aᵀuₖ
 
     @kaxpy!(n, -γₖ, vₖ₋₁, q)  # q ← q - γₖ * vₖ₋₁
     @kaxpy!(n, -βₖ, uₖ₋₁, p)  # p ← p - βₖ * uₖ₋₁

--- a/src/symmlq.jl
+++ b/src/symmlq.jl
@@ -69,7 +69,7 @@ function symmlq!(solver :: SymmlqSolver{T,S}, A, b :: AbstractVector{T};
   # Initialize Lanczos process.
   # β₁ M v₁ = b.
   Mvold .= b
-  vold = M * Mvold
+  mul!(vold, M, Mvold)
   β₁ = @kdot(m, vold, Mvold)
   β₁ == 0 && return (x, SimpleStats(true, true, [zero(T)], [zero(T)], "x = 0 is a zero-residual solution"))
   β₁ = sqrt(β₁)
@@ -79,10 +79,10 @@ function symmlq!(solver :: SymmlqSolver{T,S}, A, b :: AbstractVector{T};
 
   w̅ .= vold
 
-  Mv .= A * vold
+  mul!(Mv, A, vold)
   α = @kdot(m, vold, Mv) + λ
   @kaxpy!(m, -α, Mvold, Mv)  # Mv = Mv - α * Mvold
-  v = M * Mv
+  mul!(v, M, Mv)
   β = @kdot(m, v, Mv)
   β < 0 && error("Preconditioner is not positive definite")
   β = sqrt(β)
@@ -177,13 +177,13 @@ function symmlq!(solver :: SymmlqSolver{T,S}, A, b :: AbstractVector{T};
 
     # Generate next Lanczos vector
     oldβ = β
-    Mv_next = A * v
+    mul!(Mv_next, A, v)
     α = @kdot(m, v, Mv_next) + λ
     @kaxpy!(m, -oldβ, Mvold, Mv_next)
     @. Mvold = Mv
     @kaxpy!(m, -α, Mv, Mv_next)
     @. Mv = Mv_next
-    v = M * Mv
+    mul!(v, M, Mv)
     β = @kdot(m, v, Mv)
     β < 0 && error("Preconditioner is not positive definite")
     β = sqrt(β)

--- a/src/trilqr.jl
+++ b/src/trilqr.jl
@@ -56,7 +56,8 @@ function trilqr!(solver :: TrilqrSolver{T,S}, A, b :: AbstractVector{T}, c :: Ab
   Aᵀ = A'
 
   # Set up workspace.
-  uₖ₋₁, uₖ, vₖ₋₁, vₖ, x, t, d̅, wₖ₋₃, wₖ₋₂ = solver.uₖ₋₁, solver.uₖ, solver.vₖ₋₁, solver.vₖ, solver.x, solver.t, solver.d̅, solver.wₖ₋₃, solver.wₖ₋₂
+  uₖ₋₁, uₖ, p, vₖ₋₁, vₖ, q = solver.uₖ₋₁, solver.uₖ, solver.p, solver.vₖ₋₁, solver.vₖ, solver.q
+  x, t, d̅, wₖ₋₃, wₖ₋₂ = solver.x, solver.t, solver.d̅, solver.wₖ₋₃, solver.wₖ₋₂
 
   # Initial solution x₀ and residual r₀ = b - Ax₀.
   x .= zero(T)          # x₀
@@ -114,8 +115,8 @@ function trilqr!(solver :: TrilqrSolver{T,S}, A, b :: AbstractVector{T}, c :: Ab
     # AUₖ  = VₖTₖ    + βₖ₊₁vₖ₊₁(eₖ)ᵀ = Vₖ₊₁Tₖ₊₁.ₖ
     # AᵀVₖ = Uₖ(Tₖ)ᵀ + γₖ₊₁uₖ₊₁(eₖ)ᵀ = Uₖ₊₁(Tₖ.ₖ₊₁)ᵀ
 
-    q = A  * uₖ  # Forms vₖ₊₁ : q ← Auₖ
-    p = Aᵀ * vₖ  # Forms uₖ₊₁ : p ← Aᵀvₖ
+    mul!(q, A , uₖ)  # Forms vₖ₊₁ : q ← Auₖ
+    mul!(p, Aᵀ, vₖ)  # Forms uₖ₊₁ : p ← Aᵀvₖ
 
     @kaxpy!(m, -γₖ, vₖ₋₁, q)  # q ← q - γₖ * vₖ₋₁
     @kaxpy!(n, -βₖ, uₖ₋₁, p)  # p ← p - βₖ * uₖ₋₁

--- a/src/trimr.jl
+++ b/src/trimr.jl
@@ -89,8 +89,11 @@ function trimr!(solver :: TrimrSolver{T,S}, A, b :: AbstractVector{T}, c :: Abst
   Aᵀ = A'
 
   # Set up workspace.
-  yₖ, N⁻¹uₖ₋₁, N⁻¹uₖ, xₖ, M⁻¹vₖ₋₁, M⁻¹vₖ = solver.yₖ, solver.N⁻¹uₖ₋₁, solver.N⁻¹uₖ,  solver.xₖ, solver.M⁻¹vₖ₋₁, solver.M⁻¹vₖ
+  !MisI && isempty(solver.vₖ) && (solver.vₖ = S(undef, m))
+  !NisI && isempty(solver.uₖ) && (solver.uₖ = S(undef, n))
+  yₖ, N⁻¹uₖ₋₁, N⁻¹uₖ, p, xₖ, M⁻¹vₖ₋₁, M⁻¹vₖ, q = solver.yₖ, solver.N⁻¹uₖ₋₁, solver.N⁻¹uₖ, solver.p, solver.xₖ, solver.M⁻¹vₖ₋₁, solver.M⁻¹vₖ, solver.q
   gy₂ₖ₋₃, gy₂ₖ₋₂, gy₂ₖ₋₁, gy₂ₖ, gx₂ₖ₋₃, gx₂ₖ₋₂, gx₂ₖ₋₁, gx₂ₖ = solver.gy₂ₖ₋₃, solver.gy₂ₖ₋₂, solver.gy₂ₖ₋₁, solver.gy₂ₖ, solver.gx₂ₖ₋₃, solver.gx₂ₖ₋₂, solver.gx₂ₖ₋₁, solver.gx₂ₖ
+  uₖ, vₖ = solver.uₖ, solver.vₖ
 
   # Initial solutions x₀ and y₀.
   xₖ .= zero(T)
@@ -105,7 +108,7 @@ function trimr!(solver :: TrimrSolver{T,S}, A, b :: AbstractVector{T}, c :: Abst
 
   # β₁Ev₁ = b ↔ β₁v₁ = Mb
   M⁻¹vₖ .= b
-  vₖ = M * M⁻¹vₖ
+  mul!(vₖ, M, M⁻¹vₖ)
   βₖ = sqrt(@kdot(m, vₖ, M⁻¹vₖ))  # β₁ = ‖v₁‖_E
   if βₖ ≠ 0
     @kscal!(m, 1 / βₖ, M⁻¹vₖ)
@@ -114,7 +117,7 @@ function trimr!(solver :: TrimrSolver{T,S}, A, b :: AbstractVector{T}, c :: Abst
 
   # γ₁Fu₁ = c ↔ γ₁u₁ = Nb
   N⁻¹uₖ .= c
-  uₖ = N * N⁻¹uₖ
+  mul!(uₖ, N, N⁻¹uₖ)
   γₖ = sqrt(@kdot(n, uₖ, N⁻¹uₖ))  # γ₁ = ‖u₁‖_F
   if γₖ ≠ 0
     @kscal!(n, 1 / γₖ, N⁻¹uₖ)
@@ -171,8 +174,8 @@ function trimr!(solver :: TrimrSolver{T,S}, A, b :: AbstractVector{T}, c :: Abst
     # AUₖ  = EVₖTₖ    + βₖ₊₁Evₖ₊₁(eₖ)ᵀ = EVₖ₊₁Tₖ₊₁.ₖ
     # AᵀVₖ = FUₖ(Tₖ)ᵀ + γₖ₊₁Fuₖ₊₁(eₖ)ᵀ = FUₖ₊₁(Tₖ.ₖ₊₁)ᵀ
 
-    q = A  * uₖ  # Forms Evₖ₊₁ : q ← Auₖ
-    p = Aᵀ * vₖ  # Forms Fuₖ₊₁ : p ← Aᵀvₖ
+    mul!(q, A , uₖ)  # Forms Evₖ₊₁ : q ← Auₖ
+    mul!(p, Aᵀ, vₖ)  # Forms Fuₖ₊₁ : p ← Aᵀvₖ
 
     if iter ≥ 2
       @kaxpy!(m, -γₖ, M⁻¹vₖ₋₁, q)  # q ← q - γₖ * M⁻¹vₖ₋₁
@@ -188,8 +191,8 @@ function trimr!(solver :: TrimrSolver{T,S}, A, b :: AbstractVector{T}, c :: Abst
     NisI || (uₐᵤₓ .= uₖ)  # Tempory storage for uₖ
 
     # Compute vₖ₊₁ and uₖ₊₁
-    vₖ₊₁ = M * q  # βₖ₊₁vₖ₊₁ = MAuₖ  - γₖvₖ₋₁ - αₖvₖ
-    uₖ₊₁ = N * p  # γₖ₊₁uₖ₊₁ = NAᵀvₖ - βₖuₖ₋₁ - αₖuₖ
+    mul!(vₖ₊₁, M, q)  # βₖ₊₁vₖ₊₁ = MAuₖ  - γₖvₖ₋₁ - αₖvₖ
+    mul!(uₖ₊₁, N, p)  # γₖ₊₁uₖ₊₁ = NAᵀvₖ - βₖuₖ₋₁ - αₖuₖ
 
     βₖ₊₁ = sqrt(@kdot(m, vₖ₊₁, q))  # βₖ₊₁ = ‖vₖ₊₁‖_E
     γₖ₊₁ = sqrt(@kdot(n, uₖ₊₁, p))  # γₖ₊₁ = ‖uₖ₊₁‖_F

--- a/src/usymlq.jl
+++ b/src/usymlq.jl
@@ -65,7 +65,7 @@ function usymlq!(solver :: UsymlqSolver{T,S}, A, b :: AbstractVector{T}, c :: Ab
   Aᵀ = A'
 
   # Set up workspace.
-  uₖ₋₁, uₖ, x, d̅, vₖ₋₁, vₖ = solver.uₖ₋₁, solver.uₖ, solver.x, solver.d̅, solver.vₖ₋₁, solver.vₖ
+  uₖ₋₁, uₖ, p, x, d̅, vₖ₋₁, vₖ, q = solver.uₖ₋₁, solver.uₖ, solver.p, solver.x, solver.d̅, solver.vₖ₋₁, solver.vₖ, solver.q
 
   # Initial solution x₀ and residual norm ‖r₀‖.
   x .= zero(T)
@@ -107,8 +107,8 @@ function usymlq!(solver :: UsymlqSolver{T,S}, A, b :: AbstractVector{T}, c :: Ab
     # AUₖ  = VₖTₖ    + βₖ₊₁vₖ₊₁(eₖ)ᵀ = Vₖ₊₁Tₖ₊₁.ₖ
     # AᵀVₖ = Uₖ(Tₖ)ᵀ + γₖ₊₁uₖ₊₁(eₖ)ᵀ = Uₖ₊₁(Tₖ.ₖ₊₁)ᵀ
 
-    q = A  * uₖ  # Forms vₖ₊₁ : q ← Auₖ
-    p = Aᵀ * vₖ  # Forms uₖ₊₁ : p ← Aᵀvₖ
+    mul!(q, A , uₖ)  # Forms vₖ₊₁ : q ← Auₖ
+    mul!(p, Aᵀ, vₖ)  # Forms uₖ₊₁ : p ← Aᵀvₖ
 
     @kaxpy!(m, -γₖ, vₖ₋₁, q)  # q ← q - γₖ * vₖ₋₁
     @kaxpy!(n, -βₖ, uₖ₋₁, p)  # p ← p - βₖ * uₖ₋₁

--- a/src/usymqr.jl
+++ b/src/usymqr.jl
@@ -62,7 +62,7 @@ function usymqr!(solver :: UsymqrSolver{T,S}, A, b :: AbstractVector{T}, c :: Ab
   Aᵀ = A'
 
   # Set up workspace.
-  vₖ₋₁, vₖ, x, wₖ₋₂, wₖ₋₁, uₖ₋₁, uₖ = solver.vₖ₋₁, solver.vₖ, solver.x, solver.wₖ₋₂, solver.wₖ₋₁, solver.uₖ₋₁, solver.uₖ
+  vₖ₋₁, vₖ, q, x, wₖ₋₂, wₖ₋₁, uₖ₋₁, uₖ, p = solver.vₖ₋₁, solver.vₖ, solver.q, solver.x, solver.wₖ₋₂, solver.wₖ₋₁, solver.uₖ₋₁, solver.uₖ, solver.p
 
   # Initial solution x₀ and residual norm ‖r₀‖.
   x .= zero(T)
@@ -105,8 +105,8 @@ function usymqr!(solver :: UsymqrSolver{T,S}, A, b :: AbstractVector{T}, c :: Ab
     # AUₖ  = VₖTₖ    + βₖ₊₁vₖ₊₁(eₖ)ᵀ = Vₖ₊₁Tₖ₊₁.ₖ
     # AᵀVₖ = Uₖ(Tₖ)ᵀ + γₖ₊₁uₖ₊₁(eₖ)ᵀ = Uₖ₊₁(Tₖ.ₖ₊₁)ᵀ
 
-    q = A  * uₖ  # Forms vₖ₊₁ : q ← Auₖ
-    p = Aᵀ * vₖ  # Forms uₖ₊₁ : p ← Aᵀvₖ
+    mul!(q, A , uₖ)  # Forms vₖ₊₁ : q ← Auₖ
+    mul!(p, Aᵀ, vₖ)  # Forms uₖ₊₁ : p ← Aᵀvₖ
 
     @kaxpy!(m, -γₖ, vₖ₋₁, q) # q ← q - γₖ * vₖ₋₁
     @kaxpy!(n, -βₖ, uₖ₋₁, p) # p ← p - βₖ * uₖ₋₁


### PR DESCRIPTION
@geoffroyleconte, @dpo
What do you think about this trick ? It could solve our issue with `mul!`.
`kmul!` is `*` for LinearOperators and `mul!` for matrices and other linear operators (LinearMaps, etc...).
 
Some vectors must not be allocated by default, like the ones needed by the preconditioners or the other ones used by `LS` and `LN` methods for the regularization. Even if we update `LinearOperators.jl`, we will need that :
```
!isa(M, OpEye) && isempty(solver.v) && solver.v = kzeros(S, n)
sqd && isempty(solver.v) && solver.v = kzeros(S, n)
```
 
The idea here is that we can do the same thing for the vectors needed for `A * v` and `A' * u`.