### PR TITLE
Update CgLanczosShiftSolver

### DIFF
--- a/src/cg_lanczos.jl
+++ b/src/cg_lanczos.jl
@@ -160,7 +160,8 @@ A preconditioner M may be provided in the form of a linear operator and is
 assumed to be symmetric and positive definite.
 """
 function cg_lanczos(A, b :: AbstractVector{T}, shifts :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
-  solver = CgLanczosShiftSolver(A, b, shifts)
+  nshifts = length(shifts)
+  solver = CgLanczosShiftSolver(A, b, nshifts)
   cg_lanczos!(solver, A, b, shifts; kwargs...)
 end
 

--- a/src/krylov_solvers.jl
+++ b/src/krylov_solvers.jl
@@ -201,8 +201,8 @@ Type for storing the vectors required by the in-place version of CG-LANCZOS with
 
 The outer constructors
 
-    solver = CgLanczosShiftSolver(n, m, shifts, S)
-    solver = CgLanczosShiftSolver(A, b, shifts)
+    solver = CgLanczosShiftSolver(n, m, nshifts, S)
+    solver = CgLanczosShiftSolver(A, b, nshifts)
 
 may be used in order to create these vectors.
 """
@@ -222,8 +222,7 @@ mutable struct CgLanczosShiftSolver{T,S} <: KrylovSolver{T,S}
   converged  :: BitArray
   not_cv     :: BitArray
 
-  function CgLanczosShiftSolver(n, m, shifts, S)
-    nshifts    = length(shifts)
+  function CgLanczosShiftSolver(n, m, nshifts, S)
     T          = eltype(S)
     Mv         = S(undef, n)
     Mv_prev    = S(undef, n)
@@ -243,10 +242,10 @@ mutable struct CgLanczosShiftSolver{T,S} <: KrylovSolver{T,S}
     return solver
   end
 
-  function CgLanczosShiftSolver(A, b, shifts)
+  function CgLanczosShiftSolver(A, b, nshifts)
     n, m = size(A)
     S = ktypeof(b)
-    CgLanczosShiftSolver(n, m, shifts, S)
+    CgLanczosShiftSolver(n, m, nshifts, S)
   end
 end
 

--- a/test/test_alloc.jl
+++ b/test/test_alloc.jl
@@ -103,7 +103,7 @@ function test_alloc()
   actual_cg_lanczos_shift_bytes = @allocated cg_lanczos(A, b, shifts)
   @test actual_cg_lanczos_shift_bytes ≤ 1.02 * expected_cg_lanczos_shift_bytes
 
-  solver = CgLanczosShiftSolver(A, b, shifts)
+  solver = CgLanczosShiftSolver(A, b, nshifts)
   cg_lanczos!(solver, A, b, shifts)  # warmup
   inplace_cg_lanczos_shift_bytes = @allocated cg_lanczos!(solver, A, b, shifts)
   @test (VERSION < v"1.5") || (inplace_cg_lanczos_shift_bytes ≤ 356)

--- a/test/test_inplace.jl
+++ b/test/test_inplace.jl
@@ -7,13 +7,14 @@
   b   = Ao * ones(m) # Dimension n
   c   = Au * ones(n) # Dimension m
   mem = 10
-  shifts  = [1.0; 2.0; 3.0; 4.0; 5.0]
+  shifts = [1.0; 2.0; 3.0; 4.0; 5.0]
+  nshifts = 5
 
   cg_solver = CgSolver(n, n, Vector{Float64})
   symmlq_solver = SymmlqSolver(n, n, Vector{Float64})
   minres_solver = MinresSolver(n, n, Vector{Float64})
   cg_lanczos_solver = CgLanczosSolver(n, n, Vector{Float64})
-  cg_lanczos_shift_solver = CgLanczosShiftSolver(n, n, shifts, Vector{Float64})
+  cg_lanczos_shift_solver = CgLanczosShiftSolver(n, n, nshifts, Vector{Float64})
   diom_solver = DiomSolver(n, n, mem, Vector{Float64})
   dqgmres_solver = DqgmresSolver(n, n, mem, Vector{Float64})
   cr_solver = CrSolver(n, n, Vector{Float64})


### PR DESCRIPTION
It's more relevant to use a parameter `nshifts` instead of `shifts`. A user can create a `CgLanczosShiftSolver` before the `shifts` vector with this modification.