### PR TITLE
Use mul! instead of * for unpreconditioned Krylov methods

### DIFF
--- a/src/bilq.jl
+++ b/src/bilq.jl
@@ -52,7 +52,7 @@ function bilq!(solver :: BilqSolver{T,S}, A, b :: AbstractVector{T}; c :: Abstra
   Aᵀ = A'
 
   # Set up workspace.
-  uₖ₋₁, uₖ, vₖ₋₁, vₖ, x, d̅ = solver.uₖ₋₁, solver.uₖ, solver.vₖ₋₁, solver.vₖ, solver.x, solver.d̅
+  uₖ₋₁, uₖ, q, vₖ₋₁, vₖ, p, x, d̅ = solver.uₖ₋₁, solver.uₖ, solver.q, solver.vₖ₋₁, solver.vₖ, solver.p, solver.x, solver.d̅
 
   # Initial solution x₀ and residual norm ‖r₀‖.
   x .= zero(T)
@@ -100,8 +100,8 @@ function bilq!(solver :: BilqSolver{T,S}, A, b :: AbstractVector{T}; c :: Abstra
     # AVₖ  = VₖTₖ    + βₖ₊₁vₖ₊₁(eₖ)ᵀ = Vₖ₊₁Tₖ₊₁.ₖ
     # AᵀUₖ = Uₖ(Tₖ)ᵀ + γₖ₊₁uₖ₊₁(eₖ)ᵀ = Uₖ₊₁(Tₖ.ₖ₊₁)ᵀ
 
-    q = A  * vₖ  # Forms vₖ₊₁ : q ← Avₖ
-    p = Aᵀ * uₖ  # Forms uₖ₊₁ : p ← Aᵀuₖ
+    mul!(q, A , vₖ)  # Forms vₖ₊₁ : q ← Avₖ
+    mul!(p, Aᵀ, uₖ)  # Forms uₖ₊₁ : p ← Aᵀuₖ
 
     @kaxpy!(n, -γₖ, vₖ₋₁, q)  # q ← q - γₖ * vₖ₋₁
     @kaxpy!(n, -βₖ, uₖ₋₁, p)  # p ← p - βₖ * uₖ₋₁

--- a/src/bilqr.jl
+++ b/src/bilqr.jl
@@ -56,7 +56,8 @@ function bilqr!(solver :: BilqrSolver{T,S}, A, b :: AbstractVector{T}, c :: Abst
   Aᵀ = A'
 
   # Set up workspace.
-  uₖ₋₁, uₖ, vₖ₋₁, vₖ, x, t, d̅, wₖ₋₃, wₖ₋₂ = solver.uₖ₋₁, solver.uₖ, solver.vₖ₋₁, solver.vₖ, solver.x, solver.t, solver.d̅, solver.wₖ₋₃, solver.wₖ₋₂
+  uₖ₋₁, uₖ, q, vₖ₋₁, vₖ, p = solver.uₖ₋₁, solver.uₖ, solver.q, solver.vₖ₋₁, solver.vₖ, solver.p
+  x, t, d̅, wₖ₋₃, wₖ₋₂ = solver.x, solver.t, solver.d̅, solver.wₖ₋₃, solver.wₖ₋₂
 
   # Initial solution x₀ and residual norm ‖r₀‖ = ‖b - Ax₀‖.
   x .= zero(T)          # x₀
@@ -119,8 +120,8 @@ function bilqr!(solver :: BilqrSolver{T,S}, A, b :: AbstractVector{T}, c :: Abst
     # AVₖ  = VₖTₖ    + βₖ₊₁vₖ₊₁(eₖ)ᵀ = Vₖ₊₁Tₖ₊₁.ₖ
     # AᵀUₖ = Uₖ(Tₖ)ᵀ + γₖ₊₁uₖ₊₁(eₖ)ᵀ = Uₖ₊₁(Tₖ.ₖ₊₁)ᵀ
 
-    q = A  * vₖ  # Forms vₖ₊₁ : q ← Avₖ
-    p = Aᵀ * uₖ  # Forms uₖ₊₁ : p ← Aᵀuₖ
+    mul!(q, A , vₖ)  # Forms vₖ₊₁ : q ← Avₖ
+    mul!(p, Aᵀ, uₖ)  # Forms uₖ₊₁ : p ← Aᵀuₖ
 
     @kaxpy!(n, -γₖ, vₖ₋₁, q)  # q ← q - γₖ * vₖ₋₁
     @kaxpy!(n, -βₖ, uₖ₋₁, p)  # p ← p - βₖ * uₖ₋₁

--- a/src/krylov_solvers.jl
+++ b/src/krylov_solvers.jl
@@ -21,7 +21,7 @@ mutable struct MinresSolver{T,S} <: KrylovSolver{T,S}
   x       :: S
   r1      :: S
   r2      :: S
-  w1      :: S 
+  w1      :: S
   w2      :: S
   err_vec :: Vector{T}
   stats   :: SimpleStats{T}
@@ -350,20 +350,24 @@ may be used in order to create these vectors.
 mutable struct UsymlqSolver{T,S} <: KrylovSolver{T,S}
   uₖ₋₁ :: S
   uₖ   :: S
+  p    :: S
   x    :: S
   d̅    :: S
   vₖ₋₁ :: S
   vₖ   :: S
+  q    :: S
 
   function UsymlqSolver(n, m, S)
     T    = eltype(S)
     uₖ₋₁ = S(undef, m)
     uₖ   = S(undef, m)
+    p    = S(undef, m)
     x    = S(undef, m)
     d̅    = S(undef, m)
     vₖ₋₁ = S(undef, n)
     vₖ   = S(undef, n)
-    solver = new{T,S}(uₖ₋₁, uₖ, x, d̅, vₖ₋₁, vₖ)
+    q    = S(undef, n)
+    solver = new{T,S}(uₖ₋₁, uₖ, p, x, d̅, vₖ₋₁, vₖ, q)
     return solver
   end
 
@@ -387,22 +391,26 @@ may be used in order to create these vectors.
 mutable struct UsymqrSolver{T,S} <: KrylovSolver{T,S}
   vₖ₋₁ :: S
   vₖ   :: S
+  q    :: S
   x    :: S
   wₖ₋₂ :: S
   wₖ₋₁ :: S
   uₖ₋₁ :: S
   uₖ   :: S
+  p    :: S
 
   function UsymqrSolver(n, m, S)
     T    = eltype(S)
     vₖ₋₁ = S(undef, n)
     vₖ   = S(undef, n)
+    q    = S(undef, n)
     x    = S(undef, m)
     wₖ₋₂ = S(undef, m)
     wₖ₋₁ = S(undef, m)
     uₖ₋₁ = S(undef, m)
     uₖ   = S(undef, m)
-    solver = new{T,S}(vₖ₋₁, vₖ, x, wₖ₋₂, wₖ₋₁, uₖ₋₁, uₖ)
+    p    = S(undef, m)
+    solver = new{T,S}(vₖ₋₁, vₖ, q, x, wₖ₋₂, wₖ₋₁, uₖ₋₁, uₖ, p)
     return solver
   end
 
@@ -524,8 +532,10 @@ may be used in order to create these vectors.
 mutable struct TrilqrSolver{T,S} <: KrylovSolver{T,S}
   uₖ₋₁ :: S
   uₖ   :: S
+  p    :: S
   vₖ₋₁ :: S
   vₖ   :: S
+  q    :: S
   x    :: S
   t    :: S
   d̅    :: S
@@ -536,14 +546,16 @@ mutable struct TrilqrSolver{T,S} <: KrylovSolver{T,S}
     T    = eltype(S)
     uₖ₋₁ = S(undef, m)
     uₖ   = S(undef, m)
+    p    = S(undef, m)
     vₖ₋₁ = S(undef, n)
     vₖ   = S(undef, n)
+    q    = S(undef, n)
     x    = S(undef, m)
     t    = S(undef, n)
     d̅    = S(undef, m)
     wₖ₋₃ = S(undef, n)
     wₖ₋₂ = S(undef, n)
-    solver = new{T,S}(uₖ₋₁, uₖ, vₖ₋₁, vₖ, x, t, d̅, wₖ₋₃, wₖ₋₂)
+    solver = new{T,S}(uₖ₋₁, uₖ, p, vₖ₋₁, vₖ, q, x, t, d̅, wₖ₋₃, wₖ₋₂)
     return solver
   end
 
@@ -637,8 +649,10 @@ may be used in order to create these vectors.
 mutable struct BilqSolver{T,S} <: KrylovSolver{T,S}
   uₖ₋₁ :: S
   uₖ   :: S
+  q    :: S
   vₖ₋₁ :: S
   vₖ   :: S
+  p    :: S
   x    :: S
   d̅    :: S
 
@@ -646,11 +660,13 @@ mutable struct BilqSolver{T,S} <: KrylovSolver{T,S}
     T    = eltype(S)
     uₖ₋₁ = S(undef, n)
     uₖ   = S(undef, n)
+    q    = S(undef, n)
     vₖ₋₁ = S(undef, n)
     vₖ   = S(undef, n)
+    p    = S(undef, n)
     x    = S(undef, n)
     d̅    = S(undef, n)
-    solver = new{T,S}(uₖ₋₁, uₖ, vₖ₋₁, vₖ, x, d̅)
+    solver = new{T,S}(uₖ₋₁, uₖ, q, vₖ₋₁, vₖ, p, x, d̅)
     return solver
   end
 
@@ -674,8 +690,10 @@ may be used in order to create these vectors.
 mutable struct QmrSolver{T,S} <: KrylovSolver{T,S}
   uₖ₋₁ :: S
   uₖ   :: S
+  q    :: S
   vₖ₋₁ :: S
   vₖ   :: S
+  p    :: S
   x    :: S
   wₖ₋₂ :: S
   wₖ₋₁ :: S
@@ -684,12 +702,14 @@ mutable struct QmrSolver{T,S} <: KrylovSolver{T,S}
     T    = eltype(S)
     uₖ₋₁ = S(undef, n)
     uₖ   = S(undef, n)
+    q    = S(undef, n)
     vₖ₋₁ = S(undef, n)
     vₖ   = S(undef, n)
+    p    = S(undef, n)
     x    = S(undef, n)
     wₖ₋₂ = S(undef, n)
     wₖ₋₁ = S(undef, n)
-    solver = new{T,S}(uₖ₋₁, uₖ, vₖ₋₁, vₖ, x, wₖ₋₂, wₖ₋₁)
+    solver = new{T,S}(uₖ₋₁, uₖ, q, vₖ₋₁, vₖ, p, x, wₖ₋₂, wₖ₋₁)
     return solver
   end
 
@@ -713,8 +733,10 @@ may be used in order to create these vectors.
 mutable struct BilqrSolver{T,S} <: KrylovSolver{T,S}
   uₖ₋₁ :: S
   uₖ   :: S
+  q    :: S
   vₖ₋₁ :: S
   vₖ   :: S
+  p    :: S
   x    :: S
   t    :: S
   d̅    :: S
@@ -725,14 +747,16 @@ mutable struct BilqrSolver{T,S} <: KrylovSolver{T,S}
     T    = eltype(S)
     uₖ₋₁ = S(undef, n)
     uₖ   = S(undef, n)
+    q    = S(undef, n)
     vₖ₋₁ = S(undef, n)
     vₖ   = S(undef, n)
+    p    = S(undef, n)
     x    = S(undef, n)
     t    = S(undef, n)
     d̅    = S(undef, n)
     wₖ₋₃ = S(undef, n)
     wₖ₋₂ = S(undef, n)
-    solver = new{T,S}(uₖ₋₁, uₖ, vₖ₋₁, vₖ, x, t, d̅, wₖ₋₃, wₖ₋₂)
+    solver = new{T,S}(uₖ₋₁, uₖ, q, vₖ₋₁, vₖ, p, x, t, d̅, wₖ₋₃, wₖ₋₂)
     return solver
   end
 

--- a/src/qmr.jl
+++ b/src/qmr.jl
@@ -59,7 +59,7 @@ function qmr!(solver :: QmrSolver{T,S}, A, b :: AbstractVector{T}; c :: Abstract
   Aᵀ = A'
 
   # Set up workspace.
-  uₖ₋₁, uₖ, vₖ₋₁, vₖ, x, wₖ₋₂, wₖ₋₁ = solver.uₖ₋₁, solver.uₖ, solver.vₖ₋₁, solver.vₖ, solver.x, solver.wₖ₋₂, solver.wₖ₋₁
+  uₖ₋₁, uₖ, q, vₖ₋₁, vₖ, p, x, wₖ₋₂, wₖ₋₁ = solver.uₖ₋₁, solver.uₖ, solver.q, solver.vₖ₋₁, solver.vₖ, solver.p, solver.x, solver.wₖ₋₂, solver.wₖ₋₁
 
   # Initial solution x₀ and residual norm ‖r₀‖.
   x .= zero(T)
@@ -105,8 +105,8 @@ function qmr!(solver :: QmrSolver{T,S}, A, b :: AbstractVector{T}; c :: Abstract
     # AVₖ  = VₖTₖ    + βₖ₊₁vₖ₊₁(eₖ)ᵀ = Vₖ₊₁Tₖ₊₁.ₖ
     # AᵀUₖ = Uₖ(Tₖ)ᵀ + γₖ₊₁uₖ₊₁(eₖ)ᵀ = Uₖ₊₁(Tₖ.ₖ₊₁)ᵀ
 
-    q = A  * vₖ  # Forms vₖ₊₁ : q ← Avₖ
-    p = Aᵀ * uₖ  # Forms uₖ₊₁ : p ← Aᵀuₖ
+    mul!(q, A , vₖ)  # Forms vₖ₊₁ : q ← Avₖ
+    mul!(p, Aᵀ, uₖ)  # Forms uₖ₊₁ : p ← Aᵀuₖ
 
     @kaxpy!(n, -γₖ, vₖ₋₁, q)  # q ← q - γₖ * vₖ₋₁
     @kaxpy!(n, -βₖ, uₖ₋₁, p)  # p ← p - βₖ * uₖ₋₁

--- a/src/trilqr.jl
+++ b/src/trilqr.jl
@@ -56,7 +56,8 @@ function trilqr!(solver :: TrilqrSolver{T,S}, A, b :: AbstractVector{T}, c :: Ab
   Aᵀ = A'
 
   # Set up workspace.
-  uₖ₋₁, uₖ, vₖ₋₁, vₖ, x, t, d̅, wₖ₋₃, wₖ₋₂ = solver.uₖ₋₁, solver.uₖ, solver.vₖ₋₁, solver.vₖ, solver.x, solver.t, solver.d̅, solver.wₖ₋₃, solver.wₖ₋₂
+  uₖ₋₁, uₖ, p, vₖ₋₁, vₖ, q = solver.uₖ₋₁, solver.uₖ, solver.p, solver.vₖ₋₁, solver.vₖ, solver.q
+  x, t, d̅, wₖ₋₃, wₖ₋₂ = solver.x, solver.t, solver.d̅, solver.wₖ₋₃, solver.wₖ₋₂
 
   # Initial solution x₀ and residual r₀ = b - Ax₀.
   x .= zero(T)          # x₀
@@ -114,8 +115,8 @@ function trilqr!(solver :: TrilqrSolver{T,S}, A, b :: AbstractVector{T}, c :: Ab
     # AUₖ  = VₖTₖ    + βₖ₊₁vₖ₊₁(eₖ)ᵀ = Vₖ₊₁Tₖ₊₁.ₖ
     # AᵀVₖ = Uₖ(Tₖ)ᵀ + γₖ₊₁uₖ₊₁(eₖ)ᵀ = Uₖ₊₁(Tₖ.ₖ₊₁)ᵀ
 
-    q = A  * uₖ  # Forms vₖ₊₁ : q ← Auₖ
-    p = Aᵀ * vₖ  # Forms uₖ₊₁ : p ← Aᵀvₖ
+    mul!(q, A , uₖ)  # Forms vₖ₊₁ : q ← Auₖ
+    mul!(p, Aᵀ, vₖ)  # Forms uₖ₊₁ : p ← Aᵀvₖ
 
     @kaxpy!(m, -γₖ, vₖ₋₁, q)  # q ← q - γₖ * vₖ₋₁
     @kaxpy!(n, -βₖ, uₖ₋₁, p)  # p ← p - βₖ * uₖ₋₁

--- a/src/usymlq.jl
+++ b/src/usymlq.jl
@@ -65,7 +65,7 @@ function usymlq!(solver :: UsymlqSolver{T,S}, A, b :: AbstractVector{T}, c :: Ab
   Aᵀ = A'
 
   # Set up workspace.
-  uₖ₋₁, uₖ, x, d̅, vₖ₋₁, vₖ = solver.uₖ₋₁, solver.uₖ, solver.x, solver.d̅, solver.vₖ₋₁, solver.vₖ
+  uₖ₋₁, uₖ, p, x, d̅, vₖ₋₁, vₖ, q = solver.uₖ₋₁, solver.uₖ, solver.p, solver.x, solver.d̅, solver.vₖ₋₁, solver.vₖ, solver.q
 
   # Initial solution x₀ and residual norm ‖r₀‖.
   x .= zero(T)
@@ -107,8 +107,8 @@ function usymlq!(solver :: UsymlqSolver{T,S}, A, b :: AbstractVector{T}, c :: Ab
     # AUₖ  = VₖTₖ    + βₖ₊₁vₖ₊₁(eₖ)ᵀ = Vₖ₊₁Tₖ₊₁.ₖ
     # AᵀVₖ = Uₖ(Tₖ)ᵀ + γₖ₊₁uₖ₊₁(eₖ)ᵀ = Uₖ₊₁(Tₖ.ₖ₊₁)ᵀ
 
-    q = A  * uₖ  # Forms vₖ₊₁ : q ← Auₖ
-    p = Aᵀ * vₖ  # Forms uₖ₊₁ : p ← Aᵀvₖ
+    mul!(q, A , uₖ)  # Forms vₖ₊₁ : q ← Auₖ
+    mul!(p, Aᵀ, vₖ)  # Forms uₖ₊₁ : p ← Aᵀvₖ
 
     @kaxpy!(m, -γₖ, vₖ₋₁, q)  # q ← q - γₖ * vₖ₋₁
     @kaxpy!(n, -βₖ, uₖ₋₁, p)  # p ← p - βₖ * uₖ₋₁

--- a/src/usymqr.jl
+++ b/src/usymqr.jl
@@ -62,7 +62,7 @@ function usymqr!(solver :: UsymqrSolver{T,S}, A, b :: AbstractVector{T}, c :: Ab
   Aᵀ = A'
 
   # Set up workspace.
-  vₖ₋₁, vₖ, x, wₖ₋₂, wₖ₋₁, uₖ₋₁, uₖ = solver.vₖ₋₁, solver.vₖ, solver.x, solver.wₖ₋₂, solver.wₖ₋₁, solver.uₖ₋₁, solver.uₖ
+  vₖ₋₁, vₖ, q, x, wₖ₋₂, wₖ₋₁, uₖ₋₁, uₖ, p = solver.vₖ₋₁, solver.vₖ, solver.q, solver.x, solver.wₖ₋₂, solver.wₖ₋₁, solver.uₖ₋₁, solver.uₖ, solver.p
 
   # Initial solution x₀ and residual norm ‖r₀‖.
   x .= zero(T)
@@ -105,8 +105,8 @@ function usymqr!(solver :: UsymqrSolver{T,S}, A, b :: AbstractVector{T}, c :: Ab
     # AUₖ  = VₖTₖ    + βₖ₊₁vₖ₊₁(eₖ)ᵀ = Vₖ₊₁Tₖ₊₁.ₖ
     # AᵀVₖ = Uₖ(Tₖ)ᵀ + γₖ₊₁uₖ₊₁(eₖ)ᵀ = Uₖ₊₁(Tₖ.ₖ₊₁)ᵀ
 
-    q = A  * uₖ  # Forms vₖ₊₁ : q ← Auₖ
-    p = Aᵀ * vₖ  # Forms uₖ₊₁ : p ← Aᵀvₖ
+    mul!(q, A , uₖ)  # Forms vₖ₊₁ : q ← Auₖ
+    mul!(p, Aᵀ, vₖ)  # Forms uₖ₊₁ : p ← Aᵀvₖ
 
     @kaxpy!(m, -γₖ, vₖ₋₁, q) # q ← q - γₖ * vₖ₋₁
     @kaxpy!(n, -βₖ, uₖ₋₁, p) # p ← p - βₖ * uₖ₋₁

--- a/src/variants.jl
+++ b/src/variants.jl
@@ -26,15 +26,15 @@ function wrap_preconditioners(kwargs, S)
 end
 
 # Variants where matrix-vector products with A and Aᵀ are required
-for fn in (:cgls, :cgne, :lnlq, :craig, :craigmr, :crls, :crmr, :lslq, :lsqr, :lsmr, :bilq, :qmr)
+for fn in (:cgls, :cgne, :lnlq, :craig, :craigmr, :crls, :crmr, :lslq, :lsqr, :lsmr)
   @eval begin
     $fn(A :: AbstractMatrix{T}, b :: AbstractVector{T}; kwargs...) where T <: AbstractFloat =
       $fn(PreallocatedLinearOperator(A, storagetype=ktypeof(b)), b; wrap_preconditioners(kwargs, ktypeof(b))...)
   end
 end
 
-# Variants for USYMLQ, USYMQR, TriCG, TriMR, TriLQR and BiLQR
-for fn in (:usymlq, :usymqr, :tricg, :trimr, :trilqr, :bilqr)
+# Variants for TriCG, TriMR
+for fn in (:tricg, :trimr)
   @eval begin
     $fn(A :: AbstractMatrix{T}, b :: AbstractVector{T}, c :: AbstractVector{T}; kwargs...) where T <: AbstractFloat =
       $fn(PreallocatedLinearOperator(A, storagetype=ktypeof(b)), b, c; wrap_preconditioners(kwargs, ktypeof(b))...)


### PR DESCRIPTION
It concerns Krylov methods that are not preconditioned (`USYMLQ`, `USYMQR`, `BILQ`, `QMR`, `BILQR` and `TRILQR`).