### PR TITLE
Remove pivoting option in DIOM and FOM

### DIFF
--- a/src/dqgmres.jl
+++ b/src/dqgmres.jl
@@ -85,8 +85,8 @@ function dqgmres!(solver :: DqgmresSolver{T,S}, A, b :: AbstractVector{T};
   # Set up workspace.
   mem = length(c)  # Memory.
   for i = 1 : mem
-    V[i] .= zero(T)  # Preconditioned Krylov vectors, orthogonal basis for {M⁻¹b, M⁻¹AN⁻¹b, (M⁻¹AN⁻¹)²b, ..., (M⁻¹AN⁻¹)ᵐ⁻¹b}.
-    P[i] .= zero(T)  # Directions for x : Pₘ = Vₘ(Rₘ)⁻¹.
+    V[i] .= zero(T)  # Orthogonal basis of Kₖ(M⁻¹AN⁻¹, M⁻¹b).
+    P[i] .= zero(T)  # Directions for x : Pₘ = N⁻¹Vₘ(Rₘ)⁻¹.
   end
   s .= zero(T)  # Last mem Givens sines used for the factorization QₘRₘ = Hₘ.
   c .= zero(T)  # Last mem Givens cosines used for the factorization QₘRₘ = Hₘ.
@@ -123,7 +123,7 @@ function dqgmres!(solver :: DqgmresSolver{T,S}, A, b :: AbstractVector{T};
     for i = max(1, iter-mem+1) : iter
       ipos = mod(i-1, mem) + 1 # Position corresponding to vᵢ in the circular stack V.
       diag = iter - i + 2
-      H[diag] = @kdot(n, w, V[ipos]) # hᵢ.ₘ = < M⁻¹AN⁻¹vₘ , vᵢ >
+      H[diag] = @kdot(n, w, V[ipos]) # hᵢ.ₘ = ⟨M⁻¹AN⁻¹vₘ , vᵢ⟩
       @kaxpy!(n, -H[diag], V[ipos], w) # w ← w - hᵢ.ₘ * vᵢ
     end
     # Compute hₘ₊₁.ₘ and vₘ₊₁.
@@ -154,7 +154,7 @@ function dqgmres!(solver :: DqgmresSolver{T,S}, A, b :: AbstractVector{T};
     γₘ₊₁ = s[pos] * γₘ
     γₘ   = c[pos] * γₘ
 
-    # Compute the direction pₘ, the last column of Pₘ = Vₘ(Rₘ)⁻¹.
+    # Compute the direction pₘ, the last column of Pₘ = N⁻¹Vₘ(Rₘ)⁻¹.
     for i = max(1,iter-mem) : iter-1
       ipos = mod(i-1, mem) + 1 # Position corresponding to pᵢ in the circular stack P.
       diag = iter - i + 2

--- a/src/gmres.jl
+++ b/src/gmres.jl
@@ -87,7 +87,7 @@ function gmres!(solver :: GmresSolver{T,S}, A, b :: AbstractVector{T};
   nr = 0           # Number of coefficients stored in Rₖ.
   mem = length(c)  # Memory
   for i = 1 : mem
-    V[i] .= zero(T)  # Orthogonal basis of Kₖ(M⁻¹AN⁻¹, r₀).
+    V[i] .= zero(T)  # Orthogonal basis of Kₖ(M⁻¹AN⁻¹, M⁻¹b).
   end
   s .= zero(T)  # Givens sines used for the factorization QₖRₖ = Hₖ₊₁.ₖ.
   c .= zero(T)  # Givens cosines used for the factorization QₖRₖ = Hₖ₊₁.ₖ.

--- a/src/krylov_solvers.jl
+++ b/src/krylov_solvers.jl
@@ -362,7 +362,6 @@ may be used in order to create these vectors.
 """
 mutable struct DiomSolver{T,S} <: KrylovSolver{T,S}
   x     :: S
-  x_old :: S
   t     :: S
   z     :: S
   w     :: S
@@ -370,13 +369,11 @@ mutable struct DiomSolver{T,S} <: KrylovSolver{T,S}
   V     :: Vector{S}
   L     :: Vector{T}
   H     :: Vector{T}
-  p     :: BitVector
   stats :: SimpleStats{T}
 
   function DiomSolver(n, m, memory, S)
     T     = eltype(S)
     x     = S(undef, n)
-    x_old = S(undef, n)
     t     = S(undef, n)
     z     = S(undef, 0)
     w     = S(undef, 0)
@@ -384,9 +381,8 @@ mutable struct DiomSolver{T,S} <: KrylovSolver{T,S}
     V     = [S(undef, n) for i = 1 : memory]
     L     = Vector{T}(undef, memory)
     H     = Vector{T}(undef, memory+2)
-    p     = BitVector(undef, memory)
     stats = SimpleStats(false, false, T[], T[], "unknown")
-    solver = new{T,S}(x, x_old, t, z, w, P, V, L, H, p, stats)
+    solver = new{T,S}(x, t, z, w, P, V, L, H, stats)
     return solver
   end
 
@@ -1381,7 +1377,6 @@ mutable struct FomSolver{T,S} <: KrylovSolver{T,S}
   l     :: Vector{T}
   z     :: Vector{T}
   U     :: Vector{T}
-  perm  :: BitVector
   stats :: SimpleStats{T}
 
   function FomSolver(n, m, memory, S)
@@ -1394,9 +1389,8 @@ mutable struct FomSolver{T,S} <: KrylovSolver{T,S}
     l = Vector{T}(undef, memory)
     z = Vector{T}(undef, memory)
     U = Vector{T}(undef, div(memory * (memory+1), 2))
-    perm = BitVector(undef, memory)
     stats = SimpleStats(false, false, T[], T[], "unknown")
-    solver = new{T,S}(x, w, p, q, V, l, z, U, perm, stats)
+    solver = new{T,S}(x, w, p, q, V, l, z, U, stats)
     return solver
   end
 

--- a/test/test_alloc.jl
+++ b/test/test_alloc.jl
@@ -57,12 +57,11 @@ function test_alloc()
   @test (VERSION < v"1.5") || (inplace_minres_bytes == 0)
 
   # DIOM needs:
-  # - 3 n-vectors: x, x_old, t
+  # - 2 n-vectors: x, t
   # - 2 (n*mem)-matrices: P, V
   # - 1 mem-vector: L
   # - 1 (mem+2)-vector: H
-  # - 1 mem-bitVector: p
-  storage_diom(mem, n) = (3 * n) + (2 * n * mem) + (mem) + (mem + 2) + (mem / 64)
+  storage_diom(mem, n) = (2 * n) + (2 * n * mem) + (mem) + (mem + 2)
   storage_diom_bytes(mem, n) = 8 * storage_diom(mem, n)
 
   expected_diom_bytes = storage_diom_bytes(mem, n)
@@ -80,8 +79,7 @@ function test_alloc()
   # - 1 (n*mem)-matrix: V
   # - 2 mem-vectors: l, z
   # - 1 (mem*(mem+1)/2)-vector: U
-  # - 1 mem-bitVector: perm
-  storage_fom(mem, n) = (2 * n) + (n * mem) + (2 * mem) + (mem * (mem+1) / 2) + (mem / 64)
+  storage_fom(mem, n) = (2 * n) + (n * mem) + (2 * mem) + (mem * (mem+1) / 2)
   storage_fom_bytes(mem, n) = 8 * storage_fom(mem, n)
 
   expected_fom_bytes = storage_fom_bytes(mem, n)


### PR DESCRIPTION
close #170 
The subproblem of DIOM and FOM is different when pivoting is enable and we cannot compute the residual norm.
I understand now why it's was only mentioned in DIOM article...