### PR TITLE
Update Project.toml and remove dependencies of LinearOperators.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,12 +4,10 @@ version = "0.7.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-LinearOperators = "5c8ed15e-5a4c-59e4-a42b-c7e8811fb125"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
-LinearOperators = "1.2"
 julia = "^1.3.0"
 
 [extras]

--- a/src/Krylov.jl
+++ b/src/Krylov.jl
@@ -1,6 +1,6 @@
 module Krylov
 
-using LinearOperators, LinearAlgebra, SparseArrays, Printf
+using LinearAlgebra, SparseArrays, Printf
 
 include("krylov_stats.jl")
 include("krylov_utils.jl")

--- a/src/bicgstab.jl
+++ b/src/bicgstab.jl
@@ -17,7 +17,7 @@ export bicgstab, bicgstab!
 
 """
     (x, stats) = bicgstab(A, b::AbstractVector{T}; c::AbstractVector{T}=b,
-                          M=opEye(), N=opEye(), atol::T=√eps(T), rtol::T=√eps(T),
+                          M=I, N=I, atol::T=√eps(T), rtol::T=√eps(T),
                           itmax::Int=0, verbose::Int=0, history::Bool=false) where T <: AbstractFloat
 
 Solve the square linear system Ax = b using the BICGSTAB method.
@@ -47,7 +47,7 @@ function bicgstab(A, b :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
 end
 
 function bicgstab!(solver :: BicgstabSolver{T,S}, A, b :: AbstractVector{T}; c :: AbstractVector{T}=b,
-                   M=opEye(), N=opEye(), atol :: T=√eps(T), rtol :: T=√eps(T),
+                   M=I, N=I, atol :: T=√eps(T), rtol :: T=√eps(T),
                    itmax :: Int=0, verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, S <: DenseVector{T}}
 
   n, m = size(A)
@@ -56,8 +56,8 @@ function bicgstab!(solver :: BicgstabSolver{T,S}, A, b :: AbstractVector{T}; c :
   (verbose > 0) && @printf("BICGSTAB: system of size %d\n", n)
 
   # Check M == Iₙ and N == Iₙ
-  MisI = isa(M, opEye) || (M == I)
-  NisI = isa(N, opEye) || (N == I)
+  MisI = (M == I)
+  NisI = (N == I)
 
   # Check type consistency
   eltype(A) == T || error("eltype(A) ≠ $T")

--- a/src/cg.jl
+++ b/src/cg.jl
@@ -18,7 +18,7 @@ export cg, cg!
 
 """
     (x, stats) = cg(A, b::AbstractVector{T};
-                    M=opEye(), atol::T=√eps(T), rtol::T=√eps(T),
+                    M=I, atol::T=√eps(T), rtol::T=√eps(T),
                     itmax::Int=0, radius::T=zero(T), linesearch::Bool=false,
                     verbose::Int=0, history::Bool=false) where T <: AbstractFloat
 
@@ -43,7 +43,7 @@ function cg(A, b :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
 end
 
 function cg!(solver :: CgSolver{T,S}, A, b :: AbstractVector{T};
-             M=opEye(), atol :: T=√eps(T), rtol :: T=√eps(T),
+             M=I, atol :: T=√eps(T), rtol :: T=√eps(T),
              itmax :: Int=0, radius :: T=zero(T), linesearch :: Bool=false,
              verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, S <: DenseVector{T}}
 
@@ -55,7 +55,7 @@ function cg!(solver :: CgSolver{T,S}, A, b :: AbstractVector{T};
   (verbose > 0) && @printf("CG: system of %d equations in %d variables\n", n, n)
 
   # Tests M == Iₙ
-  MisI = isa(M, opEye) || (M == I)
+  MisI = (M == I)
 
   # Check type consistency
   eltype(A) == T || error("eltype(A) ≠ $T")

--- a/src/cg_lanczos.jl
+++ b/src/cg_lanczos.jl
@@ -16,7 +16,7 @@ export cg_lanczos, cg_lanczos!
 
 """
     (x, stats) = cg_lanczos(A, b::AbstractVector{T};
-                            M=opEye(), atol::T=√eps(T), rtol::T=√eps(T), itmax::Int=0,
+                            M=I, atol::T=√eps(T), rtol::T=√eps(T), itmax::Int=0,
                             check_curvature::Bool=false, verbose::Int=0, history::Bool=false) where T <: AbstractFloat
 
 The Lanczos version of the conjugate gradient method to solve the
@@ -40,7 +40,7 @@ function cg_lanczos(A, b :: AbstractVector{T}; kwargs...) where T <: AbstractFlo
 end
 
 function cg_lanczos!(solver :: CgLanczosSolver{T,S}, A, b :: AbstractVector{T};
-                     M=opEye(), atol :: T=√eps(T), rtol :: T=√eps(T), itmax :: Int=0,
+                     M=I, atol :: T=√eps(T), rtol :: T=√eps(T), itmax :: Int=0,
                      check_curvature :: Bool=false, verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, S <: DenseVector{T}}
 
   n, m = size(A)
@@ -49,7 +49,7 @@ function cg_lanczos!(solver :: CgLanczosSolver{T,S}, A, b :: AbstractVector{T};
   (verbose > 0) && @printf("CG Lanczos: system of %d equations in %d variables\n", n, n)
 
   # Tests M == Iₙ
-  MisI = isa(M, opEye) || (M == I)
+  MisI = (M == I)
 
   # Check type consistency
   eltype(A) == T || error("eltype(A) ≠ $T")
@@ -146,7 +146,7 @@ end
 
 """
     (x, stats) = cg_lanczos(A, b::AbstractVector{T}, shifts::AbstractVector{T};
-                            M=opEye(), atol::T=√eps(T), rtol::T=√eps(T), itmax::Int=0,
+                            M=I, atol::T=√eps(T), rtol::T=√eps(T), itmax::Int=0,
                             check_curvature::Bool=false, verbose::Int=0, history::Bool=false) where T <: AbstractFloat
 
 The Lanczos version of the conjugate gradient method to solve a family
@@ -165,7 +165,7 @@ function cg_lanczos(A, b :: AbstractVector{T}, shifts :: AbstractVector{T}; kwar
 end
 
 function cg_lanczos!(solver :: CgLanczosShiftSolver{T,S}, A, b :: AbstractVector{T}, shifts :: AbstractVector{T};
-                     M=opEye(), atol :: T=√eps(T), rtol :: T=√eps(T), itmax :: Int=0,
+                     M=I, atol :: T=√eps(T), rtol :: T=√eps(T), itmax :: Int=0,
                      check_curvature :: Bool=false, verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, S <: DenseVector{T}}
 
   n, m = size(A)
@@ -176,7 +176,7 @@ function cg_lanczos!(solver :: CgLanczosShiftSolver{T,S}, A, b :: AbstractVector
   (verbose > 0) && @printf("CG Lanczos: system of %d equations in %d variables with %d shifts\n", n, n, nshifts)
 
   # Tests M == Iₙ
-  MisI = isa(M, opEye) || (M == I)
+  MisI = (M == I)
 
   # Check type consistency
   eltype(A) == T || error("eltype(A) ≠ $T")

--- a/src/cgls.jl
+++ b/src/cgls.jl
@@ -31,7 +31,7 @@ export cgls, cgls!
 
 """
     (x, stats) = cgls(A, b::AbstractVector{T};
-                      M=opEye(), λ::T=zero(T), atol::T=√eps(T), rtol::T=√eps(T),
+                      M=I, λ::T=zero(T), atol::T=√eps(T), rtol::T=√eps(T),
                       radius::T=zero(T), itmax::Int=0, verbose::Int=0, history::Bool=false) where T <: AbstractFloat
 
 Solve the regularized linear least-squares problem
@@ -60,7 +60,7 @@ function cgls(A, b :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
 end
 
 function cgls!(solver :: CglsSolver{T,S}, A, b :: AbstractVector{T};
-               M=opEye(), λ :: T=zero(T), atol :: T=√eps(T), rtol :: T=√eps(T),
+               M=I, λ :: T=zero(T), atol :: T=√eps(T), rtol :: T=√eps(T),
                radius :: T=zero(T), itmax :: Int=0, verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, S <: DenseVector{T}}
 
   m, n = size(A)
@@ -68,7 +68,7 @@ function cgls!(solver :: CglsSolver{T,S}, A, b :: AbstractVector{T};
   (verbose > 0) && @printf("CGLS: system of %d equations in %d variables\n", m, n)
 
   # Tests M == Iₙ
-  MisI = isa(M, opEye) || (M == I)
+  MisI = (M == I)
 
   # Check type consistency
   eltype(A) == T || error("eltype(A) ≠ $T")

--- a/src/cgne.jl
+++ b/src/cgne.jl
@@ -31,7 +31,7 @@ export cgne, cgne!
 
 """
     (x, stats) = cgne(A, b::AbstractVector{T};
-                      M=opEye(), λ::T=zero(T), atol::T=√eps(T), rtol::T=√eps(T),
+                      M=I, λ::T=zero(T), atol::T=√eps(T), rtol::T=√eps(T),
                       itmax::Int=0, verbose::Int=0, history::Bool=false) where T <: AbstractFloat
 
 Solve the consistent linear system
@@ -69,7 +69,7 @@ function cgne(A, b :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
 end
 
 function cgne!(solver :: CgneSolver{T,S}, A, b :: AbstractVector{T};
-               M=opEye(), λ :: T=zero(T), atol :: T=√eps(T), rtol :: T=√eps(T),
+               M=I, λ :: T=zero(T), atol :: T=√eps(T), rtol :: T=√eps(T),
                itmax :: Int=0, verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, S <: DenseVector{T}}
 
   m, n = size(A)
@@ -77,7 +77,7 @@ function cgne!(solver :: CgneSolver{T,S}, A, b :: AbstractVector{T};
   (verbose > 0) && @printf("CGNE: system of %d equations in %d variables\n", m, n)
 
   # Tests M == Iₙ
-  MisI = isa(M, opEye) || (M == I)
+  MisI = (M == I)
 
   # Check type consistency
   eltype(A) == T || error("eltype(A) ≠ $T")

--- a/src/cgs.jl
+++ b/src/cgs.jl
@@ -12,7 +12,7 @@ export cgs, cgs!
 
 """
     (x, stats) = cgs(A, b::AbstractVector{T}; c::AbstractVector{T}=b,
-                     M=opEye(), N=opEye(), atol::T=√eps(T), rtol::T=√eps(T),
+                     M=I, N=I, atol::T=√eps(T), rtol::T=√eps(T),
                      itmax::Int=0, verbose::Int=0, history::Bool=false) where T <: AbstractFloat
 
 Solve the consistent linear system Ax = b using conjugate gradient squared algorithm.
@@ -44,7 +44,7 @@ function cgs(A, b :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
 end
 
 function cgs!(solver :: CgsSolver{T,S}, A, b :: AbstractVector{T}; c :: AbstractVector{T}=b,
-              M=opEye(), N=opEye(), atol :: T=√eps(T), rtol :: T=√eps(T),
+              M=I, N=I, atol :: T=√eps(T), rtol :: T=√eps(T),
               itmax :: Int=0, verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, S <: DenseVector{T}}
 
   m, n = size(A)
@@ -53,8 +53,8 @@ function cgs!(solver :: CgsSolver{T,S}, A, b :: AbstractVector{T}; c :: Abstract
   (verbose > 0) && @printf("CGS: system of size %d\n", n)
 
   # Check M == Iₙ and N == Iₙ
-  MisI = isa(M, opEye) || (M == I)
-  NisI = isa(N, opEye) || (N == I)
+  MisI = (M == I)
+  NisI = (N == I)
 
   # Check type consistency
   eltype(A) == T || error("eltype(A) ≠ $T")

--- a/src/cr.jl
+++ b/src/cr.jl
@@ -13,7 +13,7 @@ export cr, cr!
 
 """
     (x, stats) = cr(A, b::AbstractVector{T};
-                    M=opEye(), atol::T=√eps(T), rtol::T=√eps(T), γ::T=√eps(T), itmax::Int=0,
+                    M=I, atol::T=√eps(T), rtol::T=√eps(T), γ::T=√eps(T), itmax::Int=0,
                     radius::T=zero(T), verbose::Int=0, linesearch::Bool=false, history::Bool=false) where T <: AbstractFloat
 
 A truncated version of Stiefel’s Conjugate Residual method to solve the symmetric linear system Ax = b or the least-squares problem min ‖b - Ax‖.
@@ -38,7 +38,7 @@ function cr(A, b :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
 end
 
 function cr!(solver :: CrSolver{T,S}, A, b :: AbstractVector{T};
-             M=opEye(), atol :: T=√eps(T), rtol :: T=√eps(T), γ :: T=√eps(T), itmax :: Int=0,
+             M=I, atol :: T=√eps(T), rtol :: T=√eps(T), γ :: T=√eps(T), itmax :: Int=0,
              radius :: T=zero(T), verbose :: Int=0, linesearch :: Bool=false, history :: Bool=false) where {T <: AbstractFloat, S <: DenseVector{T}}
 
   linesearch && (radius > 0) && error("'linesearch' set to 'true' but radius > 0")
@@ -47,7 +47,7 @@ function cr!(solver :: CrSolver{T,S}, A, b :: AbstractVector{T};
   (verbose > 0) && @printf("CR: system of %d equations in %d variables\n", n, n)
 
   # Tests M == Iₙ
-  MisI = isa(M, opEye) || (M == I)
+  MisI = (M == I)
 
   # Check type consistency
   eltype(A) == T || error("eltype(A) ≠ $T")

--- a/src/craig.jl
+++ b/src/craig.jl
@@ -35,7 +35,7 @@ export craig, craig!
 
 """
     (x, y, stats) = craig(A, b::AbstractVector{T};
-                          M=opEye(), N=opEye(), sqd::Bool=false, λ::T=zero(T), atol::T=√eps(T),
+                          M=I, N=I, sqd::Bool=false, λ::T=zero(T), atol::T=√eps(T),
                           btol::T=√eps(T), rtol::T=√eps(T), conlim::T=1/√eps(T), itmax::Int=0,
                           verbose::Int=0, transfer_to_lsqr::Bool=false, history::Bool=false) where T <: AbstractFloat
 
@@ -82,7 +82,7 @@ function craig(A, b :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
 end
 
 function craig!(solver :: CraigSolver{T,S}, A, b :: AbstractVector{T};
-                M=opEye(), N=opEye(), sqd :: Bool=false, λ :: T=zero(T), atol :: T=√eps(T),
+                M=I, N=I, sqd :: Bool=false, λ :: T=zero(T), atol :: T=√eps(T),
                 btol :: T=√eps(T), rtol :: T=√eps(T), conlim :: T=1/√eps(T), itmax :: Int=0,
                 verbose :: Int=0, transfer_to_lsqr :: Bool=false, history :: Bool=false) where {T <: AbstractFloat, S <: DenseVector{T}}
 
@@ -91,8 +91,8 @@ function craig!(solver :: CraigSolver{T,S}, A, b :: AbstractVector{T};
   (verbose > 0) && @printf("CRAIG: system of %d equations in %d variables\n", m, n)
 
   # Tests M == Iₘ and N == Iₙ
-  MisI = isa(M, opEye) || (M == I)
-  NisI = isa(N, opEye) || (N == I)
+  MisI = (M == I)
+  NisI = (N == I)
 
   # Check type consistency
   eltype(A) == T || error("eltype(A) ≠ $T")

--- a/src/craigmr.jl
+++ b/src/craigmr.jl
@@ -29,7 +29,7 @@ export craigmr, craigmr!
 
 """
     (x, y, stats) = craigmr(A, b::AbstractVector{T};
-                            M=opEye(), N=opEye(), λ::T=zero(T), atol::T=√eps(T),
+                            M=I, N=I, λ::T=zero(T), atol::T=√eps(T),
                             rtol::T=√eps(T), itmax::Int=0, verbose::Int=0, history::Bool=false) where T <: AbstractFloat
 
 Solve the consistent linear system
@@ -75,7 +75,7 @@ function craigmr(A, b :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
 end
 
 function craigmr!(solver :: CraigmrSolver{T,S}, A, b :: AbstractVector{T};
-                  M=opEye(), N=opEye(), λ :: T=zero(T), atol :: T=√eps(T),
+                  M=I, N=I, λ :: T=zero(T), atol :: T=√eps(T),
                   rtol :: T=√eps(T), itmax :: Int=0, verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, S <: DenseVector{T}}
 
   m, n = size(A)
@@ -83,8 +83,8 @@ function craigmr!(solver :: CraigmrSolver{T,S}, A, b :: AbstractVector{T};
   (verbose > 0) && @printf("CRAIGMR: system of %d equations in %d variables\n", m, n)
 
   # Tests M == Iₘ and N == Iₙ
-  MisI = isa(M, opEye) || (M == I)
-  NisI = isa(N, opEye) || (N == I)
+  MisI = (M == I)
+  NisI = (N == I)
 
   # Check type consistency
   eltype(A) == T || error("eltype(A) ≠ $T")

--- a/src/crls.jl
+++ b/src/crls.jl
@@ -23,7 +23,7 @@ export crls, crls!
 
 """
     (x, stats) = crls(A, b::AbstractVector{T};
-                      M=opEye(), λ::T=zero(T), atol::T=√eps(T), rtol::T=√eps(T),
+                      M=I, λ::T=zero(T), atol::T=√eps(T), rtol::T=√eps(T),
                       radius::T=zero(T), itmax::Int=0, verbose::Int=0, history::Bool=false) where T <: AbstractFloat
 
 Solve the linear least-squares problem
@@ -51,7 +51,7 @@ function crls(A, b :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
 end
 
 function crls!(solver :: CrlsSolver{T,S}, A, b :: AbstractVector{T};
-               M=opEye(), λ :: T=zero(T), atol :: T=√eps(T), rtol :: T=√eps(T),
+               M=I, λ :: T=zero(T), atol :: T=√eps(T), rtol :: T=√eps(T),
                radius :: T=zero(T), itmax :: Int=0, verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, S <: DenseVector{T}}
 
   m, n = size(A)
@@ -59,7 +59,7 @@ function crls!(solver :: CrlsSolver{T,S}, A, b :: AbstractVector{T};
   (verbose > 0) && @printf("CRLS: system of %d equations in %d variables\n", m, n)
 
   # Tests M == Iₙ
-  MisI = isa(M, opEye) || (M == I)
+  MisI = (M == I)
 
   # Check type consistency
   eltype(A) == T || error("eltype(A) ≠ $T")

--- a/src/crmr.jl
+++ b/src/crmr.jl
@@ -29,7 +29,7 @@ export crmr, crmr!
 
 """
     (x, stats) = crmr(A, b::AbstractVector{T};
-                      M=opEye(), λ::T=zero(T), atol::T=√eps(T),
+                      M=I, λ::T=zero(T), atol::T=√eps(T),
                       rtol::T=√eps(T), itmax::Int=0, verbose::Int=0, history::Bool=false) where T <: AbstractFloat
 
 Solve the consistent linear system
@@ -67,7 +67,7 @@ function crmr(A, b :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
 end
 
 function crmr!(solver :: CrmrSolver{T,S}, A, b :: AbstractVector{T};
-               M=opEye(), λ :: T=zero(T), atol :: T=√eps(T),
+               M=I, λ :: T=zero(T), atol :: T=√eps(T),
                rtol :: T=√eps(T), itmax :: Int=0, verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, S <: DenseVector{T}}
 
   m, n = size(A)
@@ -75,7 +75,7 @@ function crmr!(solver :: CrmrSolver{T,S}, A, b :: AbstractVector{T};
   (verbose > 0) && @printf("CRMR: system of %d equations in %d variables\n", m, n)
 
   # Tests M == Iₙ
-  MisI = isa(M, opEye) || (M == I)
+  MisI = (M == I)
 
   # Check type consistency
   eltype(A) == T || error("eltype(A) ≠ $T")

--- a/src/diom.jl
+++ b/src/diom.jl
@@ -12,7 +12,7 @@ export diom, diom!
 
 """
     (x, stats) = diom(A, b::AbstractVector{T};
-                      M=opEye(), N=opEye(), atol::T=√eps(T), rtol::T=√eps(T), itmax::Int=0,
+                      M=I, N=I, atol::T=√eps(T), rtol::T=√eps(T), itmax::Int=0,
                       memory::Int=20, pivoting::Bool=false, verbose::Int=0, history::Bool=false) where T <: AbstractFloat
 
 Solve the consistent linear system Ax = b using direct incomplete orthogonalization method.
@@ -37,7 +37,7 @@ function diom(A, b :: AbstractVector{T}; memory :: Int=20, kwargs...) where T <:
 end
 
 function diom!(solver :: DiomSolver{T,S}, A, b :: AbstractVector{T};
-               M=opEye(), N=opEye(), atol :: T=√eps(T), rtol :: T=√eps(T), itmax :: Int=0,
+               M=I, N=I, atol :: T=√eps(T), rtol :: T=√eps(T), itmax :: Int=0,
                pivoting :: Bool=false, verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, S <: DenseVector{T}}
 
   m, n = size(A)
@@ -46,8 +46,8 @@ function diom!(solver :: DiomSolver{T,S}, A, b :: AbstractVector{T};
   (verbose > 0) && @printf("DIOM: system of size %d\n", n)
 
   # Check M == Iₙ and N == Iₙ
-  MisI = isa(M, opEye) || (M == I)
-  NisI = isa(N, opEye) || (N == I)
+  MisI = (M == I)
+  NisI = (N == I)
 
   # Check type consistency
   eltype(A) == T || error("eltype(A) ≠ $T")

--- a/src/dqgmres.jl
+++ b/src/dqgmres.jl
@@ -12,7 +12,7 @@ export dqgmres, dqgmres!
 
 """
     (x, stats) = dqgmres(A, b::AbstractVector{T};
-                         M=opEye(), N=opEye(), atol::T=√eps(T), rtol::T=√eps(T),
+                         M=I, N=I, atol::T=√eps(T), rtol::T=√eps(T),
                          itmax::Int=0, memory::Int=20, verbose::Int=0, history::Bool=false) where T <: AbstractFloat
 
 Solve the consistent linear system Ax = b using DQGMRES method.
@@ -35,7 +35,7 @@ function dqgmres(A, b :: AbstractVector{T}; memory :: Int=20, kwargs...) where T
 end
 
 function dqgmres!(solver :: DqgmresSolver{T,S}, A, b :: AbstractVector{T};
-                  M=opEye(), N=opEye(), atol :: T=√eps(T), rtol :: T=√eps(T),
+                  M=I, N=I, atol :: T=√eps(T), rtol :: T=√eps(T),
                   itmax :: Int=0, verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, S <: DenseVector{T}}
 
   m, n = size(A)
@@ -44,8 +44,8 @@ function dqgmres!(solver :: DqgmresSolver{T,S}, A, b :: AbstractVector{T};
   (verbose > 0) && @printf("DQGMRES: system of size %d\n", n)
 
   # Check M == Iₙ and N == Iₙ
-  MisI = isa(M, opEye) || (M == I)
-  NisI = isa(N, opEye) || (N == I)
+  MisI = (M == I)
+  NisI = (N == I)
 
   # Check type consistency
   eltype(A) == T || error("eltype(A) ≠ $T")

--- a/src/lnlq.jl
+++ b/src/lnlq.jl
@@ -26,7 +26,7 @@ export lnlq, lnlq!
 
 """
     (x, y, stats) = lnlq(A, b::AbstractVector{T};
-                         M=opEye(), N=opEye(), sqd::Bool=false, λ::T=zero(T),
+                         M=I, N=I, sqd::Bool=false, λ::T=zero(T),
                          atol::T=√eps(T), rtol::T=√eps(T), itmax::Int=0,
                          transfer_to_craig::Bool=true, verbose::Int=0, history::Bool=false) where T <: AbstractFloat
 
@@ -70,7 +70,7 @@ function lnlq(A, b :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
 end
 
 function lnlq!(solver :: LnlqSolver{T,S}, A, b :: AbstractVector{T};
-               M=opEye(), N=opEye(), sqd :: Bool=false, λ :: T=zero(T),
+               M=I, N=I, sqd :: Bool=false, λ :: T=zero(T),
                atol :: T=√eps(T), rtol :: T=√eps(T), itmax :: Int=0,
                transfer_to_craig :: Bool=true, verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, S <: DenseVector{T}}
 
@@ -79,8 +79,8 @@ function lnlq!(solver :: LnlqSolver{T,S}, A, b :: AbstractVector{T};
   (verbose > 0) && @printf("LNLQ: system of %d equations in %d variables\n", m, n)
 
   # Tests M == Iₘ and N == Iₙ
-  MisI = isa(M, opEye) || (M == I)
-  NisI = isa(N, opEye) || (N == I)
+  MisI = (M == I)
+  NisI = (N == I)
 
   # Check type consistency
   eltype(A) == T || error("eltype(A) ≠ $T")

--- a/src/lslq.jl
+++ b/src/lslq.jl
@@ -7,7 +7,7 @@ export lslq, lslq!
 """
     (x_lq, x_cg, err_lbnds, err_ubnds_lq, err_ubnds_cg, stats) =
         lslq(A, b::AbstractVector{T};
-             M=opEye(), N=opEye(), sqd::Bool=false, λ::T=zero(T),
+             M=I, N=I, sqd::Bool=false, λ::T=zero(T),
              atol::T=√eps(T), btol::T=√eps(T), etol::T=√eps(T),
              window::Int=5, utol::T=√eps(T), itmax::Int=0,
              σ::T=zero(T), conlim::T=1/√eps(T), verbose::Int=0, history::Bool=false) where T <: AbstractFloat
@@ -38,8 +38,8 @@ but is more stable.
 
 #### Optional arguments
 
-* `M::AbstractLinearOperator=opEye()`: a symmetric and positive definite dual preconditioner
-* `N::AbstractLinearOperator=opEye()`: a symmetric and positive definite primal preconditioner
+* `M::AbstractLinearOperator=I`: a symmetric and positive definite dual preconditioner
+* `N::AbstractLinearOperator=I`: a symmetric and positive definite primal preconditioner
 * `sqd::Bool=false` indicates whether or not we are solving a symmetric and quasi-definite augmented system
 
 If `sqd = true`, we solve the symmetric and quasi-definite system
@@ -109,7 +109,7 @@ function lslq(A, b :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
 end
 
 function lslq!(solver :: LslqSolver{T,S}, A, b :: AbstractVector{T};
-               M=opEye(), N=opEye(), sqd :: Bool=false, λ :: T=zero(T),
+               M=I, N=I, sqd :: Bool=false, λ :: T=zero(T),
                atol :: T=√eps(T), btol :: T=√eps(T), etol :: T=√eps(T),
                window :: Int=5, utol :: T=√eps(T), itmax :: Int=0,
                σ :: T=zero(T), conlim :: T=1/√eps(T), verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, S <: DenseVector{T}}
@@ -119,8 +119,8 @@ function lslq!(solver :: LslqSolver{T,S}, A, b :: AbstractVector{T};
   (verbose > 0) && @printf("LSLQ: system of %d equations in %d variables\n", m, n)
 
   # Tests M == Iₙ and N == Iₘ
-  MisI = isa(M, opEye) || (M == I)
-  NisI = isa(N, opEye) || (N == I)
+  MisI = (M == I)
+  NisI = (N == I)
 
   # Check type consistency
   eltype(A) == T || error("eltype(A) ≠ $T")

--- a/src/lsmr.jl
+++ b/src/lsmr.jl
@@ -27,7 +27,7 @@ export lsmr, lsmr!
 
 """
     (x, stats) = lsmr(A, b::AbstractVector{T};
-                      M=opEye(), N=opEye(), sqd::Bool=false,
+                      M=I, N=I, sqd::Bool=false,
                       λ::T=zero(T), axtol::T=√eps(T), btol::T=√eps(T),
                       atol::T=zero(T), rtol::T=zero(T),
                       etol::T=√eps(T), window::Int=5,
@@ -78,7 +78,7 @@ function lsmr(A, b :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
 end
 
 function lsmr!(solver :: LsmrSolver{T,S}, A, b :: AbstractVector{T};
-               M=opEye(), N=opEye(), sqd :: Bool=false,
+               M=I, N=I, sqd :: Bool=false,
                λ :: T=zero(T), axtol :: T=√eps(T), btol :: T=√eps(T),
                atol :: T=zero(T), rtol :: T=zero(T),
                etol :: T=√eps(T), window :: Int=5,
@@ -90,8 +90,8 @@ function lsmr!(solver :: LsmrSolver{T,S}, A, b :: AbstractVector{T};
   (verbose > 0) && @printf("LSMR: system of %d equations in %d variables\n", m, n)
 
   # Tests M == Iₙ and N == Iₘ
-  MisI = isa(M, opEye) || (M == I)
-  NisI = isa(N, opEye) || (N == I)
+  MisI = (M == I)
+  NisI = (N == I)
 
   # Check type consistency
   eltype(A) == T || error("eltype(A) ≠ $T")

--- a/src/lsqr.jl
+++ b/src/lsqr.jl
@@ -27,7 +27,7 @@ export lsqr, lsqr!
 
 """
     (x, stats) = lsqr(A, b::AbstractVector{T};
-                      M=opEye(), N=opEye(), sqd::Bool=false,
+                      M=I, N=I, sqd::Bool=false,
                       λ::T=zero(T), axtol::T=√eps(T), btol::T=√eps(T),
                       atol::T=zero(T), rtol::T=zero(T),
                       etol::T=√eps(T), window::Int=5,
@@ -78,7 +78,7 @@ function lsqr(A, b :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
 end
 
 function lsqr!(solver :: LsqrSolver{T,S}, A, b :: AbstractVector{T};
-               M=opEye(), N=opEye(), sqd :: Bool=false,
+               M=I, N=I, sqd :: Bool=false,
                λ :: T=zero(T), axtol :: T=√eps(T), btol :: T=√eps(T),
                atol :: T=zero(T), rtol :: T=zero(T),
                etol :: T=√eps(T), window :: Int=5,
@@ -90,8 +90,8 @@ function lsqr!(solver :: LsqrSolver{T,S}, A, b :: AbstractVector{T};
   (verbose > 0) && @printf("LSQR: system of %d equations in %d variables\n", m, n)
 
   # Tests M == Iₙ and N == Iₘ
-  MisI = isa(M, opEye) || (M == I)
-  NisI = isa(N, opEye) || (N == I)
+  MisI = (M == I)
+  NisI = (N == I)
 
   # Check type consistency
   eltype(A) == T || error("eltype(A) ≠ $T")

--- a/src/minres.jl
+++ b/src/minres.jl
@@ -24,7 +24,7 @@ export minres, minres!
 
 """
     (x, stats) = minres(A, b::AbstractVector{T};
-                        M=opEye(), λ::T=zero(T), atol::T=√eps(T)/100,
+                        M=I, λ::T=zero(T), atol::T=√eps(T)/100,
                         rtol::T=√eps(T)/100, ratol :: T=zero(T), 
                         rrtol :: T=zero(T), etol::T=√eps(T),
                         window::Int=5, itmax::Int=0, conlim::T=1/√eps(T),
@@ -60,7 +60,7 @@ function minres(A, b :: AbstractVector{T}; window :: Int=5, kwargs...) where T <
 end
 
 function minres!(solver :: MinresSolver{T,S}, A, b :: AbstractVector{T};
-                 M=opEye(), λ :: T=zero(T), atol :: T=√eps(T)/100, rtol :: T=√eps(T)/100, 
+                 M=I, λ :: T=zero(T), atol :: T=√eps(T)/100, rtol :: T=√eps(T)/100, 
                  ratol :: T=zero(T), rrtol :: T=zero(T), etol :: T=√eps(T),
                  itmax :: Int=0, conlim :: T=1/√eps(T),
                  verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, S <: DenseVector{T}}
@@ -71,7 +71,7 @@ function minres!(solver :: MinresSolver{T,S}, A, b :: AbstractVector{T};
   (verbose > 0) && @printf("MINRES: system of size %d\n", n)
 
   # Tests M == Iₙ
-  MisI = isa(M, opEye) || (M == I)
+  MisI = (M == I)
 
   # Check type consistency
   eltype(A) == T || error("eltype(A) ≠ $T")

--- a/src/minres_qlp.jl
+++ b/src/minres_qlp.jl
@@ -18,7 +18,7 @@ export minres_qlp, minres_qlp!
 
 """
     (x, stats) = minres_qlp(A, b::AbstractVector{T};
-                            M=opEye(), atol::T=√eps(T), rtol::T=√eps(T), λ::T=zero(T),
+                            M=I, atol::T=√eps(T), rtol::T=√eps(T), λ::T=zero(T),
                             itmax::Int=0, verbose::Int=0, history::Bool=false) where T <: AbstractFloat
 
 MINRES-QLP is the only method based on the Lanczos process that returns the minimum-norm
@@ -41,7 +41,7 @@ function minres_qlp(A, b :: AbstractVector{T}; kwargs...) where T <: AbstractFlo
 end
 
 function minres_qlp!(solver :: MinresQlpSolver{T,S}, A, b :: AbstractVector{T};
-                     M=opEye(), atol :: T=√eps(T), rtol :: T=√eps(T), λ ::T=zero(T),
+                     M=I, atol :: T=√eps(T), rtol :: T=√eps(T), λ ::T=zero(T),
                      itmax :: Int=0, verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, S <: DenseVector{T}}
 
   n, m = size(A)
@@ -50,7 +50,7 @@ function minres_qlp!(solver :: MinresQlpSolver{T,S}, A, b :: AbstractVector{T};
   (verbose > 0) && @printf("MINRES-QLP: system of size %d\n", n)
 
   # Tests M == Iₙ
-  MisI = isa(M, opEye) || (M == I)
+  MisI = (M == I)
 
   # Check type consistency
   eltype(A) == T || error("eltype(A) ≠ $T")

--- a/src/symmlq.jl
+++ b/src/symmlq.jl
@@ -14,7 +14,7 @@ export symmlq, symmlq!
 
 """
     (x, stats) = symmlq(A, b::AbstractVector{T};
-                        M=opEye(), λ::T=zero(T), transfer_to_cg::Bool=true,
+                        M=I, λ::T=zero(T), transfer_to_cg::Bool=true,
                         λest::T=zero(T), atol::T=√eps(T), rtol::T=√eps(T),
                         etol::T=√eps(T), window::Int=0, itmax::Int=0,
                         conlim::T=1/√eps(T), verbose::Int=0, history::Bool=false) where T <: AbstractFloat
@@ -41,7 +41,7 @@ function symmlq(A, b :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
 end
 
 function symmlq!(solver :: SymmlqSolver{T,S}, A, b :: AbstractVector{T};
-                 M=opEye(), λ :: T=zero(T), transfer_to_cg :: Bool=true,
+                 M=I, λ :: T=zero(T), transfer_to_cg :: Bool=true,
                  λest :: T=zero(T), atol :: T=√eps(T), rtol :: T=√eps(T),
                  etol :: T=√eps(T), window :: Int=0, itmax :: Int=0,
                  conlim :: T=1/√eps(T), verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, S <: DenseVector{T}}
@@ -52,7 +52,7 @@ function symmlq!(solver :: SymmlqSolver{T,S}, A, b :: AbstractVector{T};
   (verbose > 0) && @printf("SYMMLQ: system of size %d\n", n)
 
   # Tests M == Iₙ
-  MisI = isa(M, opEye) || (M == I)
+  MisI = (M == I)
 
   # Check type consistency
   eltype(A) == T || error("eltype(A) ≠ $T")

--- a/src/tricg.jl
+++ b/src/tricg.jl
@@ -13,7 +13,7 @@ export tricg, tricg!
 
 """
     (x, y, stats) = tricg(A, b::AbstractVector{T}, c::AbstractVector{T};
-                          M=opEye(), N=opEye(), atol::T=√eps(T), rtol::T=√eps(T),
+                          M=I, N=I, atol::T=√eps(T), rtol::T=√eps(T),
                           spd::Bool=false, snd::Bool=false, flip::Bool=false,
                           τ::T=one(T), ν::T=-one(T), itmax::Int=0, verbose::Int=0, history::Bool=false) where T <: AbstractFloat
 
@@ -56,7 +56,7 @@ function tricg(A, b :: AbstractVector{T}, c :: AbstractVector{T}; kwargs...) whe
 end
 
 function tricg!(solver :: TricgSolver{T,S}, A, b :: AbstractVector{T}, c :: AbstractVector{T};
-                M=opEye(), N=opEye(), atol :: T=√eps(T), rtol :: T=√eps(T),
+                M=I, N=I, atol :: T=√eps(T), rtol :: T=√eps(T),
                 spd :: Bool=false, snd :: Bool=false, flip :: Bool=false,
                 τ :: T=one(T), ν :: T=-one(T), itmax :: Int=0, verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, S <: DenseVector{T}}
 
@@ -71,8 +71,8 @@ function tricg!(solver :: TricgSolver{T,S}, A, b :: AbstractVector{T}, c :: Abst
   spd && snd  && error("The matrix cannot be SPD and SND")
 
   # Check M == Iₘ and N == Iₙ
-  MisI = isa(M, opEye) || (M == I)
-  NisI = isa(N, opEye) || (N == I)
+  MisI = (M == I)
+  NisI = (N == I)
 
   # Check type consistency
   eltype(A) == T || error("eltype(A) ≠ $T")

--- a/src/trimr.jl
+++ b/src/trimr.jl
@@ -13,7 +13,7 @@ export trimr, trimr!
 
 """
     (x, y, stats) = trimr(A, b::AbstractVector{T}, c::AbstractVector{T};
-                          M=opEye(), N=opEye(), atol::T=√eps(T), rtol::T=√eps(T),
+                          M=I, N=I, atol::T=√eps(T), rtol::T=√eps(T),
                           spd::Bool=false, snd::Bool=false, flip::Bool=false, sp::Bool=false,
                           τ::T=one(T), ν::T=-one(T), itmax::Int=0, verbose::Int=0, history::Bool=false) where T <: AbstractFloat
 
@@ -57,7 +57,7 @@ function trimr(A, b :: AbstractVector{T}, c :: AbstractVector{T}; kwargs...) whe
 end
 
 function trimr!(solver :: TrimrSolver{T,S}, A, b :: AbstractVector{T}, c :: AbstractVector{T};
-                M=opEye(), N=opEye(), atol :: T=√eps(T), rtol :: T=√eps(T),
+                M=I, N=I, atol :: T=√eps(T), rtol :: T=√eps(T),
                 spd :: Bool=false, snd :: Bool=false, flip :: Bool=false, sp :: Bool=false,
                 τ :: T=one(T), ν :: T=-one(T), itmax :: Int=0, verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, S <: DenseVector{T}}
 
@@ -75,8 +75,8 @@ function trimr!(solver :: TrimrSolver{T,S}, A, b :: AbstractVector{T}, c :: Abst
   sp  && flip && error("The matrix cannot be symmetric quasi-definite and a saddle-point !")
 
   # Check M == Iₘ and N == Iₙ
-  MisI = isa(M, opEye) || (M == I)
-  NisI = isa(N, opEye) || (N == I)
+  MisI = (M == I)
+  NisI = (N == I)
 
   # Check type consistency
   eltype(A) == T || error("eltype(A) ≠ $T")


### PR DESCRIPTION
@geoffroyleconte @abelsiqueira @dpo

Vectors inside KrylovSolvers used for the preconditioners or the regularization are `Union{S, Nothing}`.
Sometimes 16 extra bits are required for type inference.
To help Julia I added some `::S`.