### PR TITLE
Up `DCISolver` in breakage test

### DIFF
--- a/.github/workflows/Breakage.yml
+++ b/.github/workflows/Breakage.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         pkg: [
           "JuliaSmoothOptimizers/CaNNOLeS.jl",
-          "JuliaSmoothOptimizers/DCI.jl",
+          "JuliaSmoothOptimizers/DCISolver.jl",
           "JuliaSmoothOptimizers/JSOSolvers.jl",
           "JuliaSmoothOptimizers/Percival.jl"
         ]


### PR DESCRIPTION
`DCI.jl` was renamed `DCISolver.jl` a while ago.