### PR TITLE
Fix dimensions of u and v in LNLQ, CRAIG and CRAIGMR

### DIFF
--- a/src/craig.jl
+++ b/src/craig.jl
@@ -107,8 +107,8 @@ function craig!(solver :: CraigSolver{T,S}, A, b :: AbstractVector{T};
   sqd && (λ = one(T))
 
   # Set up workspace.
-  !MisI   && isnothing(solver.u)  && (solver.u  = S(undef, n))
-  !NisI   && isnothing(solver.v)  && (solver.v  = S(undef, m))
+  !MisI   && isnothing(solver.u)  && (solver.u  = S(undef, m))
+  !NisI   && isnothing(solver.v)  && (solver.v  = S(undef, n))
   (λ > 0) && isnothing(solver.w2) && (solver.w2 = S(undef, n))
   x, Nv, Aᵀu, y, w, Mu, Av, w2 = solver.x, solver.Nv, solver.Aᵀu, solver.y, solver.w, solver.Mu, solver.Av, solver.w2
   u = MisI ? Mu : solver.u

--- a/src/craigmr.jl
+++ b/src/craigmr.jl
@@ -96,8 +96,8 @@ function craigmr!(solver :: CraigmrSolver{T,S}, A, b :: AbstractVector{T};
   Aᵀ = A'
 
   # Set up workspace.
-  !MisI && isnothing(solver.u) && (solver.u = S(undef, n))
-  !NisI && isnothing(solver.v) && (solver.v = S(undef, m))
+  !MisI && isnothing(solver.u) && (solver.u = S(undef, m))
+  !NisI && isnothing(solver.v) && (solver.v = S(undef, n))
   x, Nv, Aᵀu, y, Mu, w, wbar, Av = solver.x, solver.Nv, solver.Aᵀu, solver.y, solver.Mu, solver.w, solver.wbar, solver.Av
   u = MisI ? Mu : solver.u
   v = NisI ? Nv : solver.v

--- a/src/lnlq.jl
+++ b/src/lnlq.jl
@@ -95,8 +95,8 @@ function lnlq!(solver :: LnlqSolver{T,S}, A, b :: AbstractVector{T};
   sqd && (λ = one(T))
 
   # Set up workspace.
-  !MisI   && isnothing(solver.u)  && (solver.u = S(undef, n))
-  !NisI   && isnothing(solver.v)  && (solver.v = S(undef, m))
+  !MisI   && isnothing(solver.u)  && (solver.u = S(undef, m))
+  !NisI   && isnothing(solver.v)  && (solver.v = S(undef, n))
   (λ > 0) && isnothing(solver.q)  && (solver.q = S(undef, n))
   x, Nv, Aᵀu, y, w̄, Mu, Av, q = solver.x, solver.Nv, solver.Aᵀu, solver.y, solver.w̄, solver.Mu, solver.Av, solver.q
   u = MisI ? Mu : solver.u


### PR DESCRIPTION
Fix #321 
@tmigot

I need to add new tests.
We only test the preconditioners M and N in these methods with square matrices A.