### PR TITLE
Don't use ~1.2 in compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
-LinearOperators = "~1.2, 1.3"
+LinearOperators = "1.2"
 julia = "^1.3.0"
 
 [extras]


### PR DESCRIPTION
`~1.2` means `[1.2.0,1.3.0)`.
`1.2` means `[1.2.0,2.0.0)`.
Using `^` is the same as not using anything.
Ref.: https://pkgdocs.julialang.org/v1/compatibility/