### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # Krylov.jl: A Julia basket of hand-picked Krylov methods
 
-[![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.822073-blue.svg)](https://doi.org/10.5281/zenodo.822073)
-
-| **Documentation** | **Linux/macOS/Windows/FreeBSD** | **Coverage** |
-|:-----------------:|:-------------------------------:|:------------:|
-| [![docs-stable][docs-stable-img]][docs-stable-url] [![docs-dev][docs-dev-img]][docs-dev-url] | [![build-gh][build-gh-img]][build-gh-url] [![build-cirrus][build-cirrus-img]][build-cirrus-url] | [![codecov][codecov-img]][codecov-url] |
+| **Documentation** | **Linux/macOS/Windows/FreeBSD** | **Coverage** | **DOI** |
+|:-----------------:|:-------------------------------:|:------------:|:-------:|
+| [![docs-stable][docs-stable-img]][docs-stable-url] [![docs-dev][docs-dev-img]][docs-dev-url] | [![build-gh][build-gh-img]][build-gh-url] [![build-cirrus][build-cirrus-img]][build-cirrus-url] | [![codecov][codecov-img]][codecov-url] | [![doi][doi-img]][doi-url] |
 
 [docs-stable-img]: https://img.shields.io/badge/docs-stable-blue.svg
 [docs-stable-url]: https://JuliaSmoothOptimizers.github.io/Krylov.jl/stable
@@ -16,6 +14,12 @@
 [build-cirrus-url]: https://cirrus-ci.com/github/JuliaSmoothOptimizers/Krylov.jl
 [codecov-img]: https://codecov.io/gh/JuliaSmoothOptimizers/Krylov.jl/branch/master/graph/badge.svg
 [codecov-url]: https://app.codecov.io/gh/JuliaSmoothOptimizers/Krylov.jl
+[doi-img]: https://img.shields.io/badge/DOI-10.5281%2Fzenodo.822073-blue.svg
+[doi-url]: https://doi.org/10.5281/zenodo.822073
+
+## How to Cite
+
+If you use Krylov.jl in your work, please cite using the format given in [`CITATION.bib`](https://github.com/JuliaSmoothOptimizers/Krylov.jl/blob/master/CITATION.bib).
 
 ## Content
 
@@ -104,8 +108,3 @@ julia> ]
 pkg> add Krylov
 pkg> test Krylov
 ```
-
-## How to Cite
-
-If you use Krylov.jl in your work, please cite using the format given in [`CITATION.bib`](https://github.com/JuliaSmoothOptimizers/Krylov.jl/blob/master/CITATION.bib).
-


### PR DESCRIPTION
@dpo Can you synchronize Krylov.jl with Zenedo ?
The last release is `0.5.1`.
I can only update packages of `bbopt` organization.