### PR TITLE
Add a boolean for error in bound computation for LSLQ

### DIFF
--- a/src/krylov_stats.jl
+++ b/src/krylov_stats.jl
@@ -98,6 +98,7 @@ Type for statistics returned by the LSLQ method, the attributes are:
 - residuals
 - Aresiduals
 - err_lbnds
+- error_with_bnd
 - err_ubnds_lq
 - err_ubnds_cg
 - status
@@ -108,6 +109,7 @@ mutable struct LSLQStats{T} <: KrylovStats{T}
   residuals :: Vector{T}
   Aresiduals :: Vector{T}
   err_lbnds :: Vector{T}
+  error_with_bnd :: Bool
   err_ubnds_lq :: Vector{T}
   err_ubnds_cg :: Vector{T}
   status :: String

--- a/test/test_alloc.jl
+++ b/test/test_alloc.jl
@@ -265,7 +265,7 @@ function test_alloc()
   solver = LslqSolver(Ao, b)
   lslq!(solver, Ao, b)  # warmup
   inplace_lslq_bytes = @allocated lslq!(solver, Ao, b)
-  @test (VERSION < v"1.5") || (inplace_lslq_bytes == 592)
+  @test (VERSION < v"1.5") || (inplace_lslq_bytes == 608)
 
   # CGLS needs:
   # - 3 m-vectors: x, p, s

--- a/test/test_lslq.jl
+++ b/test/test_lslq.jl
@@ -28,6 +28,10 @@
   @test x == zeros(size(A,1))
   @test stats.status == "x = 0 is a zero-residual solution"
 
+  # Test error in upper bound computation
+  (x, stats) = lslq(A, b, σ=1.)
+  @test stats.error_with_bnd
+
   for transfer_to_lsqr ∈ (false, true)
     # Test with smallest singular value estimate
     Σ = diagm(0 => 1:4)

--- a/test/test_show.jl
+++ b/test/test_show.jl
@@ -78,7 +78,7 @@
   status: t"""
   @test strip.(split(chomp(showed), "\n")) == strip.(split(chomp(expected), "\n"))
 
-  solver = Krylov.LSLQStats(true, false, Float64[], Float64[], Float64[], Float64[], Float64[], "t")
+  solver = Krylov.LSLQStats(true, false, Float64[], Float64[], Float64[], false, Float64[], Float64[], "t")
   io = IOBuffer()
   show(io, solver)
   showed = String(take!(io))
@@ -89,6 +89,7 @@
   residuals: []
   Aresiduals: []
   err lbnds: []
+  error with bnd: false
   error bound LQ: []
   error bound CG: []
   status: t"""


### PR DESCRIPTION
Add a boolean when there is a `DomainError` in the computation of the upper bound instead of having an error.