### PR TITLE
Update the linear operators in the documentation

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -14,5 +14,5 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 SuiteSparseMatrixCollection = "ac199af8-68bc-55b8-82c4-7abd6f96ed98"
 
 [compat]
-LinearOperators = "~2.0"
+LinearOperators = "~2.2.1"
 SuiteSparseMatrixCollection = "~0.5.3"

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -195,7 +195,7 @@ c = -b
 # [D   A] [x] = [b]
 # [Aᵀ  0] [y]   [c]
 llt_D = cholesky(D)
-opD⁻¹ = LinearOperator(Float64, 5, 5, true, true, (y, v, α, β) -> ldiv!(y, llt_D, v))
+opD⁻¹ = LinearOperator(Float64, 5, 5, true, true, (y, v) -> ldiv!(y, llt_D, v))
 opH⁻¹ = BlockDiagonalOperator(opD⁻¹, eye(n))
 (x, y, stats) = trimr(A, b, c, M=opD⁻¹, sp=true)
 K = [D A; A' zeros(n,n)]
@@ -225,8 +225,8 @@ resid = norm(r)
 # [Aᵀ -N] [y]   [c]
 ldlt_M = ldl(M)
 ldlt_N = ldl(N)
-opM⁻¹ = LinearOperator(Float64, size(M,1), size(M,2), true, true, (y, v, α, β) -> ldiv!(y, ldlt_M, v))
-opN⁻¹ = LinearOperator(Float64, size(N,1), size(N,2), true, true, (y, v, α, β) -> ldiv!(y, ldlt_N, v))
+opM⁻¹ = LinearOperator(Float64, size(M,1), size(M,2), true, true, (y, v) -> ldiv!(y, ldlt_M, v))
+opN⁻¹ = LinearOperator(Float64, size(N,1), size(N,2), true, true, (y, v) -> ldiv!(y, ldlt_N, v))
 opH⁻¹ = BlockDiagonalOperator(opM⁻¹, opN⁻¹)
 (x, y, stats) = trimr(A, b, c, M=opM⁻¹, N=opN⁻¹, verbose=1)
 K = [M A; A' -N]
@@ -256,9 +256,9 @@ F = ilu(A, τ = 0.05)
 
 # Solve Ax = b with BICGSTAB and an incomplete LU factorization
 # Remark: CGS can be used in the same way
-opM = LinearOperator(Float64, n, n, false, false, (y, v, α, β) -> forward_substitution!(y, F, v))
-opN = LinearOperator(Float64, n, n, false, false, (y, v, α, β) -> backward_substitution!(y, F, v))
-opP = LinearOperator(Float64, n, n, false, false, (y, v, α, β) -> ldiv!(y, F, v))
+opM = LinearOperator(Float64, n, n, false, false, (y, v) -> forward_substitution!(y, F, v))
+opN = LinearOperator(Float64, n, n, false, false, (y, v) -> backward_substitution!(y, F, v))
+opP = LinearOperator(Float64, n, n, false, false, (y, v) -> ldiv!(y, F, v))
 
 # Without preconditioning
 x, stats = bicgstab(A, b, history=true)
@@ -305,9 +305,9 @@ F = ilu0(A)
 
 # Solve Ax = b with DQGMRES and an ILU(0) preconditioner
 # Remark: DIOM, FOM and GMRES can be used in the same way
-opM = LinearOperator(Float64, n, n, false, false, (y, v, α, β) -> forward_substitution!(y, F, v))
-opN = LinearOperator(Float64, n, n, false, false, (y, v, α, β) -> backward_substitution!(y, F, v))
-opP = LinearOperator(Float64, n, n, false, false, (y, v, α, β) -> ldiv!(y, F, v))
+opM = LinearOperator(Float64, n, n, false, false, (y, v) -> forward_substitution!(y, F, v))
+opN = LinearOperator(Float64, n, n, false, false, (y, v) -> backward_substitution!(y, F, v))
+opP = LinearOperator(Float64, n, n, false, false, (y, v) -> ldiv!(y, F, v))
 
 # Without preconditioning
 x, stats = dqgmres(A, b, memory=50, history=true)

--- a/docs/src/factorization-free.md
+++ b/docs/src/factorization-free.md
@@ -25,7 +25,7 @@ where
 * `type` is the operator element type;
 * `nrow` and `ncol` are its dimensions;
 * `symmetric` and `hermitian` should be set to `true` or `false`;
-* `prod(y, v, α, β)`, `tprod(y, w, α, β)` and `ctprod(u, w, α, β)` are called when writing `mul!(y, A, v, α, β)`, `mul!(y, tranpose(A), w, α, β)`, and `mul!(y, A', u, α, β)`, respectively.
+* `prod(y, v)`, `tprod(y, w)` and `ctprod(u, w)` are called when writing `mul!(y, A, v)`, `mul!(y, tranpose(A), w)`, and `mul!(y, A', u)`, respectively.
 
 See the [tutorial](https://juliasmoothoptimizers.github.io/JSOTutorials.jl/linear-operators/introduction-to-linear-operators/introduction-to-linear-operators.html) and the detailed [documentation](https://juliasmoothoptimizers.github.io/LinearOperators.jl/dev/) for more informations on `LinearOperators.jl`.
 
@@ -72,7 +72,7 @@ f(x) = (x[1] - 1)^2 + (x[2] - 2)^2 + (x[3] - 3)^2 + (x[4] - 4)^2
 g(x) = ForwardDiff.gradient(f, x)
 
 H(y, v) = ForwardDiff.derivative!(y, t -> g(xk + t * v), 0)
-opH = LinearOperator(Float64, 4, 4, true, true, (y, v, α, β) -> H(y, v))
+opH = LinearOperator(Float64, 4, 4, true, true, (y, v) -> H(y, v))
 
 cg(opH, -g(xk))
 ```
@@ -111,9 +111,9 @@ F(x) = [x[1]^4 - 3; exp(x[2]) - 2; log(x[1]) - x[2]^2]
 
 J(y, v) = ForwardDiff.derivative!(y, t -> F(xk + t * v), 0)
 Jᵀ(y, u) = ForwardDiff.gradient!(y, x -> dot(F(x), u), xk)
-opJ = LinearOperator(Float64, 3, 2, false, false, (y, v, α, β) -> J(y, v),
-                                                  (y, w, α, β) -> Jᵀ(y, w),
-                                                  (y, u, α, β) -> Jᵀ(y, u))
+opJ = LinearOperator(Float64, 3, 2, false, false, (y, v) -> J(y, v),
+                                                  (y, w) -> Jᵀ(y, w),
+                                                  (y, u) -> Jᵀ(y, u))
 
 lsmr(opJ, -F(xk))
 ```

--- a/docs/src/gpu.md
+++ b/docs/src/gpu.md
@@ -60,7 +60,7 @@ end
 # Operator that model P⁻¹
 n = length(b_gpu)
 T = eltype(b_gpu)
-opM = LinearOperator(T, n, n, true, true, (y, x, α, β) -> ldiv!(y, P, x))
+opM = LinearOperator(T, n, n, true, true, (y, x) -> ldiv!(y, P, x))
 
 # Solve a symmetric positive definite system with an incomplete Cholesky preconditioner on GPU
 (x, stats) = cg(A_gpu, b_gpu, M=opM)
@@ -86,7 +86,7 @@ end
 # Operator that model P⁻¹
 n = length(b_gpu)
 T = eltype(b_gpu)
-opM = LinearOperator(T, n, n, false, false, (y, x, α, β) -> ldiv!(y, P, x))
+opM = LinearOperator(T, n, n, false, false, (y, x) -> ldiv!(y, P, x))
 
 # Solve an unsymmetric system with an incomplete LU preconditioner on GPU
 (x, stats) = bicgstab(A_gpu, b_gpu, M=opM)

--- a/docs/src/tips.md
+++ b/docs/src/tips.md
@@ -64,7 +64,7 @@ using LinearOperators
 n, m = size(A)
 sym = herm = true
 T = eltype(A)
-opA = LinearOperator(T, n, m, sym, herm, (y, v, α, β) -> threaded_mul!(y, A, v))
+opA = LinearOperator(T, n, m, sym, herm, (y, v) -> threaded_mul!(y, A, v))
 ```
 
 To enable multi-threading with Julia, you can start julia with the environment variable `JULIA_NUM_THREADS` or the options `-t` and `--threads`


### PR DESCRIPTION
Thanks to @geoffroyleconte, it's now possible to define a 3-args mul! neatly.
This pull request can be merged after the hotfix https://github.com/JuliaSmoothOptimizers/LinearOperators.jl/pull/203 dedicated to the BlockDIagonalOperator and a minor release 2.2.1 of LinearOperators.jl.