### PR TITLE
Add callback lsmr pr

### DIFF
--- a/test/test_lsmr.jl
+++ b/test/test_lsmr.jl
@@ -86,7 +86,6 @@
 
   # Test callback function
   function test_callback(solver, iter, rNorms, ArNorms)
-    @test iter == 1
     if iter >= 1
       return true
     else
@@ -94,7 +93,8 @@
     end
   end
 
-  (x, stats) = lsmr(A,b,callback = test_callback)
+  (x, stats) = lsmr(A,b,callback = test_callback, history=true)
   @test stats.status == "extra stop condition triggered"
+  @test length(stats.residuals) == 2
 
 end

--- a/test/test_lsmr.jl
+++ b/test/test_lsmr.jl
@@ -83,4 +83,17 @@
     N⁻¹ = inv(N)
     (x, stats) = lsmr(A, b, M=M⁻¹, N=N⁻¹, sqd=true)
   end
+
+  # Test callback function
+  function stop_cond(solver, A, b, iter, rNorms, ArNorms)
+    if iter ≥ 1
+      return true
+    else
+      return false
+    end
+  end
+
+  (x, stats) = lsmr(A,b,extra_sc = stop_cond)
+  @test stats.status == "extra stop condition triggered"
+
 end

--- a/test/test_lsmr.jl
+++ b/test/test_lsmr.jl
@@ -85,15 +85,16 @@
   end
 
   # Test callback function
-  function stop_cond(solver, A, b, iter, rNorms, ArNorms)
-    if iter ≥ 1
+  function test_callback(solver, iter, rNorms, ArNorms)
+    @test iter == 1
+    if iter >= 1
       return true
     else
       return false
     end
   end
 
-  (x, stats) = lsmr(A,b,extra_sc = stop_cond)
+  (x, stats) = lsmr(A,b,callback = test_callback)
   @test stats.status == "extra stop condition triggered"
 
 end


### PR DESCRIPTION
Adding a callback function to lsmr, I could later do it for other solvers if needed.
An example on how to use it is added in the docstring.
Tests to cover it have been added in test_lsmr.jl