### PR TITLE
Estimate of the error in LNLQ

### DIFF
--- a/src/krylov_stats.jl
+++ b/src/krylov_stats.jl
@@ -74,18 +74,18 @@ mutable struct AdjointStats{T} <: KrylovStats{T}
 end
 
 """
-Type for statistics returned by adjoint systems solvers BiLQR and TriLQR, the attributes are:
+Type for statistics returned by the LNLQ method, the attributes are:
 - solved
-- inconsistent
 - residuals
+- error_with_bnd
 - error_bnd_x
 - error_bnd_y
 - status
 """
 mutable struct LNLQStats{T} <: KrylovStats{T}
   solved :: Bool
-  inconsistent :: Bool
   residuals :: Vector{T}
+  error_with_bnd :: Bool
   error_bnd_x :: Vector{T}
   error_bnd_y :: Vector{T}
   status :: String
@@ -100,7 +100,7 @@ special_fields = Dict(
   :Acond => "κ₂(A)",
 )
 
-for f in ["Simple", "Lanczos", "Symmlq", "Adjoint"]
+for f in ["Simple", "Lanczos", "Symmlq", "Adjoint", "LNLQ"]
   T = Meta.parse("Krylov." * f * "Stats{S}")
   @eval function show(io :: IO, stats :: $T) where S
     s  = $f * " stats\n"

--- a/src/krylov_stats.jl
+++ b/src/krylov_stats.jl
@@ -73,6 +73,24 @@ mutable struct AdjointStats{T} <: KrylovStats{T}
   status :: String
 end
 
+"""
+Type for statistics returned by adjoint systems solvers BiLQR and TriLQR, the attributes are:
+- solved
+- inconsistent
+- residuals
+- error_bnd_x
+- error_bnd_y
+- status
+"""
+mutable struct LNLQStats{T} <: KrylovStats{T}
+  solved :: Bool
+  inconsistent :: Bool
+  residuals :: Vector{T}
+  error_bnd_x :: Vector{T}
+  error_bnd_y :: Vector{T}
+  status :: String
+end
+
 import Base.show
 
 special_fields = Dict(

--- a/src/lnlq.jl
+++ b/src/lnlq.jl
@@ -60,6 +60,10 @@ In this case, M can still be specified and indicates the weighted norm in which 
 
 In this implementation, both the x and y-parts of the solution are returned.
 
+`etolx` and `etoly` are tolerances on the upper bound of the distance to the solution ‖x-xₛ‖ and ‖y-yₛ‖, respectively.
+The bound is valid if λ>0 or σₐ>0 where σₐ should be strictly smaller than the smallest positive singular value.
+For instance σₐ:=(1-1e-7)σₘᵢₙ .
+
 #### Reference
 
 * R. Estrin, D. Orban, M.A. Saunders, *LNLQ: An Iterative Method for Least-Norm Problems with an Error Minimization Property*, SIAM Journal on Matrix Analysis and Applications, 40(3), pp. 1102--1124, 2019.
@@ -70,8 +74,8 @@ function lnlq(A, b :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
 end
 
 function lnlq!(solver :: LnlqSolver{T,S}, A, b :: AbstractVector{T};
-               M=I, N=I, sqd :: Bool=false, λ :: T=zero(T),
-               atol :: T=√eps(T), rtol :: T=√eps(T), itmax :: Int=0,
+               M=I, N=I, sqd :: Bool=false, λ :: T=zero(T), σₐ :: T=zero(T),
+               atol :: T=√eps(T), rtol :: T=√eps(T), etolx :: T=√eps(T), etoly :: T=√eps(T), itmax :: Int=0,
                transfer_to_craig :: Bool=true, verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, S <: DenseVector{T}}
 
   m, n = size(A)
@@ -102,6 +106,9 @@ function lnlq!(solver :: LnlqSolver{T,S}, A, b :: AbstractVector{T};
   u = MisI ? Mu : solver.u
   v = NisI ? Nv : solver.v
 
+  # Set up parameter σₑₛₜ for the error estimate on x and y
+  σₑₛₜ = √(σₐ^2 + λ^2)
+
   # Initial solutions (x₀, y₀) and residual norm ‖r₀‖.
   x .= zero(T)
   y .= zero(T)
@@ -110,6 +117,7 @@ function lnlq!(solver :: LnlqSolver{T,S}, A, b :: AbstractVector{T};
   bNorm == 0 && return x, y, SimpleStats(true, false, [bNorm], T[], "x = 0 is a zero-residual solution")
 
   rNorms = history ? [bNorm] : T[]
+  xNorms, yNorms = T[], T[]
   ε = atol + rtol * bNorm
 
   iter = 0
@@ -191,6 +199,22 @@ function lnlq!(solver :: LnlqSolver{T,S}, A, b :: AbstractVector{T};
   tired = false
   status = "unknown"
 
+  if σₑₛₜ > 0
+    τtildeₖ = βₖ / σₑₛₜ
+    ζtildeₖ = τtildeₖ / σₑₛₜ
+    err_x = τtildeₖ
+    err_y = ζtildeₖ
+
+    solved_lq = err_x <= etolx || err_y <= etoly
+    history && push!(xNorms, err_x)
+    history && push!(yNorms, err_y)
+
+    complex_error_bnd = false
+
+    ρbar = -σₑₛₜ
+    csig = -1
+  end
+
   while !(solved_lq || solved_cg || tired)
 
     # Update of (xᵃᵘˣ)ₖ = Vₖtₖ
@@ -267,6 +291,28 @@ function lnlq!(solver :: LnlqSolver{T,S}, A, b :: AbstractVector{T};
       αhatₖ₊₁ = αₖ₊₁
     end
 
+    if σₑₛₜ > 0 && !complex_error_bnd
+      μbar = -csig * αhatₖ
+      ρ = √(ρbar^2 + αhatₖ^2)
+      csig = ρbar / ρ
+      ssig = αhatₖ / ρ
+      ρbar = ssig * μbar + csig * σₑₛₜ
+      μbar = -csig * βhatₖ₊₁
+      θ = βhatₖ₊₁ * csig / ρbar
+      ωdisc = σₑₛₜ^2 - σₑₛₜ * βhatₖ₊₁ * θ
+      if ωdisc < 0
+        complex_error_bnd = true
+      else
+        ω = √ωdisc
+        τtildeₖ = - τₖ * βhatₖ₊₁ / ω
+      end
+
+      ρ = √(ρbar^2 + βhatₖ₊₁^2)
+      csig = ρbar / ρ
+      ssig = βhatₖ₊₁ / ρ
+      ρbar = ssig * μbar + csig * σₑₛₜ
+    end
+
     # Continue the LQ factorization of (Lₖ₊₁)ᵀ.
     # [ηₖ ϵbarₖ βₖ₊₁] [1     0     0 ] = [ηₖ  ϵₖ     0    ]
     # [0    0   αₖ₊₁] [0   cₖ₊₁  sₖ₊₁]   [0  ηₖ₊₁  ϵbarₖ₊₁]
@@ -291,6 +337,41 @@ function lnlq!(solver :: LnlqSolver{T,S}, A, b :: AbstractVector{T};
 
     # Compute w̄ₖ₊₁
     @kaxpby!(m, -cₖ₊₁, u, sₖ₊₁, w̄)
+
+    if σₑₛₜ > 0 && !complex_error_bnd
+      if transfer_to_craig
+        disc_x = τtildeₖ^2 - τₖ₊₁^2
+        if disc_x < 0
+          complex_error_bnd = true
+        else
+          err_x = √disc_x
+        end
+      else
+        disc_xL = τtildeₖ^2 - τₖ₊₁^2 + (τₖ₊₁ - ηₖ₊₁ * ζₖ)^2
+        if disc_xL < 0
+          complex_error_bnd = true
+        else
+          err_x = √disc_xL
+        end
+      end
+      ηtildeₖ = ω * sₖ₊₁
+      ϵtildeₖ = -ω * cₖ₊₁
+      ζtildeₖ = (τtildeₖ - ηtildeₖ * ζₖ) / ϵtildeₖ
+      
+      if transfer_to_craig
+        disc_y = ζtildeₖ^2 - ζbarₖ₊₁^2 
+        if disc_y < 0
+          complex_error_bnd = true
+        else
+          err_y = √disc_y
+        end
+      else
+        err_y = abs(ζtildeₖ)
+      end
+
+      history && push!(xNorms, err_x)
+      history && push!(yNorms, err_y)
+    end
 
     # Compute residual norm ‖(rᴸ)ₖ‖ = |αₖ| * √((ϵbarₖζbarₖ)² + (βₖ₊₁sₖζₖ₋₁)²)
     if iter == 1
@@ -327,6 +408,13 @@ function lnlq!(solver :: LnlqSolver{T,S}, A, b :: AbstractVector{T};
     tired = iter ≥ itmax
     solved_lq = rNorm_lq ≤ ε
     solved_cg = transfer_to_craig && rNorm_cg ≤ ε
+    if σₑₛₜ > 0
+      if transfer_to_craig
+        solved_cg = solved_cg || err_x <= etolx || err_y <= etoly
+      else
+        solved_lq = solved_lq || err_x <= etolx || err_y <= etoly
+      end
+    end
     display(iter, verbose) && @printf("%5d  %7.1e\n", iter, rNorm_lq)
 
     # Update iteration index.
@@ -363,6 +451,6 @@ function lnlq!(solver :: LnlqSolver{T,S}, A, b :: AbstractVector{T};
   tired     && (status = "maximum number of iterations exceeded")
   solved_lq && (status = "solutions (xᴸ, yᴸ) good enough for the tolerances given")
   solved_cg && (status = "solutions (xᶜ, yᶜ) good enough for the tolerances given")
-  stats = SimpleStats(solved_lq || solved_cg, false, rNorms, T[], status)
+  stats = LNLQStats(solved_lq || solved_cg, false, rNorms, xNorms, yNorms, status)
   return (x, y, stats)
 end

--- a/test/test_alloc.jl
+++ b/test/test_alloc.jl
@@ -233,7 +233,7 @@ function test_alloc()
   solver = LnlqSolver(Au, c)
   lnlq!(solver, Au, c)  # warmup
   inplace_lnlq_bytes = @allocated lnlq!(solver, Au, c)
-  @test (VERSION < v"1.5") || (inplace_lnlq_bytes == 320)
+  @test (VERSION < v"1.5") || (inplace_lnlq_bytes == 304)
 
   # CRAIG needs:
   # - 3 n-vectors: x, v, Aᵀu

--- a/test/test_alloc.jl
+++ b/test/test_alloc.jl
@@ -233,7 +233,7 @@ function test_alloc()
   solver = LnlqSolver(Au, c)
   lnlq!(solver, Au, c)  # warmup
   inplace_lnlq_bytes = @allocated lnlq!(solver, Au, c)
-  @test (VERSION < v"1.5") || (inplace_lnlq_bytes == 208)
+  @test (VERSION < v"1.5") || (inplace_lnlq_bytes == 320)
 
   # CRAIG needs:
   # - 3 n-vectors: x, v, Aᵀu

--- a/test/test_lnlq.jl
+++ b/test/test_lnlq.jl
@@ -28,7 +28,7 @@
     @test(stats.solved)
     (xI, xmin, xmin_norm) = check_min_norm(A, b, x)
     @test(norm(xI - xmin) ≤ cond(A) * lnlq_tol * xmin_norm)
-    (xₛ, yₛ, stats) = lnlq(A, b, transfer_to_craig=transfer_to_craig, atol=0.0, rtol=0.0, σₐ=0.5)
+    (xₛ, yₛ, stats) = lnlq(A, b, transfer_to_craig=transfer_to_craig, atol=0.0, rtol=0.0, σ=0.5)
     (xI, xmin, xmin_norm) = check_min_norm(A, b, xₛ)
     @test(norm(xI - xmin) ≤ cond(A) * lnlq_tol * xmin_norm)
 
@@ -40,7 +40,7 @@
     @test(stats.solved)
     (xI, xmin, xmin_norm) = check_min_norm(A, b, x)
     @test(norm(xI - xmin) ≤ cond(A) * lnlq_tol * xmin_norm)
-    (xₛ, yₛ, stats) = lnlq(A, b, transfer_to_craig=transfer_to_craig, atol=0.0, rtol=0.0, σₐ=0.5)
+    (xₛ, yₛ, stats) = lnlq(A, b, transfer_to_craig=transfer_to_craig, atol=0.0, rtol=0.0, σ=0.5)
     (xI, xmin, xmin_norm) = check_min_norm(A, b, xₛ)
     @test(norm(xI - xmin) ≤ cond(A) * lnlq_tol * xmin_norm)
 
@@ -52,7 +52,7 @@
     @test(stats.solved)
     (xI, xmin, xmin_norm) = check_min_norm(A, b, x)
     @test(norm(xI - xmin) ≤ cond(A) * lnlq_tol * xmin_norm)
-    (xₛ, yₛ, stats) = lnlq(A, b, transfer_to_craig=transfer_to_craig, atol=0.0, rtol=0.0, σₐ=0.5)
+    (xₛ, yₛ, stats) = lnlq(A, b, transfer_to_craig=transfer_to_craig, atol=0.0, rtol=0.0, σ=0.5)
     (xI, xmin, xmin_norm) = check_min_norm(A, b, xₛ)
     @test(norm(xI - xmin) ≤ cond(A) * lnlq_tol * xmin_norm)
 
@@ -74,7 +74,7 @@
     A, b, D = saddle_point()
     D⁻¹ = inv(D)
     (x, y, stats) = lnlq(A, b, N=D⁻¹, transfer_to_craig=transfer_to_craig)
-    (xₛ, yₛ, stats) = lnlq(A, b, N=D⁻¹, transfer_to_craig=transfer_to_craig, atol=0.0, rtol=0.0, σₐ=0.001)
+    (xₛ, yₛ, stats) = lnlq(A, b, N=D⁻¹, transfer_to_craig=transfer_to_craig, atol=0.0, rtol=0.0, σ=0.001)
     for (x, y) in ((x, y), (xₛ, yₛ))
       r = b - A * x
       resid = norm(r) / norm(b)
@@ -87,7 +87,7 @@
     # Test with preconditioners
     A, b, M⁻¹, N⁻¹ = two_preconditioners()
     (x, y, stats) = lnlq(A, b, M=M⁻¹, N=N⁻¹, sqd=false, transfer_to_craig=transfer_to_craig)
-    (xₛ, yₛ, stats) = lnlq(A, b, M=M⁻¹, N=N⁻¹, sqd=false, transfer_to_craig=transfer_to_craig, atol=0.0, rtol=0.0, σₐ=0.5)
+    (xₛ, yₛ, stats) = lnlq(A, b, M=M⁻¹, N=N⁻¹, sqd=false, transfer_to_craig=transfer_to_craig, atol=0.0, rtol=0.0, σ=0.5)
     for (x, y) in ((x, y), (xₛ, yₛ))
       r = b - A * x
       resid = sqrt(dot(r, M⁻¹ * r)) / norm(b)
@@ -100,7 +100,7 @@
     M⁻¹ = inv(M)
     N⁻¹ = inv(N)
     (x, y, stats) = lnlq(A, b, M=M⁻¹, N=N⁻¹, sqd=true, transfer_to_craig=transfer_to_craig)
-    (xₛ, yₛ, stats) = lnlq(A, b, M=M⁻¹, N=N⁻¹, sqd=true, transfer_to_craig=transfer_to_craig, atol=0.0, rtol=0.0, σₐ=0.5)
+    (xₛ, yₛ, stats) = lnlq(A, b, M=M⁻¹, N=N⁻¹, sqd=true, transfer_to_craig=transfer_to_craig, atol=0.0, rtol=0.0, σ=0.5)
     for (x, y) in ((x, y), (xₛ, yₛ))
       r = b - (A * x + M * y)
       resid = norm(r) / norm(b)

--- a/test/test_lnlq.jl
+++ b/test/test_lnlq.jl
@@ -2,7 +2,7 @@
   lnlq_tol = 1.0e-6
 
   function test_lnlq(A, b,transfer_to_craig)
-    (x, y, stats) = lnlq(A, b, transfer_to_craig=transfer_to_craig)
+    (x, y, stats) = lnlq(A, b, transfer_to_craig=transfer_to_craig, etolx=0.0, etoly=0.0)
     r = b - A * x
     resid = norm(r) / norm(b)
     return (x, y, stats, resid)
@@ -28,6 +28,9 @@
     @test(stats.solved)
     (xI, xmin, xmin_norm) = check_min_norm(A, b, x)
     @test(norm(xI - xmin) ≤ cond(A) * lnlq_tol * xmin_norm)
+    (xₛ, yₛ, stats) = lnlq(A, b, transfer_to_craig=transfer_to_craig, atol=0.0, rtol=0.0, σₐ=0.5)
+    (xI, xmin, xmin_norm) = check_min_norm(A, b, xₛ)
+    @test(norm(xI - xmin) ≤ cond(A) * lnlq_tol * xmin_norm)
 
     # Square consistent.
     A, b = square_consistent()
@@ -36,6 +39,9 @@
     @test(resid ≤ lnlq_tol)
     @test(stats.solved)
     (xI, xmin, xmin_norm) = check_min_norm(A, b, x)
+    @test(norm(xI - xmin) ≤ cond(A) * lnlq_tol * xmin_norm)
+    (xₛ, yₛ, stats) = lnlq(A, b, transfer_to_craig=transfer_to_craig, atol=0.0, rtol=0.0, σₐ=0.5)
+    (xI, xmin, xmin_norm) = check_min_norm(A, b, xₛ)
     @test(norm(xI - xmin) ≤ cond(A) * lnlq_tol * xmin_norm)
 
     # Overdetermined consistent.
@@ -46,48 +52,63 @@
     @test(stats.solved)
     (xI, xmin, xmin_norm) = check_min_norm(A, b, x)
     @test(norm(xI - xmin) ≤ cond(A) * lnlq_tol * xmin_norm)
+    (xₛ, yₛ, stats) = lnlq(A, b, transfer_to_craig=transfer_to_craig, atol=0.0, rtol=0.0, σₐ=0.5)
+    (xI, xmin, xmin_norm) = check_min_norm(A, b, xₛ)
+    @test(norm(xI - xmin) ≤ cond(A) * lnlq_tol * xmin_norm)
 
     # Test regularization
     A, b, λ = regularization()
-    (x, y, stats) = lnlq(A, b, λ=λ, transfer_to_craig=transfer_to_craig)
-    s = λ * y
-    r = b - (A * x + λ * s)
-    resid = norm(r) / norm(b)
-    @test(resid ≤ lnlq_tol)
-    r2 = b - (A * A' + λ^2 * I) * y
-    resid2 = norm(r2) / norm(b)
-    @test(resid2 ≤ lnlq_tol)
+    (x, y, stats) = lnlq(A, b, λ=λ, transfer_to_craig=transfer_to_craig, etolx=0.0, etoly=0.0)
+    (xₛ, yₛ, stats) = lnlq(A, b, transfer_to_craig=transfer_to_craig, atol=0.0, rtol=0.0, etolx=1e-10, etoly=1e-10, λ=λ)
+    for (x, y) in ((x, y), (xₛ, yₛ))
+      s = λ * y
+      r = b - (A * x + λ * s)
+      resid = norm(r) / norm(b)
+      @test(resid ≤ lnlq_tol)
+      r2 = b - (A * A' + λ^2 * I) * y
+      resid2 = norm(r2) / norm(b)
+      @test(resid2 ≤ lnlq_tol)
+    end
 
     # Test saddle-point systems
     A, b, D = saddle_point()
     D⁻¹ = inv(D)
     (x, y, stats) = lnlq(A, b, N=D⁻¹, transfer_to_craig=transfer_to_craig)
-    r = b - A * x
-    resid = norm(r) / norm(b)
-    @test(resid ≤ lnlq_tol)
-    r2 = b - (A * D⁻¹ * A') * y
-    resid2 = norm(r2) / norm(b)
-    @test(resid2 ≤ lnlq_tol)
+    (xₛ, yₛ, stats) = lnlq(A, b, N=D⁻¹, transfer_to_craig=transfer_to_craig, atol=0.0, rtol=0.0, σₐ=0.001)
+    for (x, y) in ((x, y), (xₛ, yₛ))
+      r = b - A * x
+      resid = norm(r) / norm(b)
+      @test(resid ≤ lnlq_tol)
+      r2 = b - (A * D⁻¹ * A') * y
+      resid2 = norm(r2) / norm(b)
+      @test(resid2 ≤ lnlq_tol)
+    end
 
     # Test with preconditioners
     A, b, M⁻¹, N⁻¹ = two_preconditioners()
     (x, y, stats) = lnlq(A, b, M=M⁻¹, N=N⁻¹, sqd=false, transfer_to_craig=transfer_to_craig)
-    r = b - A * x
-    resid = sqrt(dot(r, M⁻¹ * r)) / norm(b)
-    @test(resid ≤ lnlq_tol)
-    @test(norm(x - N⁻¹ * A' * y) ≤ lnlq_tol * norm(x))
+    (xₛ, yₛ, stats) = lnlq(A, b, M=M⁻¹, N=N⁻¹, sqd=false, transfer_to_craig=transfer_to_craig, atol=0.0, rtol=0.0, σₐ=0.5)
+    for (x, y) in ((x, y), (xₛ, yₛ))
+      r = b - A * x
+      resid = sqrt(dot(r, M⁻¹ * r)) / norm(b)
+      @test(resid ≤ lnlq_tol)
+      @test(norm(x - N⁻¹ * A' * y) ≤ lnlq_tol * norm(x))
+    end
 
     # Test symmetric and quasi-definite systems
     A, b, M, N = sqd()
     M⁻¹ = inv(M)
     N⁻¹ = inv(N)
     (x, y, stats) = lnlq(A, b, M=M⁻¹, N=N⁻¹, sqd=true, transfer_to_craig=transfer_to_craig)
-    r = b - (A * x + M * y)
-    resid = norm(r) / norm(b)
-    @test(resid ≤ lnlq_tol)
-    r2 = b - (A * N⁻¹ * A' + M) * y
-    resid2 = norm(r2) / norm(b)
-    @test(resid2 ≤ lnlq_tol)
+    (xₛ, yₛ, stats) = lnlq(A, b, M=M⁻¹, N=N⁻¹, sqd=true, transfer_to_craig=transfer_to_craig, atol=0.0, rtol=0.0, σₐ=0.5)
+    for (x, y) in ((x, y), (xₛ, yₛ))
+      r = b - (A * x + M * y)
+      resid = norm(r) / norm(b)
+      @test(resid ≤ lnlq_tol)
+      r2 = b - (A * N⁻¹ * A' + M) * y
+      resid2 = norm(r2) / norm(b)
+      @test(resid2 ≤ lnlq_tol)
+    end
 
     # Test dimension of additional vectors
     for transpose ∈ (false, true)

--- a/test/test_show.jl
+++ b/test/test_show.jl
@@ -64,4 +64,18 @@
   status: t"""
   @test strip.(split(chomp(showed), "\n")) == strip.(split(chomp(expected), "\n"))
 
+  solver = Krylov.LNLQStats(true, Float64[], false, Float64[], Float64[], "t")
+  io = IOBuffer()
+  show(io, solver)
+  showed = String(take!(io))
+  storage_type = typeof(solver)
+  expected = """LNLQ stats
+  solved: true
+  residuals: []
+  error with bnd: false
+  error bnd x: []
+  error bnd y: []
+  status: t"""
+  @test strip.(split(chomp(showed), "\n")) == strip.(split(chomp(expected), "\n"))
+
 end


### PR DESCRIPTION
This would fix Issue #265 .

The modification is heavily inspired by the Matlab implementation: [https://github.com/restrin/LinearSystemSolvers/blob/master/LNLQ/lnlq.m](https://github.com/restrin/LinearSystemSolvers/blob/master/LNLQ/lnlq.m).

A couple of comments:
- We use the CRAIG-bound when `transfer_to_craig` is set as true.
- Due to numerical issues, the `sqrt` in the bound might not be defined. When this happens, there is a boolean `complex_error_bnd` set as `true` and we stop computing this bound.
- The extra allocations are due to the use of `LNLQStats` instead of `SimpleStats`.
