### PR TITLE
Add a C interface for Krylov.jl with shared libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ benchmark/tune.json
 benchmark/commit.md
 benchmark/main.md
 benchmark/judgement.md
+**/main
+**/*.o
+app/CKrylov

--- a/app/Project.toml
+++ b/app/Project.toml
@@ -1,0 +1,9 @@
+name = "CKrylov"
+uuid = "4b4ec1ba-e703-4299-a852-2dcfc5813e64"
+authors = ["Alexis Montoison <alexis.montoison@polymtl.ca>"]
+version = "0.1.0"
+
+[deps]
+Krylov = "ba0b0d4f-ebba-5204-a429-3ac8c609bfb7"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"

--- a/app/README.md
+++ b/app/README.md
@@ -1,0 +1,29 @@
+# CKrylov
+
+App for building shared library of the [Krylov.jl](https://github.com/JuliaSmoothOptimizers/Krylov.jl) package.
+All commands shown below are executed in the `Krylov.jl/app/` directory.
+
+## Installation instructions
+
+1. Download and install Julia (version 1.3.1 or newer).
+
+2. Install `PackageCompiler`
+    ```bash
+    $ julia -e 'using Pkg; Pkg.add("PackageCompiler")'
+    ```
+
+3. Instantiate the current environment
+    ```bash
+    $ julia --startup-file=no --project=. -e 'using Pkg; Pkg.instantiate()'
+
+    ```
+
+4. Build the shared library
+    ```bash
+    $ julia --startup-file=no --project=build -e 'using Pkg; Pkg.instantiate()'
+    $ julia --startup-file=no --project=build build/build.jl
+    ```
+    The header files will be located at `Krylov.jl/app/CKrylov/include`.
+    The shared libraries will be located at `Krylov.jl/app/CKrylov/lib`.
+
+    For more information on how to create library with [PackageCompiler.jl](https://github.com/JuliaLang/PackageCompiler.jl), take a look at the [documentation](https://julialang.github.io/PackageCompiler.jl/dev/libs)and the [presentation](https://www.youtube.com/watch?v=c0IAP7NC2MU) of JuliaCon 2021.

--- a/app/build/build.jl
+++ b/app/build/build.jl
@@ -1,0 +1,15 @@
+using PackageCompiler
+
+target_dir = get(ENV, "OUTDIR", "$(@__DIR__)/../CKrylov")
+target_dir = replace(target_dir, "\\"=>"/")  # Change Windows paths to use "/"
+
+println("Creating library in $target_dir")
+PackageCompiler.create_library(".", target_dir;
+                               lib_name="krylov",
+                               precompile_execution_file=["$(@__DIR__)/generate_precompile.jl"],
+                               precompile_statements_file=["$(@__DIR__)/additional_precompile.jl"],
+                               incremental=false,
+                               filter_stdlibs=true,
+                               header_files = ["$(@__DIR__)/krylov.h"],
+                               force=true
+                              )

--- a/app/build/generate_precompile.jl
+++ b/app/build/generate_precompile.jl
@@ -1,0 +1,40 @@
+using CKrylov, LinearAlgebra, SparseArrays
+
+n   = Int32(5)
+m   = Int32(5)
+nnz = Int32(15)
+irn = Int32.([1, 1, 1, 1, 2, 3, 3, 3, 4, 4, 4, 5, 5, 5, 5])
+jcn = Int32.([1, 3, 4, 5, 2, 1, 3, 5, 1, 4, 5, 1, 3, 4, 5])
+val = [53.0, 8.0, 4.0, 3.0, 10.0, 8.0, 6.0, 8.0, 4.0, 26.0, 5.0, 3.0, 8.0, 5.0, 14.0]
+A   = Matrix(sparse(irn, jcn, val, n, m))
+b   = [108.0, 20.0, 66.0, 133.0, 117.0]
+x   = zeros(5)
+
+cg_sparse(n, m, nnz, pointer(irn), pointer(jcn), pointer(val), pointer(b), pointer(x))
+cg_dense(n, m, pointer(A), pointer(b), pointer(x))
+
+n   = Int32(7)
+m   = Int32(5)
+nnz = Int32(13)
+irn = Int32.([1, 1, 1, 2, 3, 3, 4, 4, 5, 5, 6, 7, 7])
+jcn = Int32.([1, 3, 5, 2, 3, 5, 1, 4, 4, 5, 2, 1, 3])
+val = [1.0, 2.0, 3.0, 1.0, 1.0, 2.0, 4.0, 1.0, 5.0, 1.0, 3.0, 6.0, 1.0]
+A   = Matrix(sparse(irn, jcn, val, n, m))
+b   = [22.0, 5.0, 13.0, 8.0, 25.0, 5.0, 9.0]
+x   = zeros(5)
+
+lsmr_sparse(n, m, nnz, pointer(irn), pointer(jcn), pointer(val), pointer(b), pointer(x))
+lsmr_dense(n, m, pointer(A), pointer(b), pointer(x))
+
+n   = Int32(5)
+m   = Int32(7)
+nnz = Int32(13)
+irn = Int32.([1, 1, 1, 2, 2, 2, 3, 3, 4, 4, 5, 5, 5])
+jcn = Int32.([3, 5, 7, 1, 4, 6, 2, 6, 5, 6, 3, 4, 7])
+val = [2.0, 3.0, 5.0, 1.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 1.0, 2.0, 2.0]
+A   = Matrix(sparse(irn, jcn, val, n, m))
+b   = [56.0, 21.0, 16.0, 22.0, 25.0]
+x   = zeros(7)
+
+craig_sparse(n, m, nnz, pointer(irn), pointer(jcn), pointer(val), pointer(b), pointer(x))
+craig_dense(n, m, pointer(A), pointer(b), pointer(x))

--- a/app/build/krylov.h
+++ b/app/build/krylov.h
@@ -1,0 +1,8 @@
+int cg_dense(int n, int m, double *A, double *b, double *x);
+int cg_sparse(int n, int m, int nnz, int *irn, int *jcn, double *val, double *b, double *x);
+
+int lsmr_dense(int n, int m, double *A, double *b, double *x);
+int lsmr_sparse(int n, int m, int nnz, int *irn, int *jcn, double *val, double *b, double *x);
+
+int craig_dense(int n, int m, double *A, double *b, double *x);
+int craig_sparse(int n, int m, int nnz, int *irn, int *jcn, double *val, double *b, double *x);

--- a/app/examples/Makefile
+++ b/app/examples/Makefile
@@ -1,0 +1,16 @@
+LIB_DIR := ../CKrylov/lib
+INCLUDE_DIR := ../CKrylov/include
+WLARGS := -Wl,-rpath,"$(LIB_DIR)" -Wl,-rpath,"$(LIB_DIR)/julia"
+
+CFLAGS+=-O2 -fPIE -I$(INCLUDE_DIR)
+LDFLAGS+=-lm -L$(LIB_DIR) -ljulia $(WLARGS)
+
+main: main.o
+	gcc -o $@ $< $(LDFLAGS) -lkrylov
+
+main.o: main.c
+	gcc $< -c -o $@ $(CFLAGS)
+
+.PHONY: clean
+clean:
+	rm *~ *.o main

--- a/app/examples/main.c
+++ b/app/examples/main.c
@@ -1,0 +1,69 @@
+#include <stdio.h>
+#include <krylov.h>
+#include <julia_init.h>
+
+int main(int argc, char **argv) {
+  init_julia(argc, argv);
+
+  int i, n, m, nnz;
+
+  /* Symmetric and positive definite linear system */
+  n = 5;
+  m = 5;
+  nnz = 15;
+  int irn1[15] = {1, 1, 1, 1, 2, 3, 3, 3, 4, 4, 4, 5, 5, 5, 5};
+  int jcn1[15] = {1, 3, 4, 5, 2, 1, 3, 5, 1, 4, 5, 1, 3, 4, 5};
+  double val1[15] = {53.0, 8.0, 4.0, 3.0, 10.0, 8.0, 6.0, 8.0, 4.0, 26.0, 5.0, 3.0, 8.0, 5.0, 14.0};
+  double b1[5] = {108.0, 20.0, 66.0, 133.0, 117.0};
+  double x1[5];
+
+  cg_sparse(n, m, nnz, irn1, jcn1, val1, b1, x1);
+
+  printf("Expected result with CG is x = 1.00000 2.00000 3.00000 4.00000 5.00000\n");
+  printf("Computed result with CG is x = ");
+  for(i=0; i<5; i++){
+    printf("%7.5f ", x1[i]);
+  }
+  printf("\n");
+
+  /* Least-squares problem */
+  n = 7;
+  m = 5;
+  nnz = 13;
+  int irn2[13] = {1, 1, 1, 2, 3, 3, 4, 4, 5, 5, 6, 7, 7};
+  int jcn2[13] = {1, 3, 5, 2, 3, 5, 1, 4, 4, 5, 2, 1, 3};
+  double val2[13] = {1.0, 2.0, 3.0, 1.0, 1.0, 2.0, 4.0, 1.0, 5.0, 1.0, 3.0, 6.0, 1.0};
+  double b2[7] = {22.0, 5.0, 13.0, 8.0, 25.0, 5.0, 9.0};
+  double x2[5];
+
+  lsmr_sparse(n, m, nnz, irn2, jcn2, val2, b2, x2);
+
+  printf("Expected result with LSMR is x = 1.00000 2.00000 3.00000 4.00000 5.00000\n");
+  printf("Computed result with LSMR is x = ");
+  for(i=0; i<5; i++){
+    printf("%7.5f ", x2[i]);
+  }
+  printf("\n");
+
+  /* Least-norm problem */
+  n = 5;
+  m = 7;
+  nnz = 13;
+  int irn3[13] = {1, 1, 1, 2, 2, 2, 3, 3, 4, 4, 5, 5, 5};
+  int jcn3[13] = {3, 5, 7, 1, 4, 6, 2, 6, 5, 6, 3, 4, 7};
+  double val3[13] = {2.0, 3.0, 5.0, 1.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 1.0, 2.0, 2.0};
+  double b3[5] = {56.0, 21.0, 16.0, 22.0, 25.0};
+  double x3[7];
+
+  craig_sparse(n, m, nnz, irn3, jcn3, val3, b3, x3);
+  
+  printf("Expected result with CRAIG is x = 1.00000 2.00000 3.00000 4.00000 5.00000 6.00000 7.00000\n");
+  printf("Computed result with CRAIG is x = ");
+  for(i=0; i<7; i++){
+    printf("%7.5f ", x3[i]);
+  }
+  printf("\n");
+
+  shutdown_julia(0);
+  return 0;
+}

--- a/app/src/CKrylov.jl
+++ b/app/src/CKrylov.jl
@@ -1,0 +1,10 @@
+module CKrylov
+
+using LinearAlgebra, SparseArrays
+import Krylov
+
+include("cg.jl")
+include("lsmr.jl")
+include("craig.jl")
+
+end # module

--- a/app/src/cg.jl
+++ b/app/src/cg.jl
@@ -1,0 +1,32 @@
+export cg_dense, cg_sparse
+
+Base.@ccallable function cg_dense(n::Cint, m::Cint, A::Ptr{Cdouble}, b::Ptr{Cdouble}, x::Ptr{Cdouble})::Cint
+  try
+    cA = unsafe_wrap(Array, A, (n, m))
+    cb = unsafe_wrap(Array, b, n)
+    cx = unsafe_wrap(Array, x, m)
+    sol, _ = Krylov.cg(cA, cb)
+    cx .= sol
+  catch
+    Base.invokelatest(Base.display_error, Base.catch_stack())
+    return 1
+  end
+  return 0
+end
+
+Base.@ccallable function cg_sparse(n::Cint, m::Cint, nnz::Cint, irn::Ptr{Cint}, jcn::Ptr{Cint}, val::Ptr{Cdouble}, b::Ptr{Cdouble}, x::Ptr{Cdouble})::Cint
+  try
+    cirn = unsafe_wrap(Array, irn, nnz)
+    cjcn = unsafe_wrap(Array, jcn, nnz)
+    cval = unsafe_wrap(Array, val, nnz)
+    cA = sparse(cirn, cjcn, cval, n, m)
+    cb = unsafe_wrap(Array, b, n)
+    cx = unsafe_wrap(Array, x, m)
+    sol, _ = Krylov.cg(cA, cb)
+    cx .= sol
+  catch
+    Base.invokelatest(Base.display_error, Base.catch_stack())
+    return 1
+  end
+  return 0
+end

--- a/app/src/craig.jl
+++ b/app/src/craig.jl
@@ -1,0 +1,32 @@
+export craig_dense, craig_sparse
+
+Base.@ccallable function craig_dense(n::Cint, m::Cint, A::Ptr{Cdouble}, b::Ptr{Cdouble}, x::Ptr{Cdouble})::Cint
+  try
+    cA = unsafe_wrap(Array, A, (n, m))
+    cb = unsafe_wrap(Array, b, n)
+    cx = unsafe_wrap(Array, x, m)
+    sol, _, _ = Krylov.craig(cA, cb)
+    cx .= sol
+  catch
+    Base.invokelatest(Base.display_error, Base.catch_stack())
+    return 1
+  end
+  return 0
+end
+
+Base.@ccallable function craig_sparse(n::Cint, m::Cint, nnz::Cint, irn::Ptr{Cint}, jcn::Ptr{Cint}, val::Ptr{Cdouble}, b::Ptr{Cdouble}, x::Ptr{Cdouble})::Cint
+  try
+    cirn = unsafe_wrap(Array, irn, nnz)
+    cjcn = unsafe_wrap(Array, jcn, nnz)
+    cval = unsafe_wrap(Array, val, nnz)
+    cA = sparse(cirn, cjcn, cval, n, m)
+    cb = unsafe_wrap(Array, b, n)
+    cx = unsafe_wrap(Array, x, m)
+    sol, _, _ = Krylov.craig(cA, cb)
+    cx .= sol
+  catch
+    Base.invokelatest(Base.display_error, Base.catch_stack())
+    return 1
+  end
+  return 0
+end

--- a/app/src/lsmr.jl
+++ b/app/src/lsmr.jl
@@ -1,0 +1,32 @@
+export lsmr_dense, lsmr_sparse
+
+Base.@ccallable function lsmr_dense(n::Cint, m::Cint, A::Ptr{Cdouble}, b::Ptr{Cdouble}, x::Ptr{Cdouble})::Cint
+  try
+    cA = unsafe_wrap(Array, A, (n, m))
+    cb = unsafe_wrap(Array, b, n)
+    cx = unsafe_wrap(Array, x, m)
+    sol, _ = Krylov.lsmr(cA, cb)
+    cx .= sol
+  catch
+    Base.invokelatest(Base.display_error, Base.catch_stack())
+    return 1
+  end
+  return 0
+end
+
+Base.@ccallable function lsmr_sparse(n::Cint, m::Cint, nnz::Cint, irn::Ptr{Cint}, jcn::Ptr{Cint}, val::Ptr{Cdouble}, b::Ptr{Cdouble}, x::Ptr{Cdouble})::Cint
+  try
+    cirn = unsafe_wrap(Array, irn, nnz)
+    cjcn = unsafe_wrap(Array, jcn, nnz)
+    cval = unsafe_wrap(Array, val, nnz)
+    cA = sparse(cirn, cjcn, cval, n, m)
+    cb = unsafe_wrap(Array, b, n)
+    cx = unsafe_wrap(Array, x, m)
+    sol, _ = Krylov.lsmr(cA, cb)
+    cx .= sol
+  catch
+    Base.invokelatest(Base.display_error, Base.catch_stack())
+    return 1
+  end
+  return 0
+end


### PR DESCRIPTION
@dpo 
Since the JuliaCon  2021, `PackageCompiler.jl` is able to generate shared libraries for Julia packages.
I tested it with three Krylov methods (`CG`, `LSMR` and `CRAIG`).
It's a basic interface but it works fine and could be a nice feature if we do an article about Krylov.jl before the end of the thesis.
