### PR TITLE
Generic `reset!` function

### DIFF
--- a/src/krylov_stats.jl
+++ b/src/krylov_stats.jl
@@ -17,11 +17,6 @@ mutable struct SimpleStats{T} <: KrylovStats{T}
   status       :: String
 end
 
-function reset!(stats :: SimpleStats)
-  empty!(stats.residuals)
-  empty!(stats.Aresiduals)
-end
-
 """
 Type for statistics returned by CG-LANCZOS, the attributes are:
 - solved
@@ -38,10 +33,6 @@ mutable struct LanczosStats{T} <: KrylovStats{T}
   Anorm      :: T
   Acond      :: T
   status     :: String
-end
-
-function reset!(stats :: LanczosStats)
-  empty!(stats.residuals)
 end
 
 """
@@ -90,13 +81,6 @@ mutable struct SymmlqStats{T} <: KrylovStats{T}
   status      :: String
 end
 
-function reset!(stats :: SymmlqStats)
-  empty!(stats.residuals)
-  empty!(stats.residualscg)
-  empty!(stats.errors)
-  empty!(stats.errorscg)
-end
-
 """
 Type for statistics returned by adjoint systems solvers BiLQR and TriLQR, the attributes are:
 - solved_primal
@@ -111,11 +95,6 @@ mutable struct AdjointStats{T} <: KrylovStats{T}
   residuals_primal :: Vector{T}
   residuals_dual   :: Vector{T}
   status           :: String
-end
-
-function reset!(stats :: AdjointStats)
-  empty!(stats.residuals_primal)
-  empty!(stats.residuals_dual)
 end
 
 """
@@ -134,12 +113,6 @@ mutable struct LNLQStats{T} <: KrylovStats{T}
   error_bnd_x    :: Vector{T}
   error_bnd_y    :: Vector{T}
   status         :: String
-end
-
-function reset!(stats :: LNLQStats)
-  empty!(stats.residuals)
-  empty!(stats.error_bnd_x)
-  empty!(stats.error_bnd_y)
 end
 
 """
@@ -166,14 +139,6 @@ mutable struct LSLQStats{T} <: KrylovStats{T}
   status         :: String
 end
 
-function reset!(stats :: LSLQStats)
-  empty!(stats.residuals)
-  empty!(stats.Aresiduals)
-  empty!(stats.err_lbnds)
-  empty!(stats.err_ubnds_lq)
-  empty!(stats.err_ubnds_cg)
-end
-
 import Base.show
 
 special_fields = Dict(
@@ -184,6 +149,24 @@ special_fields = Dict(
   :err_ubnds_lq => "error bound LQ",
   :err_ubnds_cg => "error bound CG",
 )
+
+for f in ["Simple", "Adjoint", "LNLQ", "LSLQ", "Lanczos", "Symmlq"]
+  T = Meta.parse("Krylov." * f * "Stats{S}")
+
+  @eval function empty_field!(stats :: $T, i, ::Type{Vector{Si}}) where {S, Si}
+    statfield = getfield(stats, i)
+    empty!(statfield)
+  end
+  @eval empty_field!(stats :: $T, i, type) where S = stats
+
+  @eval function reset!(stats :: $T) where S
+    nfield = length($T.types)
+    for i = 1 : nfield
+      type  = fieldtype($T, i)
+      empty_field!(stats, i, type)
+    end
+  end
+end
 
 for f in ["Simple", "Lanczos", "LanczosShift", "Symmlq", "Adjoint", "LNLQ", "LSLQ"]
   T = Meta.parse("Krylov." * f * "Stats{S}")


### PR DESCRIPTION
Solving the issue raised in #417 .
However, I don't see how to include the `LanczosShift` as adding
```
@eval function empty_field!(stats :: $T, i, ::Type{Vector{Vec}}) where {S, Vec<:AbstractVector}
  statfield = getfield(stats, i)
  for vec in statfield
    empty!(vec)
  end
end
```
seems to allocate (the type of `statfield` being problematic apparently...).