### PR TITLE
Update the references -- DOI

### DIFF
--- a/src/bicgstab.jl
+++ b/src/bicgstab.jl
@@ -40,7 +40,7 @@ This implementation allows a left preconditioner `M` and a right preconditioner 
 
 #### References
 
-* H. A. van der Vorst, *Bi-CGSTAB: A fast and smoothly converging variant of Bi-CG for the solution of nonsymmetric linear systems*, SIAM Journal on Scientific and Statistical Computing, 13(2), pp. 631--644, 1992.
+* H. A. van der Vorst, [*Bi-CGSTAB: A fast and smoothly converging variant of Bi-CG for the solution of nonsymmetric linear systems*](https://doi.org/10.1137/0913035), SIAM Journal on Scientific and Statistical Computing, 13(2), pp. 631--644, 1992.
 * G. L.G. Sleijpen and D. R. Fokkema, *BiCGstab(ℓ) for linear equations involving unsymmetric matrices with complex spectrum*, Electronic Transactions on Numerical Analysis, 1, pp. 11--32, 1993.
 """
 function bicgstab(A, b :: AbstractVector{T}; kwargs...) where T <: AbstractFloat

--- a/src/bilq.jl
+++ b/src/bilq.jl
@@ -28,7 +28,7 @@ when it exists. The transfer is based on the residual norm.
 
 #### Reference
 
-* A. Montoison and D. Orban, *BiLQ: An Iterative Method for Nonsymmetric Linear Systems with a Quasi-Minimum Error Property*, SIAM Journal on Matrix Analysis and Applications, 41(3), pp. 1145--1166, 2020.
+* A. Montoison and D. Orban, [*BiLQ: An Iterative Method for Nonsymmetric Linear Systems with a Quasi-Minimum Error Property*](https://doi.org/10.1137/19M1290991), SIAM Journal on Matrix Analysis and Applications, 41(3), pp. 1145--1166, 2020.
 """
 function bilq(A, b :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
   solver = BilqSolver(A, b)

--- a/src/bilqr.jl
+++ b/src/bilqr.jl
@@ -31,7 +31,7 @@ BiCG point, when it exists. The transfer is based on the residual norm.
 
 #### Reference
 
-* A. Montoison and D. Orban, *BiLQ: An Iterative Method for Nonsymmetric Linear Systems with a Quasi-Minimum Error Property*, SIAM Journal on Matrix Analysis and Applications, 41(3), pp. 1145--1166, 2020.
+* A. Montoison and D. Orban, [*BiLQ: An Iterative Method for Nonsymmetric Linear Systems with a Quasi-Minimum Error Property*](https://doi.org/10.1137/19M1290991), SIAM Journal on Matrix Analysis and Applications, 41(3), pp. 1145--1166, 2020.
 """
 function bilqr(A, b :: AbstractVector{T}, c :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
   solver = BilqrSolver(A, b)

--- a/src/cg.jl
+++ b/src/cg.jl
@@ -35,7 +35,7 @@ with `n = length(b)`.
 
 #### Reference
 
-* M. R. Hestenes and E. Stiefel, *Methods of conjugate gradients for solving linear systems*, Journal of Research of the National Bureau of Standards, 49(6), pp. 409--436, 1952.
+* M. R. Hestenes and E. Stiefel, [*Methods of conjugate gradients for solving linear systems*](https://doi.org/10.6028/jres.049.044), Journal of Research of the National Bureau of Standards, 49(6), pp. 409--436, 1952.
 """
 function cg(A, b :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
   solver = CgSolver(A, b)

--- a/src/cg_lanczos.jl
+++ b/src/cg_lanczos.jl
@@ -31,8 +31,8 @@ assumed to be symmetric and positive definite.
 
 #### References
 
-* A. Frommer and P. Maass, *Fast CG-Based Methods for Tikhonov-Phillips Regularization*, SIAM Journal on Scientific Computing, 20(5), pp. 1831--1850, 1999.
-* C. C. Paige and M. A. Saunders, *Solution of Sparse Indefinite Systems of Linear Equations*, SIAM Journal on Numerical Analysis, 12(4), pp. 617--629, 1975.
+* A. Frommer and P. Maass, [*Fast CG-Based Methods for Tikhonov-Phillips Regularization*](https://doi.org/10.1137/S1064827596313310), SIAM Journal on Scientific Computing, 20(5), pp. 1831--1850, 1999.
+* C. C. Paige and M. A. Saunders, [*Solution of Sparse Indefinite Systems of Linear Equations*](https://doi.org/10.1137/0712047), SIAM Journal on Numerical Analysis, 12(4), pp. 617--629, 1975.
 """
 function cg_lanczos(A, b :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
   solver = CgLanczosSolver(A, b)

--- a/src/cgls.jl
+++ b/src/cgls.jl
@@ -51,8 +51,8 @@ but simpler to implement.
 
 #### References
 
-* M. R. Hestenes and E. Stiefel. *Methods of conjugate gradients for solving linear systems*, Journal of Research of the National Bureau of Standards, 49(6), pp. 409--436, 1952.
-* A. Björck, T. Elfving and Z. Strakos, *Stability of Conjugate Gradient and Lanczos Methods for Linear Least Squares Problems*, SIAM Journal on Matrix Analysis and Applications, 19(3), pp. 720--736, 1998.
+* M. R. Hestenes and E. Stiefel. [*Methods of conjugate gradients for solving linear systems*](https://doi.org/10.6028/jres.049.044), Journal of Research of the National Bureau of Standards, 49(6), pp. 409--436, 1952.
+* A. Björck, T. Elfving and Z. Strakos, [*Stability of Conjugate Gradient and Lanczos Methods for Linear Least Squares Problems*](https://doi.org/10.1137/S089547989631202X), SIAM Journal on Matrix Analysis and Applications, 19(3), pp. 720--736, 1998.
 """
 function cgls(A, b :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
   solver = CglsSolver(A, b)

--- a/src/cgne.jl
+++ b/src/cgne.jl
@@ -60,7 +60,7 @@ A preconditioner M may be provided in the form of a linear operator.
 
 #### References
 
-* J. E. Craig, *The N-step iteration procedures*, Journal of Mathematics and Physics, 34(1), pp. 64--73, 1955.
+* J. E. Craig, [*The N-step iteration procedures*](https://doi.org/10.1002/sapm195534164), Journal of Mathematics and Physics, 34(1), pp. 64--73, 1955.
 * J. E. Craig, *Iterations Procedures for Simultaneous Equations*, Ph.D. Thesis, Department of Electrical Engineering, MIT, 1954.
 """
 function cgne(A, b :: AbstractVector{T}; kwargs...) where T <: AbstractFloat

--- a/src/cgs.jl
+++ b/src/cgs.jl
@@ -38,7 +38,7 @@ This implementation allows a left preconditioner M and a right preconditioner N.
 
 #### Reference
 
-* P. Sonneveld, *CGS, A Fast Lanczos-Type Solver for Nonsymmetric Linear systems*, SIAM Journal on Scientific and Statistical Computing, 10(1), pp. 36--52, 1989.
+* P. Sonneveld, [*CGS, A Fast Lanczos-Type Solver for Nonsymmetric Linear systems*](https://doi.org/10.1137/0910004), SIAM Journal on Scientific and Statistical Computing, 10(1), pp. 36--52, 1989.
 """
 function cgs(A, b :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
   solver = CgsSolver(A, b)

--- a/src/cr.jl
+++ b/src/cr.jl
@@ -1,7 +1,10 @@
 # A truncated version of Stiefel’s Conjugate Residual method described in
 #
-# M. R. Hestenes and E. Stiefel. Methods of conjugate gradients for solving linear systems.
+# M. R. Hestenes and E. Stiefel, Methods of conjugate gradients for solving linear systems.
 # Journal of Research of the National Bureau of Standards, 49(6), pp. 409--436, 1952.
+#
+# E. Stiefel, Relaxationsmethoden bester Strategie zur Losung linearer Gleichungssysteme.
+# Commentarii Mathematici Helvetici, 29(1), pp. 157--179, 1955.
 #
 # M-A. Dahito and D. Orban, The Conjugate Residual Method in Linesearch and Trust-Region Methods.
 # SIAM Journal on Optimization, 29(3), pp. 1988--2025, 2019.
@@ -29,8 +32,9 @@ with `n = length(b)`.
 
 #### References
 
-* M. R. Hestenes and E. Stiefel, *Methods of conjugate gradients for solving linear systems*, Journal of Research of the National Bureau of Standards, 49(6), pp. 409--436, 1952.
-* M-A. Dahito and D. Orban, *The Conjugate Residual Method in Linesearch and Trust-Region Methods*, SIAM Journal on Optimization, 29(3), pp. 1988--2025, 2019.
+* M. R. Hestenes and E. Stiefel, [*Methods of conjugate gradients for solving linear systems*](https://doi.org/10.6028/jres.049.044), Journal of Research of the National Bureau of Standards, 49(6), pp. 409--436, 1952.
+* E. Stiefel, [*Relaxationsmethoden bester Strategie zur Losung linearer Gleichungssysteme*](https://doi.org/10.1007/BF02564277), Commentarii Mathematici Helvetici, 29(1), pp. 157--179, 1955.
+* M-A. Dahito and D. Orban, [*The Conjugate Residual Method in Linesearch and Trust-Region Methods*](https://doi.org/10.1137/18M1204255), SIAM Journal on Optimization, 29(3), pp. 1988--2025, 2019.
 """
 function cr(A, b :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
   solver = CrSolver(A, b)
@@ -43,8 +47,9 @@ function cr!(solver :: CrSolver{T,S}, A, b :: AbstractVector{T};
              radius :: T=zero(T), verbose :: Int=0, linesearch :: Bool=false, history :: Bool=false) where {T <: AbstractFloat, S <: DenseVector{T}}
 
   linesearch && (radius > 0) && error("'linesearch' set to 'true' but radius > 0")
-  n = size(b, 1) # size of the problem
-  (size(A, 1) == n & size(A, 2) == n) || error("Inconsistent problem size")
+  n, m = size(A)
+  m == n || error("System must be square")
+  length(b) == n || error("Inconsistent problem size")
   (verbose > 0) && @printf("CR: system of %d equations in %d variables\n", n, n)
 
   # Tests M == Iₙ

--- a/src/craig.jl
+++ b/src/craig.jl
@@ -73,8 +73,8 @@ In this implementation, both the x and y-parts of the solution are returned.
 
 #### References
 
-* C. C. Paige and M. A. Saunders, *LSQR: An Algorithm for Sparse Linear Equations and Sparse Least Squares*, ACM Transactions on Mathematical Software, 8(1), pp. 43--71, 1982.
-* M. A. Saunders, *Solutions of Sparse Rectangular Systems Using LSQR and CRAIG*, BIT Numerical Mathematics, 35(4), pp. 588--604, 1995.
+* C. C. Paige and M. A. Saunders, [*LSQR: An Algorithm for Sparse Linear Equations and Sparse Least Squares*](https://doi.org/10.1145/355984.355989), ACM Transactions on Mathematical Software, 8(1), pp. 43--71, 1982.
+* M. A. Saunders, [*Solutions of Sparse Rectangular Systems Using LSQR and CRAIG*](https://doi.org/10.1007/BF01739829), BIT Numerical Mathematics, 35(4), pp. 588--604, 1995.
 """
 function craig(A, b :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
   solver = CraigSolver(A, b)

--- a/src/craigmr.jl
+++ b/src/craigmr.jl
@@ -66,8 +66,8 @@ returned.
 
 #### References
 
-* D. Orban and M. Arioli. *Iterative Solution of Symmetric Quasi-Definite Linear Systems*, Volume 3 of Spotlights. SIAM, Philadelphia, PA, 2017.
-* D. Orban, *The Projected Golub-Kahan Process for Constrained, Linear Least-Squares Problems*. Cahier du GERAD G-2014-15, 2014.
+* D. Orban and M. Arioli. [*Iterative Solution of Symmetric Quasi-Definite Linear Systems*](https://doi.org/10.1137/1.9781611974737), Volume 3 of Spotlights. SIAM, Philadelphia, PA, 2017.
+* D. Orban, [*The Projected Golub-Kahan Process for Constrained, Linear Least-Squares Problems*](https://dx.doi.org/10.13140/RG.2.2.17443.99360). Cahier du GERAD G-2014-15, 2014.
 """
 function craigmr(A, b :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
   solver = CraigmrSolver(A, b)

--- a/src/crmr.jl
+++ b/src/crmr.jl
@@ -58,8 +58,8 @@ A preconditioner M may be provided in the form of a linear operator.
 
 #### References
 
-* D. Orban and M. Arioli, *Iterative Solution of Symmetric Quasi-Definite Linear Systems*, Volume 3 of Spotlights. SIAM, Philadelphia, PA, 2017.
-* D. Orban, *The Projected Golub-Kahan Process for Constrained Linear Least-Squares Problems*. Cahier du GERAD G-2014-15, 2014.
+* D. Orban and M. Arioli, [*Iterative Solution of Symmetric Quasi-Definite Linear Systems*](https://doi.org/10.1137/1.9781611974737), Volume 3 of Spotlights. SIAM, Philadelphia, PA, 2017.
+* D. Orban, [*The Projected Golub-Kahan Process for Constrained Linear Least-Squares Problems*](https://dx.doi.org/10.13140/RG.2.2.17443.99360). Cahier du GERAD G-2014-15, 2014.
 """
 function crmr(A, b :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
   solver = CrmrSolver(A, b)

--- a/src/diom.jl
+++ b/src/diom.jl
@@ -30,7 +30,7 @@ This implementation allows a left preconditioner M and a right preconditioner N.
 
 #### Reference
 
-* Y. Saad, *Practical use of some krylov subspace methods for solving indefinite and nonsymmetric linear systems*, SIAM journal on scientific and statistical computing, 5(1), pp. 203--228, 1984.
+* Y. Saad, [*Practical use of some krylov subspace methods for solving indefinite and nonsymmetric linear systems*](https://doi.org/10.1137/0905015), SIAM journal on scientific and statistical computing, 5(1), pp. 203--228, 1984.
 """
 function diom(A, b :: AbstractVector{T}; memory :: Int=20, kwargs...) where T <: AbstractFloat
   solver = DiomSolver(A, b, memory)

--- a/src/dqgmres.jl
+++ b/src/dqgmres.jl
@@ -28,7 +28,7 @@ This implementation allows a left preconditioner M and a right preconditioner N.
 
 #### Reference
 
-* Y. Saad and K. Wu, *DQGMRES: a quasi minimal residual algorithm based on incomplete orthogonalization*, Numerical Linear Algebra with Applications, Vol. 3(4), pp. 329--343, 1996.
+* Y. Saad and K. Wu, [*DQGMRES: a quasi minimal residual algorithm based on incomplete orthogonalization*](https://doi.org/10.1002/(SICI)1099-1506(199607/08)3:4%3C329::AID-NLA86%3E3.0.CO;2-8), Numerical Linear Algebra with Applications, Vol. 3(4), pp. 329--343, 1996.
 """
 function dqgmres(A, b :: AbstractVector{T}; memory :: Int=20, kwargs...) where T <: AbstractFloat
   solver = DqgmresSolver(A, b, memory)

--- a/src/fom.jl
+++ b/src/fom.jl
@@ -28,7 +28,7 @@ This implementation allows a left preconditioner M and a right preconditioner N.
 
 #### Reference
 
-* Y. Saad, *Krylov subspace methods for solving unsymmetric linear systems*, Mathematics of computation, Vol. 37(155), pp. 105--126, 1981.
+* Y. Saad, [*Krylov subspace methods for solving unsymmetric linear systems*](https://doi.org/10.1090/S0025-5718-1981-0616364-6), Mathematics of computation, Vol. 37(155), pp. 105--126, 1981.
 """
 function fom(A, b :: AbstractVector{T}; memory :: Int=20, kwargs...) where T <: AbstractFloat
   solver = FomSolver(A, b, memory)

--- a/src/gmres.jl
+++ b/src/gmres.jl
@@ -28,7 +28,7 @@ This implementation allows a left preconditioner M and a right preconditioner N.
 
 #### Reference
 
-* Y. Saad and M. H. Schultz, *GMRES: A Generalized Minimal Residual Algorithm for Solving Nonsymmetric Linear Systems*, SIAM Journal on Scientific and Statistical Computing, Vol. 7(3), pp. 856--869, 1986.
+* Y. Saad and M. H. Schultz, [*GMRES: A Generalized Minimal Residual Algorithm for Solving Nonsymmetric Linear Systems*](https://doi.org/10.1137/0907058), SIAM Journal on Scientific and Statistical Computing, Vol. 7(3), pp. 856--869, 1986.
 """
 function gmres(A, b :: AbstractVector{T}; memory :: Int=20, kwargs...) where T <: AbstractFloat
   solver = GmresSolver(A, b, memory)

--- a/src/lnlq.jl
+++ b/src/lnlq.jl
@@ -66,7 +66,7 @@ For instance σ:=(1-1e-7)σₘᵢₙ .
 
 #### Reference
 
-* R. Estrin, D. Orban, M.A. Saunders, *LNLQ: An Iterative Method for Least-Norm Problems with an Error Minimization Property*, SIAM Journal on Matrix Analysis and Applications, 40(3), pp. 1102--1124, 2019.
+* R. Estrin, D. Orban, M.A. Saunders, [*LNLQ: An Iterative Method for Least-Norm Problems with an Error Minimization Property*](https://doi.org/10.1137/18M1194948), SIAM Journal on Matrix Analysis and Applications, 40(3), pp. 1102--1124, 2019.
 """
 function lnlq(A, b :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
   solver = LnlqSolver(A, b)

--- a/src/lslq.jl
+++ b/src/lslq.jl
@@ -124,8 +124,8 @@ The iterations stop as soon as one of the following conditions holds true:
 
 #### References
 
-* R. Estrin, D. Orban and M. A. Saunders, *Euclidean-norm error bounds for SYMMLQ and CG*, SIAM Journal on Matrix Analysis and Applications, 40(1), pp. 235--253, 2019.
-* R. Estrin, D. Orban and M. A. Saunders, *LSLQ: An Iterative Method for Linear Least-Squares with an Error Minimization Property*, SIAM Journal on Matrix Analysis and Applications, 40(1), pp. 254--275, 2019.
+* R. Estrin, D. Orban and M. A. Saunders, [*Euclidean-norm error bounds for SYMMLQ and CG*](https://doi.org/10.1137/16M1094816), SIAM Journal on Matrix Analysis and Applications, 40(1), pp. 235--253, 2019.
+* R. Estrin, D. Orban and M. A. Saunders, [*LSLQ: An Iterative Method for Linear Least-Squares with an Error Minimization Property*](https://doi.org/10.1137/17M1113552), SIAM Journal on Matrix Analysis and Applications, 40(1), pp. 254--275, 2019.
 """
 function lslq(A, b :: AbstractVector{T}; window :: Int=5, kwargs...) where T <: AbstractFloat
   solver = LslqSolver(A, b, window=window)

--- a/src/lsmr.jl
+++ b/src/lsmr.jl
@@ -89,7 +89,7 @@ Note that `history` should be set to `true` to have access to `rNorms` and `ArNo
 
 #### Reference
 
-* D. C.-L. Fong and M. A. Saunders, *LSMR: An Iterative Algorithm for Sparse Least Squares Problems*, SIAM Journal on Scientific Computing, 33(5), pp. 2950--2971, 2011.
+* D. C.-L. Fong and M. A. Saunders, [*LSMR: An Iterative Algorithm for Sparse Least Squares Problems*](https://doi.org/10.1137/10079687X), SIAM Journal on Scientific Computing, 33(5), pp. 2950--2971, 2011.
 """
 function lsmr(A, b :: AbstractVector{T}; window :: Int=5, kwargs...) where T <: AbstractFloat
   solver = LsmrSolver(A, b, window=window)

--- a/src/lsqr.jl
+++ b/src/lsqr.jl
@@ -79,7 +79,7 @@ In this case, `N` can still be specified and indicates the weighted norm in whic
 
 #### Reference
 
-* C. C. Paige and M. A. Saunders, *LSQR: An Algorithm for Sparse Linear Equations and Sparse Least Squares*, ACM Transactions on Mathematical Software, 8(1), pp. 43--71, 1982.
+* C. C. Paige and M. A. Saunders, [*LSQR: An Algorithm for Sparse Linear Equations and Sparse Least Squares*](https://doi.org/10.1145/355984.355989), ACM Transactions on Mathematical Software, 8(1), pp. 43--71, 1982.
 """
 function lsqr(A, b :: AbstractVector{T}; window :: Int=5, kwargs...) where T <: AbstractFloat
   solver = LsqrSolver(A, b, window=window)

--- a/src/minres.jl
+++ b/src/minres.jl
@@ -53,7 +53,7 @@ assumed to be symmetric and positive definite.
 
 #### Reference
 
-* C. C. Paige and M. A. Saunders, *Solution of Sparse Indefinite Systems of Linear Equations*, SIAM Journal on Numerical Analysis, 12(4), pp. 617--629, 1975.
+* C. C. Paige and M. A. Saunders, [*Solution of Sparse Indefinite Systems of Linear Equations*](https://doi.org/10.1137/0712047), SIAM Journal on Numerical Analysis, 12(4), pp. 617--629, 1975.
 """
 function minres(A, b :: AbstractVector{T}; window :: Int=5, kwargs...) where T <: AbstractFloat
   solver = MinresSolver(A, b, window=window)

--- a/src/minres_qlp.jl
+++ b/src/minres_qlp.jl
@@ -33,8 +33,8 @@ M also indicates the weighted norm in which residuals are measured.
 #### References
 
 * S.-C. T. Choi, *Iterative methods for singular linear equations and least-squares problems*, Ph.D. thesis, ICME, Stanford University, 2006.
-* S.-C. T. Choi, C. C. Paige and M. A. Saunders, *MINRES-QLP: A Krylov subspace method for indefinite or singular symmetric systems*, SIAM Journal on Scientific Computing, Vol. 33(4), pp. 1810--1836, 2011.
-* S.-C. T. Choi and M. A. Saunders, *Algorithm 937: MINRES-QLP for symmetric and Hermitian linear equations and least-squares problems*, ACM Transactions on Mathematical Software, 40(2), pp. 1--12, 2014.
+* S.-C. T. Choi, C. C. Paige and M. A. Saunders, [*MINRES-QLP: A Krylov subspace method for indefinite or singular symmetric systems*](https://doi.org/10.1137/100787921), SIAM Journal on Scientific Computing, Vol. 33(4), pp. 1810--1836, 2011.
+* S.-C. T. Choi and M. A. Saunders, [*Algorithm 937: MINRES-QLP for symmetric and Hermitian linear equations and least-squares problems*](https://doi.org/10.1145/2527267), ACM Transactions on Mathematical Software, 40(2), pp. 1--12, 2014.
 """
 function minres_qlp(A, b :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
   solver = MinresQlpSolver(A, b)

--- a/src/qmr.jl
+++ b/src/qmr.jl
@@ -33,9 +33,9 @@ When `A` is symmetric and `b = c`, QMR is equivalent to MINRES.
 
 #### References
 
-* R. W. Freund and N. M. Nachtigal, *QMR : a quasi-minimal residual method for non-Hermitian linear systems*, Numerische mathematik, Vol. 60(1), pp. 315--339, 1991.
-* R. W. Freund and N. M. Nachtigal, *An implementation of the QMR method based on coupled two-term recurrences*, SIAM Journal on Scientific Computing, Vol. 15(2), pp. 313--337, 1994.
-* A. Montoison and D. Orban, *BiLQ: An Iterative Method for Nonsymmetric Linear Systems with a Quasi-Minimum Error Property*, SIAM Journal on Matrix Analysis and Applications, 41(3), pp. 1145--1166, 2020.
+* R. W. Freund and N. M. Nachtigal, [*QMR : a quasi-minimal residual method for non-Hermitian linear systems*](https://doi.org/10.1007/BF01385726), Numerische mathematik, Vol. 60(1), pp. 315--339, 1991.
+* R. W. Freund and N. M. Nachtigal, [*An implementation of the QMR method based on coupled two-term recurrences*](https://doi.org/10.1137/0915022), SIAM Journal on Scientific Computing, Vol. 15(2), pp. 313--337, 1994.
+* A. Montoison and D. Orban, [*BiLQ: An Iterative Method for Nonsymmetric Linear Systems with a Quasi-Minimum Error Property*](https://doi.org/10.1137/19M1290991), SIAM Journal on Matrix Analysis and Applications, 41(3), pp. 1145--1166, 2020.
 """
 function qmr(A, b :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
   solver = QmrSolver(A, b)

--- a/src/symmlq.jl
+++ b/src/symmlq.jl
@@ -34,7 +34,7 @@ assumed to be symmetric and positive definite.
 
 #### Reference
 
-* C. C. Paige and M. A. Saunders, *Solution of Sparse Indefinite Systems of Linear Equations*, SIAM Journal on Numerical Analysis, 12(4), pp. 617--629, 1975.
+* C. C. Paige and M. A. Saunders, [*Solution of Sparse Indefinite Systems of Linear Equations*](https://doi.org/10.1137/0712047), SIAM Journal on Numerical Analysis, 12(4), pp. 617--629, 1975.
 """
 function symmlq(A, b :: AbstractVector{T}; window :: Int=5, kwargs...) where T <: AbstractFloat
   solver = SymmlqSolver(A, b, window=window)

--- a/src/tricg.jl
+++ b/src/tricg.jl
@@ -51,7 +51,7 @@ Information will be displayed every `verbose` iterations.
 
 #### Reference
 
-* A. Montoison and D. Orban, *TriCG and TriMR: Two Iterative Methods for Symmetric Quasi-Definite Systems*, SIAM Journal on Scientific Computing, 43(4), pp. 2502--2525, 2021.
+* A. Montoison and D. Orban, [*TriCG and TriMR: Two Iterative Methods for Symmetric Quasi-Definite Systems*](https://doi.org/10.1137/20M1363030), SIAM Journal on Scientific Computing, 43(4), pp. 2502--2525, 2021.
 """
 function tricg(A, b :: AbstractVector{T}, c :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
   solver = TricgSolver(A, b)

--- a/src/trilqr.jl
+++ b/src/trilqr.jl
@@ -30,7 +30,7 @@ USYMCG point, when it exists. The transfer is based on the residual norm.
 
 #### Reference
 
-* A. Montoison and D. Orban, *BiLQ: An Iterative Method for Nonsymmetric Linear Systems with a Quasi-Minimum Error Property*, SIAM Journal on Matrix Analysis and Applications, 41(3), pp. 1145--1166, 2020.
+* A. Montoison and D. Orban, [*BiLQ: An Iterative Method for Nonsymmetric Linear Systems with a Quasi-Minimum Error Property*](https://doi.org/10.1137/19M1290991), SIAM Journal on Matrix Analysis and Applications, 41(3), pp. 1145--1166, 2020.
 """
 function trilqr(A, b :: AbstractVector{T}, c :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
   solver = TrilqrSolver(A, b)

--- a/src/trimr.jl
+++ b/src/trimr.jl
@@ -51,7 +51,7 @@ Information will be displayed every `verbose` iterations.
 
 #### Reference
 
-* A. Montoison and D. Orban, *TriCG and TriMR: Two Iterative Methods for Symmetric Quasi-Definite Systems*, SIAM Journal on Scientific Computing, 43(4), pp. 2502--2525, 2021.
+* A. Montoison and D. Orban, [*TriCG and TriMR: Two Iterative Methods for Symmetric Quasi-Definite Systems*](https://doi.org/10.1137/20M1363030), SIAM Journal on Scientific Computing, 43(4), pp. 2502--2525, 2021.
 """
 function trimr(A, b :: AbstractVector{T}, c :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
   solver = TrimrSolver(A, b)

--- a/src/usymlq.jl
+++ b/src/usymlq.jl
@@ -39,9 +39,9 @@ when it exists. The transfer is based on the residual norm.
 
 #### References
 
-* M. A. Saunders, H. D. Simon, and E. L. Yip, *Two Conjugate-Gradient-Type Methods for Unsymmetric Linear Equations*, SIAM Journal on Numerical Analysis, 25(4), pp. 927--940, 1988.
-* A. Buttari, D. Orban, D. Ruiz and D. Titley-Peloquin, *A tridiagonalization method for symmetric saddle-point and quasi-definite systems*, SIAM Journal on Scientific Computing, 41(5), pp. 409--432, 2019.
-* A. Montoison and D. Orban, *BiLQ: An Iterative Method for Nonsymmetric Linear Systems with a Quasi-Minimum Error Property*, SIAM Journal on Matrix Analysis and Applications, 41(3), pp. 1145--1166, 2020.
+* M. A. Saunders, H. D. Simon, and E. L. Yip, [*Two Conjugate-Gradient-Type Methods for Unsymmetric Linear Equations*](https://doi.org/10.1137/0725052), SIAM Journal on Numerical Analysis, 25(4), pp. 927--940, 1988.
+* A. Buttari, D. Orban, D. Ruiz and D. Titley-Peloquin, [*A tridiagonalization method for symmetric saddle-point and quasi-definite systems*](https://doi.org/10.1137/18M1194900), SIAM Journal on Scientific Computing, 41(5), pp. 409--432, 2019.
+* A. Montoison and D. Orban, [*BiLQ: An Iterative Method for Nonsymmetric Linear Systems with a Quasi-Minimum Error Property*](https://doi.org/10.1137/19M1290991), SIAM Journal on Matrix Analysis and Applications, 41(3), pp. 1145--1166, 2020.
 """
 function usymlq(A, b :: AbstractVector{T}, c :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
   solver = UsymlqSolver(A, b)

--- a/src/usymqr.jl
+++ b/src/usymqr.jl
@@ -36,9 +36,9 @@ USYMQR finds the minimum-norm solution if problems are inconsistent.
 
 #### References
 
-* M. A. Saunders, H. D. Simon, and E. L. Yip, *Two Conjugate-Gradient-Type Methods for Unsymmetric Linear Equations*, SIAM Journal on Numerical Analysis, 25(4), pp. 927--940, 1988.
-* A. Buttari, D. Orban, D. Ruiz and D. Titley-Peloquin, *A tridiagonalization method for symmetric saddle-point and quasi-definite systems*, SIAM Journal on Scientific Computing, 41(5), pp. 409--432, 2019.
-* A. Montoison and D. Orban, *BiLQ: An Iterative Method for Nonsymmetric Linear Systems with a Quasi-Minimum Error Property*, SIAM Journal on Matrix Analysis and Applications, 41(3), pp. 1145--1166, 2020.
+* M. A. Saunders, H. D. Simon, and E. L. Yip, [*Two Conjugate-Gradient-Type Methods for Unsymmetric Linear Equations*](https://doi.org/10.1137/0725052), SIAM Journal on Numerical Analysis, 25(4), pp. 927--940, 1988.
+* A. Buttari, D. Orban, D. Ruiz and D. Titley-Peloquin, [*A tridiagonalization method for symmetric saddle-point and quasi-definite systems*](https://doi.org/10.1137/18M1194900), SIAM Journal on Scientific Computing, 41(5), pp. 409--432, 2019.
+* A. Montoison and D. Orban, [*BiLQ: An Iterative Method for Nonsymmetric Linear Systems with a Quasi-Minimum Error Property*](https://doi.org/10.1137/19M1290991), SIAM Journal on Matrix Analysis and Applications, 41(3), pp. 1145--1166, 2020.
 """
 function usymqr(A, b :: AbstractVector{T}, c :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
   solver = UsymqrSolver(A, b)


### PR DESCRIPTION
close #448 
-> Five references don't have a DOI (3 thesis / 1 ETNA paper and a technical report)

* J. E. Craig, *Iterations Procedures for Simultaneous Equations*, Ph.D. Thesis, Department of Electrical Engineering, MIT, 1954.
* G. L.G. Sleijpen and D. R. Fokkema, *BiCGstab(ℓ) for linear equations involving unsymmetric matrices with complex spectrum*, Electronic Transactions on Numerical Analysis, 1, pp. 11--32, 1993.
* S.-C. T. Choi, *Iterative methods for singular linear equations and least-squares problems*, Ph.D. thesis, ICME, Stanford University, 2006.
* D. C.-L. Fong, *Minimum-Residual Methods for Sparse, Least-Squares using Golubg-Kahan Bidiagonalization*, Ph.D. Thesis, Stanford University, 2011.
* D. Orban, *The Projected Golub-Kahan Process for Constrained Linear Least-Squares Problems*. Cahier du GERAD G-2014-15, 2014.

@dpo Could you generate a DOI for your [technical report](https://www.researchgate.net/publication/264544703_The_Projected_Golub-Kahan_Process_for_Constrained_Linear_Least-Squares_Problems) ?