### PR TITLE
Add in-place stats for `lsmr`

### DIFF
--- a/src/krylov_solvers.jl
+++ b/src/krylov_solvers.jl
@@ -1097,15 +1097,16 @@ The outer constructors
 may be used in order to create these vectors.
 """
 mutable struct LsmrSolver{T,S} <: KrylovSolver{T,S}
-  x    :: S
-  Nv   :: S
-  Aᵀu  :: S
-  h    :: S
-  hbar :: S
-  Mu   :: S
-  Av   :: S
-  u    :: S
-  v    :: S
+  x     :: S
+  Nv    :: S
+  Aᵀu   :: S
+  h     :: S
+  hbar  :: S
+  Mu    :: S
+  Av    :: S
+  u     :: S
+  v     :: S
+  stats :: SimpleStats{T}
 
   function LsmrSolver(n, m, S)
     T    = eltype(S)
@@ -1118,7 +1119,8 @@ mutable struct LsmrSolver{T,S} <: KrylovSolver{T,S}
     Av   = S(undef, n)
     u    = S(undef, 0)
     v    = S(undef, 0)
-    solver = new{T,S}(x, Nv, Aᵀu, h, hbar, Mu, Av, u, v)
+    stats = SimpleStats(false, false, T[], T[], "unknown")
+    solver = new{T,S}(x, Nv, Aᵀu, h, hbar, Mu, Av, u, v, stats)
     return solver
   end
 

--- a/test/test_alloc.jl
+++ b/test/test_alloc.jl
@@ -329,7 +329,7 @@ function test_alloc()
   solver = LsmrSolver(Ao, b)
   lsmr!(solver, Ao, b)  # warmup
   inplace_lsmr_bytes = @allocated lsmr!(solver, Ao, b)
-  @test (VERSION < v"1.5") || (inplace_lsmr_bytes ≤ 336)
+  @test (VERSION < v"1.5") || (inplace_lsmr_bytes ≤ 128)
 
   # USYMQR needs:
   # - 6 m-vectors: vₖ₋₁, vₖ, x, wₖ₋₁, wₖ, p 


### PR DESCRIPTION
#361 

This one is not completely with 0 allocations as we will need a LsmrSolver I think for the `err_vec`. I suggest we fix this in a separate PR.