### PR TITLE
Support of complex linear systems

### DIFF
--- a/src/Krylov.jl
+++ b/src/Krylov.jl
@@ -2,8 +2,8 @@ module Krylov
 
 using LinearAlgebra, SparseArrays, Printf
 
-include("krylov_stats.jl")
 include("krylov_utils.jl")
+include("krylov_stats.jl")
 include("krylov_solvers.jl")
 
 include("cg.jl")

--- a/src/bicgstab.jl
+++ b/src/bicgstab.jl
@@ -16,9 +16,12 @@
 export bicgstab, bicgstab!
 
 """
-    (x, stats) = bicgstab(A, b::AbstractVector{T}; c::AbstractVector{T}=b,
+    (x, stats) = bicgstab(A, b::AbstractVector{FC}; c::AbstractVector{FC}=b,
                           M=I, N=I, atol::T=√eps(T), rtol::T=√eps(T),
-                          itmax::Int=0, verbose::Int=0, history::Bool=false) where T <: AbstractFloat
+                          itmax::Int=0, verbose::Int=0, history::Bool=false)
+
+`T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
+`FC` is `T` or `Complex{T}`.
 
 Solve the square linear system Ax = b using the BICGSTAB method.
 BICGSTAB requires two initial vectors `b` and `c`.
@@ -43,15 +46,15 @@ This implementation allows a left preconditioner `M` and a right preconditioner 
 * H. A. van der Vorst, [*Bi-CGSTAB: A fast and smoothly converging variant of Bi-CG for the solution of nonsymmetric linear systems*](https://doi.org/10.1137/0913035), SIAM Journal on Scientific and Statistical Computing, 13(2), pp. 631--644, 1992.
 * G. L.G. Sleijpen and D. R. Fokkema, *BiCGstab(ℓ) for linear equations involving unsymmetric matrices with complex spectrum*, Electronic Transactions on Numerical Analysis, 1, pp. 11--32, 1993.
 """
-function bicgstab(A, b :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
+function bicgstab(A, b :: AbstractVector{FC}; kwargs...) where FC <: FloatOrComplex
   solver = BicgstabSolver(A, b)
   bicgstab!(solver, A, b; kwargs...)
   return (solver.x, solver.stats)
 end
 
-function bicgstab!(solver :: BicgstabSolver{T,S}, A, b :: AbstractVector{T}; c :: AbstractVector{T}=b,
+function bicgstab!(solver :: BicgstabSolver{T,FC,S}, A, b :: AbstractVector{FC}; c :: AbstractVector{FC}=b,
                    M=I, N=I, atol :: T=√eps(T), rtol :: T=√eps(T),
-                   itmax :: Int=0, verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, S <: DenseVector{T}}
+                   itmax :: Int=0, verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: DenseVector{FC}}
 
   n, m = size(A)
   m == n || error("System must be square")

--- a/src/bilq.jl
+++ b/src/bilq.jl
@@ -13,9 +13,12 @@
 export bilq, bilq!
 
 """
-    (x, stats) = bilq(A, b::AbstractVector{T}; c::AbstractVector{T}=b,
+    (x, stats) = bilq(A, b::AbstractVector{FC}; c::AbstractVector{FC}=b,
                       atol::T=√eps(T), rtol::T=√eps(T), transfer_to_bicg::Bool=true,
-                      itmax::Int=0, verbose::Int=0, history::Bool=false) where T <: AbstractFloat
+                      itmax::Int=0, verbose::Int=0, history::Bool=false)
+
+`T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
+`FC` is `T` or `Complex{T}`.
 
 Solve the square linear system Ax = b using the BiLQ method.
 
@@ -30,15 +33,15 @@ when it exists. The transfer is based on the residual norm.
 
 * A. Montoison and D. Orban, [*BiLQ: An Iterative Method for Nonsymmetric Linear Systems with a Quasi-Minimum Error Property*](https://doi.org/10.1137/19M1290991), SIAM Journal on Matrix Analysis and Applications, 41(3), pp. 1145--1166, 2020.
 """
-function bilq(A, b :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
+function bilq(A, b :: AbstractVector{FC}; kwargs...) where FC <: FloatOrComplex
   solver = BilqSolver(A, b)
   bilq!(solver, A, b; kwargs...)
   return (solver.x, solver.stats)
 end
 
-function bilq!(solver :: BilqSolver{T,S}, A, b :: AbstractVector{T}; c :: AbstractVector{T}=b,
+function bilq!(solver :: BilqSolver{T,FC,S}, A, b :: AbstractVector{FC}; c :: AbstractVector{FC}=b,
                atol :: T=√eps(T), rtol :: T=√eps(T), transfer_to_bicg :: Bool=true,
-               itmax :: Int=0, verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, S <: DenseVector{T}}
+               itmax :: Int=0, verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: DenseVector{FC}}
 
   n, m = size(A)
   m == n || error("System must be square")

--- a/src/bilqr.jl
+++ b/src/bilqr.jl
@@ -13,9 +13,12 @@
 export bilqr, bilqr!
 
 """
-    (x, y, stats) = bilqr(A, b::AbstractVector{T}, c::AbstractVector{T};
+    (x, y, stats) = bilqr(A, b::AbstractVector{FC}, c::AbstractVector{FC};
                           atol::T=√eps(T), rtol::T=√eps(T), transfer_to_bicg::Bool=true,
-                          itmax::Int=0, verbose::Int=0, history::Bool=false) where T <: AbstractFloat
+                          itmax::Int=0, verbose::Int=0, history::Bool=false)
+
+`T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
+`FC` is `T` or `Complex{T}`.
 
 Combine BiLQ and QMR to solve adjoint systems.
 
@@ -33,15 +36,15 @@ BiCG point, when it exists. The transfer is based on the residual norm.
 
 * A. Montoison and D. Orban, [*BiLQ: An Iterative Method for Nonsymmetric Linear Systems with a Quasi-Minimum Error Property*](https://doi.org/10.1137/19M1290991), SIAM Journal on Matrix Analysis and Applications, 41(3), pp. 1145--1166, 2020.
 """
-function bilqr(A, b :: AbstractVector{T}, c :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
+function bilqr(A, b :: AbstractVector{FC}, c :: AbstractVector{FC}; kwargs...) where FC <: FloatOrComplex
   solver = BilqrSolver(A, b)
   bilqr!(solver, A, b, c; kwargs...)
   return (solver.x, solver.y, solver.stats)
 end
 
-function bilqr!(solver :: BilqrSolver{T,S}, A, b :: AbstractVector{T}, c :: AbstractVector{T};
+function bilqr!(solver :: BilqrSolver{T,FC,S}, A, b :: AbstractVector{FC}, c :: AbstractVector{FC};
                 atol :: T=√eps(T), rtol :: T=√eps(T), transfer_to_bicg :: Bool=true,
-                itmax :: Int=0, verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, S <: DenseVector{T}}
+                itmax :: Int=0, verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: DenseVector{FC}}
 
   n, m = size(A)
   m == n || error("Systems must be square")

--- a/src/cg.jl
+++ b/src/cg.jl
@@ -17,10 +17,13 @@ export cg, cg!
 
 
 """
-    (x, stats) = cg(A, b::AbstractVector{T};
+    (x, stats) = cg(A, b::AbstractVector{FC};
                     M=I, atol::T=√eps(T), rtol::T=√eps(T), restart::Bool=false,
                     itmax::Int=0, radius::T=zero(T), linesearch::Bool=false,
-                    verbose::Int=0, history::Bool=false) where T <: AbstractFloat
+                    verbose::Int=0, history::Bool=false)
+
+`T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
+`FC` is `T` or `Complex{T}`.
 
 The conjugate gradient method to solve the symmetric linear system Ax=b.
 
@@ -37,16 +40,16 @@ with `n = length(b)`.
 
 * M. R. Hestenes and E. Stiefel, [*Methods of conjugate gradients for solving linear systems*](https://doi.org/10.6028/jres.049.044), Journal of Research of the National Bureau of Standards, 49(6), pp. 409--436, 1952.
 """
-function cg(A, b :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
+function cg(A, b :: AbstractVector{FC}; kwargs...) where FC <: FloatOrComplex
   solver = CgSolver(A, b)
   cg!(solver, A, b; kwargs...)
   return (solver.x, solver.stats)
 end
 
-function cg!(solver :: CgSolver{T,S}, A, b :: AbstractVector{T};
+function cg!(solver :: CgSolver{T,FC,S}, A, b :: AbstractVector{FC};
              M=I, atol :: T=√eps(T), rtol :: T=√eps(T), restart :: Bool=false,
              itmax :: Int=0, radius :: T=zero(T), linesearch :: Bool=false,
-             verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, S <: DenseVector{T}}
+             verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: DenseVector{FC}}
 
   linesearch && (radius > 0) && error("`linesearch` set to `true` but trust-region radius > 0")
 

--- a/src/cg_lanczos.jl
+++ b/src/cg_lanczos.jl
@@ -15,9 +15,12 @@ export cg_lanczos, cg_lanczos!
 
 
 """
-    (x, stats) = cg_lanczos(A, b::AbstractVector{T};
+    (x, stats) = cg_lanczos(A, b::AbstractVector{FC};
                             M=I, atol::T=√eps(T), rtol::T=√eps(T), itmax::Int=0,
-                            check_curvature::Bool=false, verbose::Int=0, history::Bool=false) where T <: AbstractFloat
+                            check_curvature::Bool=false, verbose::Int=0, history::Bool=false)
+
+`T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
+`FC` is `T` or `Complex{T}`.
 
 The Lanczos version of the conjugate gradient method to solve the
 symmetric linear system
@@ -34,15 +37,15 @@ assumed to be symmetric and positive definite.
 * A. Frommer and P. Maass, [*Fast CG-Based Methods for Tikhonov-Phillips Regularization*](https://doi.org/10.1137/S1064827596313310), SIAM Journal on Scientific Computing, 20(5), pp. 1831--1850, 1999.
 * C. C. Paige and M. A. Saunders, [*Solution of Sparse Indefinite Systems of Linear Equations*](https://doi.org/10.1137/0712047), SIAM Journal on Numerical Analysis, 12(4), pp. 617--629, 1975.
 """
-function cg_lanczos(A, b :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
+function cg_lanczos(A, b :: AbstractVector{FC}; kwargs...) where FC <: FloatOrComplex
   solver = CgLanczosSolver(A, b)
   cg_lanczos!(solver, A, b; kwargs...)
   return (solver.x, solver.stats)
 end
 
-function cg_lanczos!(solver :: CgLanczosSolver{T,S}, A, b :: AbstractVector{T};
+function cg_lanczos!(solver :: CgLanczosSolver{T,FC,S}, A, b :: AbstractVector{FC};
                      M=I, atol :: T=√eps(T), rtol :: T=√eps(T), itmax :: Int=0,
-                     check_curvature :: Bool=false, verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, S <: DenseVector{T}}
+                     check_curvature :: Bool=false, verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: DenseVector{FC}}
 
   n, m = size(A)
   m == n || error("System must be square")
@@ -160,9 +163,12 @@ end
 
 
 """
-    (x, stats) = cg_lanczos(A, b::AbstractVector{T}, shifts::AbstractVector{T};
+    (x, stats) = cg_lanczos(A, b::AbstractVector{FC}, shifts::AbstractVector{FC};
                             M=I, atol::T=√eps(T), rtol::T=√eps(T), itmax::Int=0,
-                            check_curvature::Bool=false, verbose::Int=0, history::Bool=false) where T <: AbstractFloat
+                            check_curvature::Bool=false, verbose::Int=0, history::Bool=false)
+
+`T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
+`FC` is `T` or `Complex{T}`.
 
 The Lanczos version of the conjugate gradient method to solve a family
 of shifted systems
@@ -174,16 +180,16 @@ The method does _not_ abort if A + αI is not definite.
 A preconditioner M may be provided in the form of a linear operator and is
 assumed to be symmetric and positive definite.
 """
-function cg_lanczos(A, b :: AbstractVector{T}, shifts :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
+function cg_lanczos(A, b :: AbstractVector{FC}, shifts :: AbstractVector{FC}; kwargs...) where FC <: FloatOrComplex
   nshifts = length(shifts)
   solver = CgLanczosShiftSolver(A, b, nshifts)
   cg_lanczos!(solver, A, b, shifts; kwargs...)
   return (solver.x, solver.stats)
 end
 
-function cg_lanczos!(solver :: CgLanczosShiftSolver{T,S}, A, b :: AbstractVector{T}, shifts :: AbstractVector{T};
+function cg_lanczos!(solver :: CgLanczosShiftSolver{T,FC,S}, A, b :: AbstractVector{FC}, shifts :: AbstractVector{FC};
                      M=I, atol :: T=√eps(T), rtol :: T=√eps(T), itmax :: Int=0,
-                     check_curvature :: Bool=false, verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, S <: DenseVector{T}}
+                     check_curvature :: Bool=false, verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: DenseVector{FC}}
 
   n, m = size(A)
   m == n || error("System must be square")

--- a/src/cgls.jl
+++ b/src/cgls.jl
@@ -30,9 +30,12 @@ export cgls, cgls!
 
 
 """
-    (x, stats) = cgls(A, b::AbstractVector{T};
+    (x, stats) = cgls(A, b::AbstractVector{FC};
                       M=I, λ::T=zero(T), atol::T=√eps(T), rtol::T=√eps(T),
-                      radius::T=zero(T), itmax::Int=0, verbose::Int=0, history::Bool=false) where T <: AbstractFloat
+                      radius::T=zero(T), itmax::Int=0, verbose::Int=0, history::Bool=false)
+
+`T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
+`FC` is `T` or `Complex{T}`.
 
 Solve the regularized linear least-squares problem
 
@@ -54,15 +57,15 @@ but simpler to implement.
 * M. R. Hestenes and E. Stiefel. [*Methods of conjugate gradients for solving linear systems*](https://doi.org/10.6028/jres.049.044), Journal of Research of the National Bureau of Standards, 49(6), pp. 409--436, 1952.
 * A. Björck, T. Elfving and Z. Strakos, [*Stability of Conjugate Gradient and Lanczos Methods for Linear Least Squares Problems*](https://doi.org/10.1137/S089547989631202X), SIAM Journal on Matrix Analysis and Applications, 19(3), pp. 720--736, 1998.
 """
-function cgls(A, b :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
+function cgls(A, b :: AbstractVector{FC}; kwargs...) where FC <: FloatOrComplex
   solver = CglsSolver(A, b)
   cgls!(solver, A, b; kwargs...)
   return (solver.x, solver.stats)
 end
 
-function cgls!(solver :: CglsSolver{T,S}, A, b :: AbstractVector{T};
+function cgls!(solver :: CglsSolver{T,FC,S}, A, b :: AbstractVector{FC};
                M=I, λ :: T=zero(T), atol :: T=√eps(T), rtol :: T=√eps(T),
-               radius :: T=zero(T), itmax :: Int=0, verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, S <: DenseVector{T}}
+               radius :: T=zero(T), itmax :: Int=0, verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: DenseVector{FC}}
 
   m, n = size(A)
   length(b) == m || error("Inconsistent problem size")

--- a/src/cgne.jl
+++ b/src/cgne.jl
@@ -30,9 +30,12 @@ export cgne, cgne!
 
 
 """
-    (x, stats) = cgne(A, b::AbstractVector{T};
+    (x, stats) = cgne(A, b::AbstractVector{FC};
                       M=I, λ::T=zero(T), atol::T=√eps(T), rtol::T=√eps(T),
-                      itmax::Int=0, verbose::Int=0, history::Bool=false) where T <: AbstractFloat
+                      itmax::Int=0, verbose::Int=0, history::Bool=false)
+
+`T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
+`FC` is `T` or `Complex{T}`.
 
 Solve the consistent linear system
 
@@ -63,15 +66,15 @@ A preconditioner M may be provided in the form of a linear operator.
 * J. E. Craig, [*The N-step iteration procedures*](https://doi.org/10.1002/sapm195534164), Journal of Mathematics and Physics, 34(1), pp. 64--73, 1955.
 * J. E. Craig, *Iterations Procedures for Simultaneous Equations*, Ph.D. Thesis, Department of Electrical Engineering, MIT, 1954.
 """
-function cgne(A, b :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
+function cgne(A, b :: AbstractVector{FC}; kwargs...) where FC <: FloatOrComplex
   solver = CgneSolver(A, b)
   cgne!(solver, A, b; kwargs...)
   return (solver.x, solver.stats)
 end
 
-function cgne!(solver :: CgneSolver{T,S}, A, b :: AbstractVector{T};
+function cgne!(solver :: CgneSolver{T,FC,S}, A, b :: AbstractVector{FC};
                M=I, λ :: T=zero(T), atol :: T=√eps(T), rtol :: T=√eps(T),
-               itmax :: Int=0, verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, S <: DenseVector{T}}
+               itmax :: Int=0, verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: DenseVector{FC}}
 
   m, n = size(A)
   length(b) == m || error("Inconsistent problem size")

--- a/src/cgs.jl
+++ b/src/cgs.jl
@@ -11,9 +11,12 @@
 export cgs, cgs!
 
 """
-    (x, stats) = cgs(A, b::AbstractVector{T}; c::AbstractVector{T}=b,
+    (x, stats) = cgs(A, b::AbstractVector{FC}; c::AbstractVector{FC}=b,
                      M=I, N=I, atol::T=√eps(T), rtol::T=√eps(T),
-                     itmax::Int=0, verbose::Int=0, history::Bool=false) where T <: AbstractFloat
+                     itmax::Int=0, verbose::Int=0, history::Bool=false)
+
+`T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
+`FC` is `T` or `Complex{T}`.
 
 Solve the consistent linear system Ax = b using conjugate gradient squared algorithm.
 CGS requires two initial vectors `b` and `c`.
@@ -40,15 +43,15 @@ This implementation allows a left preconditioner M and a right preconditioner N.
 
 * P. Sonneveld, [*CGS, A Fast Lanczos-Type Solver for Nonsymmetric Linear systems*](https://doi.org/10.1137/0910004), SIAM Journal on Scientific and Statistical Computing, 10(1), pp. 36--52, 1989.
 """
-function cgs(A, b :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
+function cgs(A, b :: AbstractVector{FC}; kwargs...) where FC <: FloatOrComplex
   solver = CgsSolver(A, b)
   cgs!(solver, A, b; kwargs...)
   return (solver.x, solver.stats)
 end
 
-function cgs!(solver :: CgsSolver{T,S}, A, b :: AbstractVector{T}; c :: AbstractVector{T}=b,
+function cgs!(solver :: CgsSolver{T,FC,S}, A, b :: AbstractVector{FC}; c :: AbstractVector{FC}=b,
               M=I, N=I, atol :: T=√eps(T), rtol :: T=√eps(T),
-              itmax :: Int=0, verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, S <: DenseVector{T}}
+              itmax :: Int=0, verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: DenseVector{FC}}
 
   m, n = size(A)
   m == n || error("System must be square")

--- a/src/cr.jl
+++ b/src/cr.jl
@@ -15,9 +15,12 @@
 export cr, cr!
 
 """
-    (x, stats) = cr(A, b::AbstractVector{T};
+    (x, stats) = cr(A, b::AbstractVector{FC};
                     M=I, atol::T=√eps(T), rtol::T=√eps(T), γ::T=√eps(T), itmax::Int=0,
-                    radius::T=zero(T), verbose::Int=0, linesearch::Bool=false, history::Bool=false) where T <: AbstractFloat
+                    radius::T=zero(T), verbose::Int=0, linesearch::Bool=false, history::Bool=false)
+
+`T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
+`FC` is `T` or `Complex{T}`.
 
 A truncated version of Stiefel’s Conjugate Residual method to solve the symmetric linear system Ax = b or the least-squares problem min ‖b - Ax‖.
 The matrix A must be positive semi-definite.
@@ -36,15 +39,15 @@ with `n = length(b)`.
 * E. Stiefel, [*Relaxationsmethoden bester Strategie zur Losung linearer Gleichungssysteme*](https://doi.org/10.1007/BF02564277), Commentarii Mathematici Helvetici, 29(1), pp. 157--179, 1955.
 * M-A. Dahito and D. Orban, [*The Conjugate Residual Method in Linesearch and Trust-Region Methods*](https://doi.org/10.1137/18M1204255), SIAM Journal on Optimization, 29(3), pp. 1988--2025, 2019.
 """
-function cr(A, b :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
+function cr(A, b :: AbstractVector{FC}; kwargs...) where FC <: FloatOrComplex
   solver = CrSolver(A, b)
   cr!(solver, A, b; kwargs...)
   return (solver.x, solver.stats)
 end
 
-function cr!(solver :: CrSolver{T,S}, A, b :: AbstractVector{T};
+function cr!(solver :: CrSolver{T,FC,S}, A, b :: AbstractVector{FC};
              M=I, atol :: T=√eps(T), rtol :: T=√eps(T), γ :: T=√eps(T), itmax :: Int=0,
-             radius :: T=zero(T), verbose :: Int=0, linesearch :: Bool=false, history :: Bool=false) where {T <: AbstractFloat, S <: DenseVector{T}}
+             radius :: T=zero(T), verbose :: Int=0, linesearch :: Bool=false, history :: Bool=false) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: DenseVector{FC}}
 
   linesearch && (radius > 0) && error("'linesearch' set to 'true' but radius > 0")
   n, m = size(A)

--- a/src/craig.jl
+++ b/src/craig.jl
@@ -34,10 +34,13 @@ export craig, craig!
 
 
 """
-    (x, y, stats) = craig(A, b::AbstractVector{T};
+    (x, y, stats) = craig(A, b::AbstractVector{FC};
                           M=I, N=I, sqd::Bool=false, λ::T=zero(T), atol::T=√eps(T),
                           btol::T=√eps(T), rtol::T=√eps(T), conlim::T=1/√eps(T), itmax::Int=0,
-                          verbose::Int=0, transfer_to_lsqr::Bool=false, history::Bool=false) where T <: AbstractFloat
+                          verbose::Int=0, transfer_to_lsqr::Bool=false, history::Bool=false)
+
+`T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
+`FC` is `T` or `Complex{T}`.
 
 Find the least-norm solution of the consistent linear system
 
@@ -76,16 +79,16 @@ In this implementation, both the x and y-parts of the solution are returned.
 * C. C. Paige and M. A. Saunders, [*LSQR: An Algorithm for Sparse Linear Equations and Sparse Least Squares*](https://doi.org/10.1145/355984.355989), ACM Transactions on Mathematical Software, 8(1), pp. 43--71, 1982.
 * M. A. Saunders, [*Solutions of Sparse Rectangular Systems Using LSQR and CRAIG*](https://doi.org/10.1007/BF01739829), BIT Numerical Mathematics, 35(4), pp. 588--604, 1995.
 """
-function craig(A, b :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
+function craig(A, b :: AbstractVector{FC}; kwargs...) where FC <: FloatOrComplex
   solver = CraigSolver(A, b)
   craig!(solver, A, b; kwargs...)
   return (solver.x, solver.y, solver.stats)
 end
 
-function craig!(solver :: CraigSolver{T,S}, A, b :: AbstractVector{T};
+function craig!(solver :: CraigSolver{T,FC,S}, A, b :: AbstractVector{FC};
                 M=I, N=I, sqd :: Bool=false, λ :: T=zero(T), atol :: T=√eps(T),
                 btol :: T=√eps(T), rtol :: T=√eps(T), conlim :: T=1/√eps(T), itmax :: Int=0,
-                verbose :: Int=0, transfer_to_lsqr :: Bool=false, history :: Bool=false) where {T <: AbstractFloat, S <: DenseVector{T}}
+                verbose :: Int=0, transfer_to_lsqr :: Bool=false, history :: Bool=false) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: DenseVector{FC}}
 
   m, n = size(A)
   length(b) == m || error("Inconsistent problem size")

--- a/src/craigmr.jl
+++ b/src/craigmr.jl
@@ -28,9 +28,12 @@ export craigmr, craigmr!
 
 
 """
-    (x, y, stats) = craigmr(A, b::AbstractVector{T};
+    (x, y, stats) = craigmr(A, b::AbstractVector{FC};
                             M=I, N=I, λ::T=zero(T), atol::T=√eps(T),
-                            rtol::T=√eps(T), itmax::Int=0, verbose::Int=0, history::Bool=false) where T <: AbstractFloat
+                            rtol::T=√eps(T), itmax::Int=0, verbose::Int=0, history::Bool=false)
+
+`T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
+`FC` is `T` or `Complex{T}`.
 
 Solve the consistent linear system
 
@@ -69,15 +72,15 @@ returned.
 * D. Orban and M. Arioli. [*Iterative Solution of Symmetric Quasi-Definite Linear Systems*](https://doi.org/10.1137/1.9781611974737), Volume 3 of Spotlights. SIAM, Philadelphia, PA, 2017.
 * D. Orban, [*The Projected Golub-Kahan Process for Constrained, Linear Least-Squares Problems*](https://dx.doi.org/10.13140/RG.2.2.17443.99360). Cahier du GERAD G-2014-15, 2014.
 """
-function craigmr(A, b :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
+function craigmr(A, b :: AbstractVector{FC}; kwargs...) where FC <: FloatOrComplex
   solver = CraigmrSolver(A, b)
   craigmr!(solver, A, b; kwargs...)
   return (solver.x, solver.y, solver.stats)
 end
 
-function craigmr!(solver :: CraigmrSolver{T,S}, A, b :: AbstractVector{T};
+function craigmr!(solver :: CraigmrSolver{T,FC,S}, A, b :: AbstractVector{FC};
                   M=I, N=I, λ :: T=zero(T), atol :: T=√eps(T),
-                  rtol :: T=√eps(T), itmax :: Int=0, verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, S <: DenseVector{T}}
+                  rtol :: T=√eps(T), itmax :: Int=0, verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: DenseVector{FC}}
 
   m, n = size(A)
   length(b) == m || error("Inconsistent problem size")

--- a/src/crls.jl
+++ b/src/crls.jl
@@ -22,9 +22,12 @@ export crls, crls!
 
 
 """
-    (x, stats) = crls(A, b::AbstractVector{T};
+    (x, stats) = crls(A, b::AbstractVector{FC};
                       M=I, λ::T=zero(T), atol::T=√eps(T), rtol::T=√eps(T),
-                      radius::T=zero(T), itmax::Int=0, verbose::Int=0, history::Bool=false) where T <: AbstractFloat
+                      radius::T=zero(T), itmax::Int=0, verbose::Int=0, history::Bool=false)
+
+`T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
+`FC` is `T` or `Complex{T}`.
 
 Solve the linear least-squares problem
 
@@ -45,15 +48,15 @@ but simpler to implement.
 
 * D. C.-L. Fong, *Minimum-Residual Methods for Sparse, Least-Squares using Golubg-Kahan Bidiagonalization*, Ph.D. Thesis, Stanford University, 2011.
 """
-function crls(A, b :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
+function crls(A, b :: AbstractVector{FC}; kwargs...) where FC <: FloatOrComplex
   solver = CrlsSolver(A, b)
   crls!(solver, A, b; kwargs...)
   return (solver.x, solver.stats)
 end
 
-function crls!(solver :: CrlsSolver{T,S}, A, b :: AbstractVector{T};
+function crls!(solver :: CrlsSolver{T,FC,S}, A, b :: AbstractVector{FC};
                M=I, λ :: T=zero(T), atol :: T=√eps(T), rtol :: T=√eps(T),
-               radius :: T=zero(T), itmax :: Int=0, verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, S <: DenseVector{T}}
+               radius :: T=zero(T), itmax :: Int=0, verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: DenseVector{FC}}
 
   m, n = size(A)
   length(b) == m || error("Inconsistent problem size")

--- a/src/crmr.jl
+++ b/src/crmr.jl
@@ -28,9 +28,12 @@ export crmr, crmr!
 
 
 """
-    (x, stats) = crmr(A, b::AbstractVector{T};
+    (x, stats) = crmr(A, b::AbstractVector{FC};
                       M=I, λ::T=zero(T), atol::T=√eps(T),
-                      rtol::T=√eps(T), itmax::Int=0, verbose::Int=0, history::Bool=false) where T <: AbstractFloat
+                      rtol::T=√eps(T), itmax::Int=0, verbose::Int=0, history::Bool=false)
+
+`T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
+`FC` is `T` or `Complex{T}`.
 
 Solve the consistent linear system
 
@@ -61,15 +64,15 @@ A preconditioner M may be provided in the form of a linear operator.
 * D. Orban and M. Arioli, [*Iterative Solution of Symmetric Quasi-Definite Linear Systems*](https://doi.org/10.1137/1.9781611974737), Volume 3 of Spotlights. SIAM, Philadelphia, PA, 2017.
 * D. Orban, [*The Projected Golub-Kahan Process for Constrained Linear Least-Squares Problems*](https://dx.doi.org/10.13140/RG.2.2.17443.99360). Cahier du GERAD G-2014-15, 2014.
 """
-function crmr(A, b :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
+function crmr(A, b :: AbstractVector{FC}; kwargs...) where FC <: FloatOrComplex
   solver = CrmrSolver(A, b)
   crmr!(solver, A, b; kwargs...)
   return (solver.x, solver.stats)
 end
 
-function crmr!(solver :: CrmrSolver{T,S}, A, b :: AbstractVector{T};
+function crmr!(solver :: CrmrSolver{T,FC,S}, A, b :: AbstractVector{FC};
                M=I, λ :: T=zero(T), atol :: T=√eps(T),
-               rtol :: T=√eps(T), itmax :: Int=0, verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, S <: DenseVector{T}}
+               rtol :: T=√eps(T), itmax :: Int=0, verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: DenseVector{FC}}
 
   m, n = size(A)
   length(b) == m || error("Inconsistent problem size")

--- a/src/diom.jl
+++ b/src/diom.jl
@@ -11,10 +11,13 @@
 export diom, diom!
 
 """
-    (x, stats) = diom(A, b::AbstractVector{T};
+    (x, stats) = diom(A, b::AbstractVector{FC};
                       M=I, N=I, atol::T=√eps(T), rtol::T=√eps(T),
                       restart::Bool=false, itmax::Int=0, memory::Int=20,
-                      verbose::Int=0, history::Bool=false) where T <: AbstractFloat
+                      verbose::Int=0, history::Bool=false)
+
+`T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
+`FC` is `T` or `Complex{T}`.
 
 Solve the consistent linear system Ax = b using direct incomplete orthogonalization method.
 
@@ -32,16 +35,16 @@ This implementation allows a left preconditioner M and a right preconditioner N.
 
 * Y. Saad, [*Practical use of some krylov subspace methods for solving indefinite and nonsymmetric linear systems*](https://doi.org/10.1137/0905015), SIAM journal on scientific and statistical computing, 5(1), pp. 203--228, 1984.
 """
-function diom(A, b :: AbstractVector{T}; memory :: Int=20, kwargs...) where T <: AbstractFloat
+function diom(A, b :: AbstractVector{FC}; memory :: Int=20, kwargs...) where FC <: FloatOrComplex
   solver = DiomSolver(A, b, memory)
   diom!(solver, A, b; kwargs...)
   return (solver.x, solver.stats)
 end
 
-function diom!(solver :: DiomSolver{T,S}, A, b :: AbstractVector{T};
+function diom!(solver :: DiomSolver{T,FC,S}, A, b :: AbstractVector{FC};
                M=I, N=I, atol :: T=√eps(T), rtol :: T=√eps(T),
                restart :: Bool=false, itmax :: Int=0,
-               verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, S <: DenseVector{T}}
+               verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: DenseVector{FC}}
 
   m, n = size(A)
   m == n || error("System must be square")

--- a/src/dqgmres.jl
+++ b/src/dqgmres.jl
@@ -11,10 +11,13 @@
 export dqgmres, dqgmres!
 
 """
-    (x, stats) = dqgmres(A, b::AbstractVector{T};
+    (x, stats) = dqgmres(A, b::AbstractVector{FC};
                          M=I, N=I, atol::T=√eps(T), rtol::T=√eps(T),
                          restart::Bool=false, itmax::Int=0, memory::Int=20,
-                         verbose::Int=0, history::Bool=false) where T <: AbstractFloat
+                         verbose::Int=0, history::Bool=false)
+
+`T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
+`FC` is `T` or `Complex{T}`.
 
 Solve the consistent linear system Ax = b using DQGMRES method.
 
@@ -30,16 +33,16 @@ This implementation allows a left preconditioner M and a right preconditioner N.
 
 * Y. Saad and K. Wu, [*DQGMRES: a quasi minimal residual algorithm based on incomplete orthogonalization*](https://doi.org/10.1002/(SICI)1099-1506(199607/08)3:4%3C329::AID-NLA86%3E3.0.CO;2-8), Numerical Linear Algebra with Applications, Vol. 3(4), pp. 329--343, 1996.
 """
-function dqgmres(A, b :: AbstractVector{T}; memory :: Int=20, kwargs...) where T <: AbstractFloat
+function dqgmres(A, b :: AbstractVector{FC}; memory :: Int=20, kwargs...) where FC <: FloatOrComplex
   solver = DqgmresSolver(A, b, memory)
   dqgmres!(solver, A, b; kwargs...)
   return (solver.x, solver.stats)
 end
 
-function dqgmres!(solver :: DqgmresSolver{T,S}, A, b :: AbstractVector{T};
+function dqgmres!(solver :: DqgmresSolver{T,FC,S}, A, b :: AbstractVector{FC};
                   M=I, N=I, atol :: T=√eps(T), rtol :: T=√eps(T),
                   restart :: Bool=false, itmax :: Int=0,
-                  verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, S <: DenseVector{T}}
+                  verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: DenseVector{FC}}
 
   m, n = size(A)
   m == n || error("System must be square")

--- a/src/fom.jl
+++ b/src/fom.jl
@@ -11,11 +11,14 @@
 export fom, fom!
 
 """
-    (x, stats) = fom(A, b::AbstractVector{T};
+    (x, stats) = fom(A, b::AbstractVector{FC};
                      M=I, N=I, atol::T=√eps(T), rtol::T=√eps(T),
                      reorthogonalization::Bool=false, itmax::Int=0,
                      restart::Bool=false, memory::Int=20,
-                     verbose::Int=0, history::Bool=false) where T <: AbstractFloat
+                     verbose::Int=0, history::Bool=false)
+
+`T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
+`FC` is `T` or `Complex{T}`.
 
 Solve the linear system Ax = b using FOM method.
 
@@ -30,16 +33,16 @@ This implementation allows a left preconditioner M and a right preconditioner N.
 
 * Y. Saad, [*Krylov subspace methods for solving unsymmetric linear systems*](https://doi.org/10.1090/S0025-5718-1981-0616364-6), Mathematics of computation, Vol. 37(155), pp. 105--126, 1981.
 """
-function fom(A, b :: AbstractVector{T}; memory :: Int=20, kwargs...) where T <: AbstractFloat
+function fom(A, b :: AbstractVector{FC}; memory :: Int=20, kwargs...) where FC <: FloatOrComplex
   solver = FomSolver(A, b, memory)
   fom!(solver, A, b; kwargs...)
   return (solver.x, solver.stats)
 end
 
-function fom!(solver :: FomSolver{T,S}, A, b :: AbstractVector{T};
+function fom!(solver :: FomSolver{T,FC,S}, A, b :: AbstractVector{FC};
               M=I, N=I, atol :: T=√eps(T), rtol :: T=√eps(T),
               reorthogonalization :: Bool=false, itmax :: Int=0,
-              restart :: Bool=false, verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, S <: DenseVector{T}}
+              restart :: Bool=false, verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: DenseVector{FC}}
 
   m, n = size(A)
   m == n || error("System must be square")

--- a/src/gmres.jl
+++ b/src/gmres.jl
@@ -11,11 +11,14 @@
 export gmres, gmres!
 
 """
-    (x, stats) = gmres(A, b::AbstractVector{T};
+    (x, stats) = gmres(A, b::AbstractVector{FC};
                        M=I, N=I, atol::T=√eps(T), rtol::T=√eps(T),
                        reorthogonalization::Bool=false, itmax::Int=0,
                        restart::Bool=false, memory::Int=20,
-                       verbose::Int=0, history::Bool=false) where T <: AbstractFloat
+                       verbose::Int=0, history::Bool=false)
+
+`T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
+`FC` is `T` or `Complex{T}`.
 
 Solve the linear system Ax = b using GMRES method.
 
@@ -30,16 +33,16 @@ This implementation allows a left preconditioner M and a right preconditioner N.
 
 * Y. Saad and M. H. Schultz, [*GMRES: A Generalized Minimal Residual Algorithm for Solving Nonsymmetric Linear Systems*](https://doi.org/10.1137/0907058), SIAM Journal on Scientific and Statistical Computing, Vol. 7(3), pp. 856--869, 1986.
 """
-function gmres(A, b :: AbstractVector{T}; memory :: Int=20, kwargs...) where T <: AbstractFloat
+function gmres(A, b :: AbstractVector{FC}; memory :: Int=20, kwargs...) where FC <: FloatOrComplex
   solver = GmresSolver(A, b, memory)
   gmres!(solver, A, b; kwargs...)
   return (solver.x, solver.stats)
 end
 
-function gmres!(solver :: GmresSolver{T,S}, A, b :: AbstractVector{T};
+function gmres!(solver :: GmresSolver{T,FC,S}, A, b :: AbstractVector{FC};
                 M=I, N=I, atol :: T=√eps(T), rtol :: T=√eps(T),
                 reorthogonalization :: Bool=false, itmax :: Int=0,
-                restart :: Bool=false, verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, S <: DenseVector{T}}
+                restart :: Bool=false, verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: DenseVector{FC}}
 
   m, n = size(A)
   m == n || error("System must be square")

--- a/src/gpmr.jl
+++ b/src/gpmr.jl
@@ -12,11 +12,14 @@
 export gpmr, gpmr!
 
 """
-    (x, y, stats) = gpmr(A, B, b::AbstractVector{T}, c::AbstractVector{T};
+    (x, y, stats) = gpmr(A, B, b::AbstractVector{FC}, c::AbstractVector{FC};
                          C=I, D=I, E=I, F=I, atol::T=√eps(T), rtol::T=√eps(T),
                          gsp::Bool=false, reorthogonalization::Bool=false, itmax::Int=0,
                          restart::Bool=false, λ::T=one(T), μ::T=one(T),
-                         verbose::Int=0, history::Bool=false) where T <: AbstractFloat
+                         verbose::Int=0, history::Bool=false)
+
+`T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
+`FC` is `T` or `Complex{T}`.
 
 GPMR solves the unsymmetric partitioned linear system
 
@@ -56,17 +59,17 @@ Information will be displayed every `verbose` iterations.
 
 * A. Montoison and D. Orban, [*GPMR: An Iterative Method for Unsymmetric Partitioned Linear Systems*](https://dx.doi.org/10.13140/RG.2.2.24069.68326), Cahier du GERAD G-2021-62, GERAD, Montréal, 2021.
 """
-function gpmr(A, B, b :: AbstractVector{T}, c :: AbstractVector{T}; memory :: Int=20, kwargs...) where T <: AbstractFloat
+function gpmr(A, B, b :: AbstractVector{FC}, c :: AbstractVector{FC}; memory :: Int=20, kwargs...) where FC <: FloatOrComplex
   solver = GpmrSolver(A, b, memory)
   gpmr!(solver, A, B, b, c; kwargs...)
   return (solver.x, solver.y, solver.stats)
 end
 
-function gpmr!(solver :: GpmrSolver{T,S}, A, B, b :: AbstractVector{T}, c :: AbstractVector{T};
+function gpmr!(solver :: GpmrSolver{T,FC,S}, A, B, b :: AbstractVector{FC}, c :: AbstractVector{FC};
                C=I, D=I, E=I, F=I, atol :: T=√eps(T), rtol :: T=√eps(T),
                gsp :: Bool=false, reorthogonalization :: Bool=false, itmax :: Int=0,
                restart :: Bool=false, λ :: T=one(T), μ :: T=one(T),
-               verbose :: Int=0, history::Bool=false) where {T <: AbstractFloat, S <: DenseVector{T}}
+               verbose :: Int=0, history::Bool=false) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: DenseVector{FC}}
 
   m, n = size(A)
   s, t = size(B)

--- a/src/krylov_solvers.jl
+++ b/src/krylov_solvers.jl
@@ -8,7 +8,7 @@ GmresSolver, FomSolver, GpmrSolver
 export solve!, solution, nsolution, statistics, issolved, issolved_primal, issolved_dual
 
 "Abstract type for using Krylov solvers in-place"
-abstract type KrylovSolver{T,S} end
+abstract type KrylovSolver{T,FC,S} end
 
 """
 Type for storing the vectors required by the in-place version of MINRES.
@@ -20,7 +20,7 @@ The outer constructors
 
 may be used in order to create these vectors.
 """
-mutable struct MinresSolver{T,S} <: KrylovSolver{T,S}
+mutable struct MinresSolver{T,FC,S} <: KrylovSolver{T,FC,S}
   Δx      :: S
   x       :: S
   r1      :: S
@@ -33,7 +33,8 @@ mutable struct MinresSolver{T,S} <: KrylovSolver{T,S}
   stats   :: SimpleStats{T}
 
   function MinresSolver(n, m, S; window :: Int=5)
-    T  = eltype(S)
+    FC = eltype(S)
+    T  = real(FC)
     Δx = S(undef, 0)
     x  = S(undef, n)
     r1 = S(undef, n)
@@ -44,7 +45,7 @@ mutable struct MinresSolver{T,S} <: KrylovSolver{T,S}
     v  = S(undef, 0)
     err_vec = zeros(T, window)
     stats = SimpleStats(false, false, T[], T[], T[], "unknown")
-    solver = new{T,S}(Δx, x, r1, r2, w1, w2, y, v, err_vec, stats)
+    solver = new{T,FC,S}(Δx, x, r1, r2, w1, w2, y, v, err_vec, stats)
     return solver
   end
 
@@ -65,7 +66,7 @@ The outer constructors
 
 may be used in order to create these vectors.
 """
-mutable struct CgSolver{T,S} <: KrylovSolver{T,S}
+mutable struct CgSolver{T,FC,S} <: KrylovSolver{T,FC,S}
   Δx    :: S
   x     :: S
   r     :: S
@@ -75,7 +76,8 @@ mutable struct CgSolver{T,S} <: KrylovSolver{T,S}
   stats :: SimpleStats{T}
 
   function CgSolver(n, m, S)
-    T  = eltype(S)
+    FC = eltype(S)
+    T  = real(FC)
     Δx = S(undef, 0)
     x  = S(undef, n)
     r  = S(undef, n)
@@ -83,7 +85,7 @@ mutable struct CgSolver{T,S} <: KrylovSolver{T,S}
     Ap = S(undef, n)
     z  = S(undef, 0)
     stats = SimpleStats(false, false, T[], T[], T[], "unknown")
-    solver = new{T,S}(Δx, x, r, p, Ap, z, stats)
+    solver = new{T,FC,S}(Δx, x, r, p, Ap, z, stats)
     return solver
   end
 
@@ -104,7 +106,7 @@ The outer constructors
 
 may be used in order to create these vectors.
 """
-mutable struct CrSolver{T,S} <: KrylovSolver{T,S}
+mutable struct CrSolver{T,FC,S} <: KrylovSolver{T,FC,S}
   x     :: S
   r     :: S
   p     :: S
@@ -114,7 +116,8 @@ mutable struct CrSolver{T,S} <: KrylovSolver{T,S}
   stats :: SimpleStats{T}
 
   function CrSolver(n, m, S)
-    T  = eltype(S)
+    FC = eltype(S)
+    T  = real(FC)
     x  = S(undef, n)
     r  = S(undef, n)
     p  = S(undef, n)
@@ -122,7 +125,7 @@ mutable struct CrSolver{T,S} <: KrylovSolver{T,S}
     Ar = S(undef, n)
     Mq = S(undef, 0)
     stats = SimpleStats(false, false, T[], T[], T[], "unknown")
-    solver = new{T,S}(x, r, p, q, Ar, Mq, stats)
+    solver = new{T,FC,S}(x, r, p, q, Ar, Mq, stats)
     return solver
   end
 
@@ -143,7 +146,7 @@ The outer constructors
 
 may be used in order to create these vectors.
 """
-mutable struct SymmlqSolver{T,S} <: KrylovSolver{T,S}
+mutable struct SymmlqSolver{T,FC,S} <: KrylovSolver{T,FC,S}
   Δx      :: S
   x       :: S
   Mvold   :: S
@@ -157,7 +160,8 @@ mutable struct SymmlqSolver{T,S} <: KrylovSolver{T,S}
   stats   :: SymmlqStats{T}
 
   function SymmlqSolver(n, m, S; window :: Int=5)
-    T       = eltype(S)
+    FC      = eltype(S)
+    T       = real(FC)
     Δx      = S(undef, 0)
     x       = S(undef, n)
     Mvold   = S(undef, n)
@@ -169,7 +173,7 @@ mutable struct SymmlqSolver{T,S} <: KrylovSolver{T,S}
     zlist   = zeros(T, window)
     sprod   = ones(T, window)
     stats = SymmlqStats(false, T[], Union{T, Missing}[], T[], Union{T, Missing}[], T(NaN), T(NaN), "unknown")
-    solver = new{T,S}(Δx, x, Mvold, Mv, Mv_next, w̅, v, clist, zlist, sprod, stats)
+    solver = new{T,FC,S}(Δx, x, Mvold, Mv, Mv_next, w̅, v, clist, zlist, sprod, stats)
     return solver
   end
 
@@ -190,7 +194,7 @@ The outer constructors
 
 may be used in order to create these vectors.
 """
-mutable struct CgLanczosSolver{T,S} <: KrylovSolver{T,S}
+mutable struct CgLanczosSolver{T,FC,S} <: KrylovSolver{T,FC,S}
   x       :: S
   Mv      :: S
   Mv_prev :: S
@@ -200,7 +204,8 @@ mutable struct CgLanczosSolver{T,S} <: KrylovSolver{T,S}
   stats   :: LanczosStats{T}
 
   function CgLanczosSolver(n, m, S)
-    T       = eltype(S)
+    FC      = eltype(S)
+    T       = real(FC)
     x       = S(undef, n)
     Mv      = S(undef, n)
     Mv_prev = S(undef, n)
@@ -208,7 +213,7 @@ mutable struct CgLanczosSolver{T,S} <: KrylovSolver{T,S}
     Mv_next = S(undef, n)
     v       = S(undef, 0)
     stats = LanczosStats(false, T[], false, T(NaN), T(NaN), "unknown")
-    solver = new{T,S}(x, Mv, Mv_prev, p, Mv_next, v, stats)
+    solver = new{T,FC,S}(x, Mv, Mv_prev, p, Mv_next, v, stats)
     return solver
   end
 
@@ -229,7 +234,7 @@ The outer constructors
 
 may be used in order to create these vectors.
 """
-mutable struct CgLanczosShiftSolver{T,S} <: KrylovSolver{T,S}
+mutable struct CgLanczosShiftSolver{T,FC,S} <: KrylovSolver{T,FC,S}
   Mv         :: S
   Mv_prev    :: S
   Mv_next    :: S
@@ -246,7 +251,8 @@ mutable struct CgLanczosShiftSolver{T,S} <: KrylovSolver{T,S}
   stats      :: LanczosShiftStats{T}
 
   function CgLanczosShiftSolver(n, m, nshifts, S)
-    T          = eltype(S)
+    FC         = eltype(S)
+    T          = real(FC)
     Mv         = S(undef, n)
     Mv_prev    = S(undef, n)
     Mv_next    = S(undef, n)
@@ -262,7 +268,7 @@ mutable struct CgLanczosShiftSolver{T,S} <: KrylovSolver{T,S}
     converged  = BitVector(undef, nshifts)
     not_cv     = BitVector(undef, nshifts)
     stats = LanczosShiftStats(false, [T[] for i = 1 : nshifts], indefinite, T(NaN), T(NaN), "unknown")
-    solver = new{T,S}(Mv, Mv_prev, Mv_next, v, x, p, σ, δhat, ω, γ, rNorms, converged, not_cv, stats)
+    solver = new{T,FC,S}(Mv, Mv_prev, Mv_next, v, x, p, σ, δhat, ω, γ, rNorms, converged, not_cv, stats)
     return solver
   end
 
@@ -283,7 +289,7 @@ The outer constructors
 
 may be used in order to create these vectors.
 """
-mutable struct MinresQlpSolver{T,S} <: KrylovSolver{T,S}
+mutable struct MinresQlpSolver{T,FC,S} <: KrylovSolver{T,FC,S}
   Δx      :: S
   wₖ₋₁    :: S
   wₖ      :: S
@@ -295,7 +301,8 @@ mutable struct MinresQlpSolver{T,S} <: KrylovSolver{T,S}
   stats   :: SimpleStats{T}
 
   function MinresQlpSolver(n, m, S)
-    T       = eltype(S)
+    FC      = eltype(S)
+    T       = real(FC)
     Δx      = S(undef, 0)
     wₖ₋₁    = S(undef, n)
     wₖ      = S(undef, n)
@@ -305,7 +312,7 @@ mutable struct MinresQlpSolver{T,S} <: KrylovSolver{T,S}
     p       = S(undef, n)
     vₖ      = S(undef, 0)
     stats = SimpleStats(false, false, T[], T[], T[], "unknown")
-    solver = new{T,S}(Δx, wₖ₋₁, wₖ, M⁻¹vₖ₋₁, M⁻¹vₖ, x, p, vₖ, stats)
+    solver = new{T,FC,S}(Δx, wₖ₋₁, wₖ, M⁻¹vₖ₋₁, M⁻¹vₖ, x, p, vₖ, stats)
     return solver
   end
 
@@ -326,7 +333,7 @@ The outer constructors
 
 may be used in order to create these vectors.
 """
-mutable struct DqgmresSolver{T,S} <: KrylovSolver{T,S}
+mutable struct DqgmresSolver{T,FC,S} <: KrylovSolver{T,FC,S}
   Δx    :: S
   x     :: S
   t     :: S
@@ -340,7 +347,8 @@ mutable struct DqgmresSolver{T,S} <: KrylovSolver{T,S}
   stats :: SimpleStats{T}
 
   function DqgmresSolver(n, m, memory, S)
-    T  = eltype(S)
+    FC = eltype(S)
+    T  = real(FC)
     Δx = S(undef, 0)
     x  = S(undef, n)
     t  = S(undef, n)
@@ -352,7 +360,7 @@ mutable struct DqgmresSolver{T,S} <: KrylovSolver{T,S}
     s  = Vector{T}(undef, memory)
     H  = Vector{T}(undef, memory+2)
     stats = SimpleStats(false, false, T[], T[], T[], "unknown")
-    solver = new{T,S}(Δx, x, t, z, w, P, V, c, s, H, stats)
+    solver = new{T,FC,S}(Δx, x, t, z, w, P, V, c, s, H, stats)
     return solver
   end
 
@@ -373,7 +381,7 @@ The outer constructors
 
 may be used in order to create these vectors.
 """
-mutable struct DiomSolver{T,S} <: KrylovSolver{T,S}
+mutable struct DiomSolver{T,FC,S} <: KrylovSolver{T,FC,S}
   Δx    :: S
   x     :: S
   t     :: S
@@ -386,7 +394,8 @@ mutable struct DiomSolver{T,S} <: KrylovSolver{T,S}
   stats :: SimpleStats{T}
 
   function DiomSolver(n, m, memory, S)
-    T  = eltype(S)
+    FC  = eltype(S)
+    T   = real(FC)
     Δx = S(undef, 0)
     x  = S(undef, n)
     t  = S(undef, n)
@@ -397,7 +406,7 @@ mutable struct DiomSolver{T,S} <: KrylovSolver{T,S}
     L  = Vector{T}(undef, memory)
     H  = Vector{T}(undef, memory+2)
     stats = SimpleStats(false, false, T[], T[], T[], "unknown")
-    solver = new{T,S}(Δx, x, t, z, w, P, V, L, H, stats)
+    solver = new{T,FC,S}(Δx, x, t, z, w, P, V, L, H, stats)
     return solver
   end
 
@@ -418,7 +427,7 @@ The outer constructors
 
 may be used in order to create these vectors.
 """
-mutable struct UsymlqSolver{T,S} <: KrylovSolver{T,S}
+mutable struct UsymlqSolver{T,FC,S} <: KrylovSolver{T,FC,S}
   uₖ₋₁  :: S
   uₖ    :: S
   p     :: S
@@ -430,7 +439,8 @@ mutable struct UsymlqSolver{T,S} <: KrylovSolver{T,S}
   stats :: SimpleStats{T}
 
   function UsymlqSolver(n, m, S)
-    T    = eltype(S)
+    FC   = eltype(S)
+    T    = real(FC)
     uₖ₋₁ = S(undef, m)
     uₖ   = S(undef, m)
     p    = S(undef, m)
@@ -440,7 +450,7 @@ mutable struct UsymlqSolver{T,S} <: KrylovSolver{T,S}
     vₖ   = S(undef, n)
     q    = S(undef, n)
     stats = SimpleStats(false, false, T[], T[], T[], "unknown")
-    solver = new{T,S}(uₖ₋₁, uₖ, p, x, d̅, vₖ₋₁, vₖ, q, stats)
+    solver = new{T,FC,S}(uₖ₋₁, uₖ, p, x, d̅, vₖ₋₁, vₖ, q, stats)
     return solver
   end
 
@@ -461,7 +471,7 @@ The outer constructors
 
 may be used in order to create these vectors.
 """
-mutable struct UsymqrSolver{T,S} <: KrylovSolver{T,S}
+mutable struct UsymqrSolver{T,FC,S} <: KrylovSolver{T,FC,S}
   vₖ₋₁  :: S
   vₖ    :: S
   q     :: S
@@ -474,7 +484,8 @@ mutable struct UsymqrSolver{T,S} <: KrylovSolver{T,S}
   stats :: SimpleStats{T}
 
   function UsymqrSolver(n, m, S)
-    T    = eltype(S)
+    FC   = eltype(S)
+    T    = real(FC)
     vₖ₋₁ = S(undef, n)
     vₖ   = S(undef, n)
     q    = S(undef, n)
@@ -485,7 +496,7 @@ mutable struct UsymqrSolver{T,S} <: KrylovSolver{T,S}
     uₖ   = S(undef, m)
     p    = S(undef, m)
     stats = SimpleStats(false, false, T[], T[], T[], "unknown")
-    solver = new{T,S}(vₖ₋₁, vₖ, q, x, wₖ₋₂, wₖ₋₁, uₖ₋₁, uₖ, p, stats)
+    solver = new{T,FC,S}(vₖ₋₁, vₖ, q, x, wₖ₋₂, wₖ₋₁, uₖ₋₁, uₖ, p, stats)
     return solver
   end
 
@@ -506,7 +517,7 @@ The outer constructors
 
 may be used in order to create these vectors.
 """
-mutable struct TricgSolver{T,S} <: KrylovSolver{T,S}
+mutable struct TricgSolver{T,FC,S} <: KrylovSolver{T,FC,S}
   y       :: S
   N⁻¹uₖ₋₁ :: S
   N⁻¹uₖ   :: S
@@ -526,7 +537,8 @@ mutable struct TricgSolver{T,S} <: KrylovSolver{T,S}
   stats   :: SimpleStats{T}
 
   function TricgSolver(n, m, S)
-    T       = eltype(S)
+    FC      = eltype(S)
+    T       = real(FC)
     y       = S(undef, m)
     N⁻¹uₖ₋₁ = S(undef, m)
     N⁻¹uₖ   = S(undef, m)
@@ -544,7 +556,7 @@ mutable struct TricgSolver{T,S} <: KrylovSolver{T,S}
     uₖ      = S(undef, 0)
     vₖ      = S(undef, 0)
     stats = SimpleStats(false, false, T[], T[], T[], "unknown")
-    solver = new{T,S}(y, N⁻¹uₖ₋₁, N⁻¹uₖ, p, gy₂ₖ₋₁, gy₂ₖ, x, M⁻¹vₖ₋₁, M⁻¹vₖ, q, gx₂ₖ₋₁, gx₂ₖ, Δx, Δy, uₖ, vₖ, stats)
+    solver = new{T,FC,S}(y, N⁻¹uₖ₋₁, N⁻¹uₖ, p, gy₂ₖ₋₁, gy₂ₖ, x, M⁻¹vₖ₋₁, M⁻¹vₖ, q, gx₂ₖ₋₁, gx₂ₖ, Δx, Δy, uₖ, vₖ, stats)
     return solver
   end
 
@@ -565,7 +577,7 @@ The outer constructors
 
 may be used in order to create these vectors.
 """
-mutable struct TrimrSolver{T,S} <: KrylovSolver{T,S}
+mutable struct TrimrSolver{T,FC,S} <: KrylovSolver{T,FC,S}
   y       :: S
   N⁻¹uₖ₋₁ :: S
   N⁻¹uₖ   :: S
@@ -589,7 +601,8 @@ mutable struct TrimrSolver{T,S} <: KrylovSolver{T,S}
   stats   :: SimpleStats{T}
 
   function TrimrSolver(n, m, S)
-    T       = eltype(S)
+    FC      = eltype(S)
+    T       = real(FC)
     y       = S(undef, m)
     N⁻¹uₖ₋₁ = S(undef, m)
     N⁻¹uₖ   = S(undef, m)
@@ -611,7 +624,7 @@ mutable struct TrimrSolver{T,S} <: KrylovSolver{T,S}
     uₖ      = S(undef, 0)
     vₖ      = S(undef, 0)
     stats = SimpleStats(false, false, T[], T[], T[], "unknown")
-    solver = new{T,S}(y, N⁻¹uₖ₋₁, N⁻¹uₖ, p, gy₂ₖ₋₃, gy₂ₖ₋₂, gy₂ₖ₋₁, gy₂ₖ, x, M⁻¹vₖ₋₁, M⁻¹vₖ, q, gx₂ₖ₋₃, gx₂ₖ₋₂, gx₂ₖ₋₁, gx₂ₖ, Δx, Δy, uₖ, vₖ, stats)
+    solver = new{T,FC,S}(y, N⁻¹uₖ₋₁, N⁻¹uₖ, p, gy₂ₖ₋₃, gy₂ₖ₋₂, gy₂ₖ₋₁, gy₂ₖ, x, M⁻¹vₖ₋₁, M⁻¹vₖ, q, gx₂ₖ₋₃, gx₂ₖ₋₂, gx₂ₖ₋₁, gx₂ₖ, Δx, Δy, uₖ, vₖ, stats)
     return solver
   end
 
@@ -632,7 +645,7 @@ The outer constructors
 
 may be used in order to create these vectors.
 """
-mutable struct TrilqrSolver{T,S} <: KrylovSolver{T,S}
+mutable struct TrilqrSolver{T,FC,S} <: KrylovSolver{T,FC,S}
   uₖ₋₁  :: S
   uₖ    :: S
   p     :: S
@@ -647,7 +660,8 @@ mutable struct TrilqrSolver{T,S} <: KrylovSolver{T,S}
   stats :: AdjointStats{T}
 
   function TrilqrSolver(n, m, S)
-    T    = eltype(S)
+    FC   = eltype(S)
+    T    = real(FC)
     uₖ₋₁ = S(undef, m)
     uₖ   = S(undef, m)
     p    = S(undef, m)
@@ -660,7 +674,7 @@ mutable struct TrilqrSolver{T,S} <: KrylovSolver{T,S}
     wₖ₋₃ = S(undef, n)
     wₖ₋₂ = S(undef, n)
     stats = AdjointStats(false, false, T[], T[], "unknown")
-    solver = new{T,S}(uₖ₋₁, uₖ, p, d̅, x, vₖ₋₁, vₖ, q, y, wₖ₋₃, wₖ₋₂, stats)
+    solver = new{T,FC,S}(uₖ₋₁, uₖ, p, d̅, x, vₖ₋₁, vₖ, q, y, wₖ₋₃, wₖ₋₂, stats)
     return solver
   end
 
@@ -681,7 +695,7 @@ The outer constructorss
 
 may be used in order to create these vectors.
 """
-mutable struct CgsSolver{T,S} <: KrylovSolver{T,S}
+mutable struct CgsSolver{T,FC,S} <: KrylovSolver{T,FC,S}
   x     :: S
   r     :: S
   u     :: S
@@ -693,7 +707,8 @@ mutable struct CgsSolver{T,S} <: KrylovSolver{T,S}
   stats :: SimpleStats{T}
 
   function CgsSolver(n, m, S)
-    T  = eltype(S)
+    FC = eltype(S)
+    T  = real(FC)
     x  = S(undef, n)
     r  = S(undef, n)
     u  = S(undef, n)
@@ -703,7 +718,7 @@ mutable struct CgsSolver{T,S} <: KrylovSolver{T,S}
     yz = S(undef, 0)
     vw = S(undef, 0)
     stats = SimpleStats(false, false, T[], T[], T[], "unknown")
-    solver = new{T,S}(x, r, u, p, q, ts, yz, vw, stats)
+    solver = new{T,FC,S}(x, r, u, p, q, ts, yz, vw, stats)
     return solver
   end
 
@@ -724,7 +739,7 @@ The outer constructors
 
 may be used in order to create these vectors.
 """
-mutable struct BicgstabSolver{T,S} <: KrylovSolver{T,S}
+mutable struct BicgstabSolver{T,FC,S} <: KrylovSolver{T,FC,S}
   x     :: S
   r     :: S
   p     :: S
@@ -736,7 +751,8 @@ mutable struct BicgstabSolver{T,S} <: KrylovSolver{T,S}
   stats :: SimpleStats{T}
 
   function BicgstabSolver(n, m, S)
-    T  = eltype(S)
+    FC = eltype(S)
+    T  = real(FC)
     x  = S(undef, n)
     r  = S(undef, n)
     p  = S(undef, n)
@@ -746,7 +762,7 @@ mutable struct BicgstabSolver{T,S} <: KrylovSolver{T,S}
     yz = S(undef, 0)
     t  = S(undef, 0)
     stats = SimpleStats(false, false, T[], T[], T[], "unknown")
-    solver = new{T,S}(x, r, p, v, s, qd, yz, t, stats)
+    solver = new{T,FC,S}(x, r, p, v, s, qd, yz, t, stats)
     return solver
   end
 
@@ -767,7 +783,7 @@ The outer constructors
 
 may be used in order to create these vectors.
 """
-mutable struct BilqSolver{T,S} <: KrylovSolver{T,S}
+mutable struct BilqSolver{T,FC,S} <: KrylovSolver{T,FC,S}
   uₖ₋₁  :: S
   uₖ    :: S
   q     :: S
@@ -779,7 +795,8 @@ mutable struct BilqSolver{T,S} <: KrylovSolver{T,S}
   stats :: SimpleStats{T}
 
   function BilqSolver(n, m, S)
-    T    = eltype(S)
+    FC   = eltype(S)
+    T    = real(FC)
     uₖ₋₁ = S(undef, n)
     uₖ   = S(undef, n)
     q    = S(undef, n)
@@ -789,7 +806,7 @@ mutable struct BilqSolver{T,S} <: KrylovSolver{T,S}
     x    = S(undef, n)
     d̅    = S(undef, n)
     stats = SimpleStats(false, false, T[], T[], T[], "unknown")
-    solver = new{T,S}(uₖ₋₁, uₖ, q, vₖ₋₁, vₖ, p, x, d̅, stats)
+    solver = new{T,FC,S}(uₖ₋₁, uₖ, q, vₖ₋₁, vₖ, p, x, d̅, stats)
     return solver
   end
 
@@ -810,7 +827,7 @@ The outer constructors
 
 may be used in order to create these vectors.
 """
-mutable struct QmrSolver{T,S} <: KrylovSolver{T,S}
+mutable struct QmrSolver{T,FC,S} <: KrylovSolver{T,FC,S}
   uₖ₋₁  :: S
   uₖ    :: S
   q     :: S
@@ -823,7 +840,8 @@ mutable struct QmrSolver{T,S} <: KrylovSolver{T,S}
   stats :: SimpleStats{T}
 
   function QmrSolver(n, m, S)
-    T    = eltype(S)
+    FC   = eltype(S)
+    T    = real(FC)
     uₖ₋₁ = S(undef, n)
     uₖ   = S(undef, n)
     q    = S(undef, n)
@@ -834,7 +852,7 @@ mutable struct QmrSolver{T,S} <: KrylovSolver{T,S}
     wₖ₋₂ = S(undef, n)
     wₖ₋₁ = S(undef, n)
     stats = SimpleStats(false, false, T[], T[], T[], "unknown")
-    solver = new{T,S}(uₖ₋₁, uₖ, q, vₖ₋₁, vₖ, p, x, wₖ₋₂, wₖ₋₁, stats)
+    solver = new{T,FC,S}(uₖ₋₁, uₖ, q, vₖ₋₁, vₖ, p, x, wₖ₋₂, wₖ₋₁, stats)
     return solver
   end
 
@@ -855,7 +873,7 @@ The outer constructors
 
 may be used in order to create these vectors.
 """
-mutable struct BilqrSolver{T,S} <: KrylovSolver{T,S}
+mutable struct BilqrSolver{T,FC,S} <: KrylovSolver{T,FC,S}
   uₖ₋₁  :: S
   uₖ    :: S
   q     :: S
@@ -870,7 +888,8 @@ mutable struct BilqrSolver{T,S} <: KrylovSolver{T,S}
   stats :: AdjointStats{T}
 
   function BilqrSolver(n, m, S)
-    T    = eltype(S)
+    FC   = eltype(S)
+    T    = real(FC)
     uₖ₋₁ = S(undef, n)
     uₖ   = S(undef, n)
     q    = S(undef, n)
@@ -883,7 +902,7 @@ mutable struct BilqrSolver{T,S} <: KrylovSolver{T,S}
     wₖ₋₃ = S(undef, n)
     wₖ₋₂ = S(undef, n)
     stats = AdjointStats(false, false, T[], T[], "unknown")
-    solver = new{T,S}(uₖ₋₁, uₖ, q, vₖ₋₁, vₖ, p, x, y, d̅, wₖ₋₃, wₖ₋₂, stats)
+    solver = new{T,FC,S}(uₖ₋₁, uₖ, q, vₖ₋₁, vₖ, p, x, y, d̅, wₖ₋₃, wₖ₋₂, stats)
     return solver
   end
 
@@ -904,7 +923,7 @@ The outer constructors
 
 may be used in order to create these vectors.
 """
-mutable struct CglsSolver{T,S} <: KrylovSolver{T,S}
+mutable struct CglsSolver{T,FC,S} <: KrylovSolver{T,FC,S}
   x     :: S
   p     :: S
   s     :: S
@@ -914,7 +933,8 @@ mutable struct CglsSolver{T,S} <: KrylovSolver{T,S}
   stats :: SimpleStats{T}
 
   function CglsSolver(n, m, S)
-    T  = eltype(S)
+    FC = eltype(S)
+    T  = real(FC)
     x  = S(undef, m)
     p  = S(undef, m)
     s  = S(undef, m)
@@ -922,7 +942,7 @@ mutable struct CglsSolver{T,S} <: KrylovSolver{T,S}
     q  = S(undef, n)
     Mr = S(undef, 0)
     stats = SimpleStats(false, false, T[], T[], T[], "unknown")
-    solver = new{T,S}(x, p, s, r, q, Mr, stats)
+    solver = new{T,FC,S}(x, p, s, r, q, Mr, stats)
     return solver
   end
 
@@ -943,7 +963,7 @@ The outer constructors
 
 may be used in order to create these vectors.
 """
-mutable struct CrlsSolver{T,S} <: KrylovSolver{T,S}
+mutable struct CrlsSolver{T,FC,S} <: KrylovSolver{T,FC,S}
   x     :: S
   p     :: S
   Ar    :: S
@@ -955,7 +975,8 @@ mutable struct CrlsSolver{T,S} <: KrylovSolver{T,S}
   stats :: SimpleStats{T}
 
   function CrlsSolver(n, m, S)
-    T  = eltype(S)
+    FC = eltype(S)
+    T  = real(FC)
     x  = S(undef, m)
     p  = S(undef, m)
     Ar = S(undef, m)
@@ -965,7 +986,7 @@ mutable struct CrlsSolver{T,S} <: KrylovSolver{T,S}
     s  = S(undef, n)
     Ms = S(undef, 0)
     stats = SimpleStats(false, false, T[], T[], T[], "unknown")
-    solver = new{T,S}(x, p, Ar, q, r, Ap, s, Ms, stats)
+    solver = new{T,FC,S}(x, p, Ar, q, r, Ap, s, Ms, stats)
     return solver
   end
 
@@ -986,7 +1007,7 @@ The outer constructors
 
 may be used in order to create these vectors.
 """
-mutable struct CgneSolver{T,S} <: KrylovSolver{T,S}
+mutable struct CgneSolver{T,FC,S} <: KrylovSolver{T,FC,S}
   x     :: S
   p     :: S
   Aᵀz   :: S
@@ -997,7 +1018,8 @@ mutable struct CgneSolver{T,S} <: KrylovSolver{T,S}
   stats :: SimpleStats{T}
 
   function CgneSolver(n, m, S)
-    T   = eltype(S)
+    FC  = eltype(S)
+    T   = real(FC)
     x   = S(undef, m)
     p   = S(undef, m)
     Aᵀz = S(undef, m)
@@ -1006,7 +1028,7 @@ mutable struct CgneSolver{T,S} <: KrylovSolver{T,S}
     s   = S(undef, 0)
     z   = S(undef, 0)
     stats = SimpleStats(false, false, T[], T[], T[], "unknown")
-    solver = new{T,S}(x, p, Aᵀz, r, q, s, z, stats)
+    solver = new{T,FC,S}(x, p, Aᵀz, r, q, s, z, stats)
     return solver
   end
 
@@ -1027,7 +1049,7 @@ The outer constructors
 
 may be used in order to create these vectors.
 """
-mutable struct CrmrSolver{T,S} <: KrylovSolver{T,S}
+mutable struct CrmrSolver{T,FC,S} <: KrylovSolver{T,FC,S}
   x     :: S
   p     :: S
   Aᵀr   :: S
@@ -1038,7 +1060,8 @@ mutable struct CrmrSolver{T,S} <: KrylovSolver{T,S}
   stats :: SimpleStats{T}
 
   function CrmrSolver(n, m, S)
-    T = eltype(S)
+    FC  = eltype(S)
+    T   = real(FC)
     x   = S(undef, m)
     p   = S(undef, m)
     Aᵀr = S(undef, m)
@@ -1047,7 +1070,7 @@ mutable struct CrmrSolver{T,S} <: KrylovSolver{T,S}
     Mq  = S(undef, 0)
     s   = S(undef, 0)
     stats = SimpleStats(false, false, T[], T[], T[], "unknown")
-    solver = new{T,S}(x, p, Aᵀr, r, q, Mq, s, stats)
+    solver = new{T,FC,S}(x, p, Aᵀr, r, q, Mq, s, stats)
     return solver
   end
 
@@ -1068,7 +1091,7 @@ The outer constructors
 
 may be used in order to create these vectors.
 """
-mutable struct LslqSolver{T,S} <: KrylovSolver{T,S}
+mutable struct LslqSolver{T,FC,S} <: KrylovSolver{T,FC,S}
   x       :: S
   Nv      :: S
   Aᵀu     :: S
@@ -1081,7 +1104,8 @@ mutable struct LslqSolver{T,S} <: KrylovSolver{T,S}
   stats   :: LSLQStats{T}
 
   function LslqSolver(n, m, S; window :: Int=5)
-    T   = eltype(S)
+    FC  = eltype(S)
+    T   = real(FC)
     x   = S(undef, m)
     Nv  = S(undef, m)
     Aᵀu = S(undef, m)
@@ -1092,7 +1116,7 @@ mutable struct LslqSolver{T,S} <: KrylovSolver{T,S}
     v   = S(undef, 0)
     err_vec = zeros(T, window)
     stats = LSLQStats(false, false, T[], T[], T[], false, T[], T[], "unknown")
-    solver = new{T,S}(x, Nv, Aᵀu, w̄, Mu, Av, u, v, err_vec, stats)
+    solver = new{T,FC,S}(x, Nv, Aᵀu, w̄, Mu, Av, u, v, err_vec, stats)
     return solver
   end
 
@@ -1113,7 +1137,7 @@ The outer constructors
 
 may be used in order to create these vectors.
 """
-mutable struct LsqrSolver{T,S} <: KrylovSolver{T,S}
+mutable struct LsqrSolver{T,FC,S} <: KrylovSolver{T,FC,S}
   x       :: S
   Nv      :: S
   Aᵀu     :: S
@@ -1126,7 +1150,8 @@ mutable struct LsqrSolver{T,S} <: KrylovSolver{T,S}
   stats   :: SimpleStats{T}
 
   function LsqrSolver(n, m, S; window :: Int=5)
-    T   = eltype(S)
+    FC  = eltype(S)
+    T   = real(FC)
     x   = S(undef, m)
     Nv  = S(undef, m)
     Aᵀu = S(undef, m)
@@ -1137,7 +1162,7 @@ mutable struct LsqrSolver{T,S} <: KrylovSolver{T,S}
     v   = S(undef, 0)
     err_vec = zeros(T, window)
     stats = SimpleStats(false, false, T[], T[], T[], "unknown")
-    solver = new{T,S}(x, Nv, Aᵀu, w, Mu, Av, u, v, err_vec, stats)
+    solver = new{T,FC,S}(x, Nv, Aᵀu, w, Mu, Av, u, v, err_vec, stats)
     return solver
   end
 
@@ -1158,7 +1183,7 @@ The outer constructors
 
 may be used in order to create these vectors.
 """
-mutable struct LsmrSolver{T,S} <: KrylovSolver{T,S}
+mutable struct LsmrSolver{T,FC,S} <: KrylovSolver{T,FC,S}
   x       :: S
   Nv      :: S
   Aᵀu     :: S
@@ -1172,7 +1197,8 @@ mutable struct LsmrSolver{T,S} <: KrylovSolver{T,S}
   stats   :: SimpleStats{T}
 
   function LsmrSolver(n, m, S; window :: Int=5)
-    T    = eltype(S)
+    FC   = eltype(S)
+    T    = real(FC)
     x    = S(undef, m)
     Nv   = S(undef, m)
     Aᵀu  = S(undef, m)
@@ -1184,7 +1210,7 @@ mutable struct LsmrSolver{T,S} <: KrylovSolver{T,S}
     v    = S(undef, 0)
     err_vec = zeros(T, window)
     stats = SimpleStats(false, false, T[], T[], T[], "unknown")
-    solver = new{T,S}(x, Nv, Aᵀu, h, hbar, Mu, Av, u, v, err_vec, stats)
+    solver = new{T,FC,S}(x, Nv, Aᵀu, h, hbar, Mu, Av, u, v, err_vec, stats)
     return solver
   end
 
@@ -1205,7 +1231,7 @@ The outer constructors
 
 may be used in order to create these vectors.
 """
-mutable struct LnlqSolver{T,S} <: KrylovSolver{T,S}
+mutable struct LnlqSolver{T,FC,S} <: KrylovSolver{T,FC,S}
   x     :: S
   Nv    :: S
   Aᵀu   :: S
@@ -1219,7 +1245,8 @@ mutable struct LnlqSolver{T,S} <: KrylovSolver{T,S}
   stats :: LNLQStats{T}
 
   function LnlqSolver(n, m, S)
-    T  = eltype(S)
+    FC  = eltype(S)
+    T   = real(FC)
     x   = S(undef, m)
     Nv  = S(undef, m)
     Aᵀu = S(undef, m)
@@ -1231,7 +1258,7 @@ mutable struct LnlqSolver{T,S} <: KrylovSolver{T,S}
     v   = S(undef, 0)
     q   = S(undef, 0)
     stats = LNLQStats(false, T[], false, T[], T[], "unknown")
-    solver = new{T,S}(x, Nv, Aᵀu, y, w̄, Mu, Av, u, v, q, stats)
+    solver = new{T,FC,S}(x, Nv, Aᵀu, y, w̄, Mu, Av, u, v, q, stats)
     return solver
   end
 
@@ -1252,7 +1279,7 @@ The outer constructors
 
 may be used in order to create these vectors.
 """
-mutable struct CraigSolver{T,S} <: KrylovSolver{T,S}
+mutable struct CraigSolver{T,FC,S} <: KrylovSolver{T,FC,S}
   x     :: S
   Nv    :: S
   Aᵀu   :: S
@@ -1266,7 +1293,8 @@ mutable struct CraigSolver{T,S} <: KrylovSolver{T,S}
   stats :: SimpleStats{T}
 
   function CraigSolver(n, m, S)
-    T   = eltype(S)
+    FC  = eltype(S)
+    T   = real(FC)
     x   = S(undef, m)
     Nv  = S(undef, m)
     Aᵀu = S(undef, m)
@@ -1278,7 +1306,7 @@ mutable struct CraigSolver{T,S} <: KrylovSolver{T,S}
     v   = S(undef, 0)
     w2  = S(undef, 0)
     stats = SimpleStats(false, false, T[], T[], T[], "unknown")
-    solver = new{T,S}(x, Nv, Aᵀu, y, w, Mu, Av, u, v, w2, stats)
+    solver = new{T,FC,S}(x, Nv, Aᵀu, y, w, Mu, Av, u, v, w2, stats)
     return solver
   end
 
@@ -1299,7 +1327,7 @@ The outer constructors
 
 may be used in order to create these vectors.
 """
-mutable struct CraigmrSolver{T,S} <: KrylovSolver{T,S}
+mutable struct CraigmrSolver{T,FC,S} <: KrylovSolver{T,FC,S}
   x     :: S
   Nv    :: S
   Aᵀu   :: S
@@ -1313,7 +1341,8 @@ mutable struct CraigmrSolver{T,S} <: KrylovSolver{T,S}
   stats :: SimpleStats{T}
 
   function CraigmrSolver(n, m, S)
-    T    = eltype(S)
+    FC   = eltype(S)
+    T    = real(FC)
     x    = S(undef, m)
     Nv   = S(undef, m)
     Aᵀu  = S(undef, m)
@@ -1325,7 +1354,7 @@ mutable struct CraigmrSolver{T,S} <: KrylovSolver{T,S}
     u    = S(undef, 0)
     v    = S(undef, 0)
     stats = SimpleStats(false, false, T[], T[], T[], "unknown")
-    solver = new{T,S}(x, Nv, Aᵀu, y, Mu, w, wbar, Av, u, v, stats)
+    solver = new{T,FC,S}(x, Nv, Aᵀu, y, Mu, w, wbar, Av, u, v, stats)
     return solver
   end
 
@@ -1346,7 +1375,7 @@ The outer constructors
 
 may be used in order to create these vectors.
 """
-mutable struct GmresSolver{T,S} <: KrylovSolver{T,S}
+mutable struct GmresSolver{T,FC,S} <: KrylovSolver{T,FC,S}
   Δx    :: S
   x     :: S
   w     :: S
@@ -1360,7 +1389,8 @@ mutable struct GmresSolver{T,S} <: KrylovSolver{T,S}
   stats :: SimpleStats{T}
 
   function GmresSolver(n, m, memory, S)
-    T  = eltype(S)
+    FC = eltype(S)
+    T  = real(FC)
     Δx = S(undef, 0)
     x  = S(undef, n)
     w  = S(undef, n)
@@ -1372,7 +1402,7 @@ mutable struct GmresSolver{T,S} <: KrylovSolver{T,S}
     z  = Vector{T}(undef, memory)
     R  = Vector{T}(undef, div(memory * (memory+1), 2))
     stats = SimpleStats(false, false, T[], T[], T[], "unknown")
-    solver = new{T,S}(Δx, x, w, p, q, V, c, s, z, R, stats)
+    solver = new{T,FC,S}(Δx, x, w, p, q, V, c, s, z, R, stats)
     return solver
   end
 
@@ -1393,7 +1423,7 @@ The outer constructors
 
 may be used in order to create these vectors.
 """
-mutable struct FomSolver{T,S} <: KrylovSolver{T,S}
+mutable struct FomSolver{T,FC,S} <: KrylovSolver{T,FC,S}
   Δx    :: S
   x     :: S
   w     :: S
@@ -1406,7 +1436,8 @@ mutable struct FomSolver{T,S} <: KrylovSolver{T,S}
   stats :: SimpleStats{T}
 
   function FomSolver(n, m, memory, S)
-    T  = eltype(S)
+    FC = eltype(S)
+    T  = real(FC)
     Δx = S(undef, 0)
     x  = S(undef, n)
     w  = S(undef, n)
@@ -1417,7 +1448,7 @@ mutable struct FomSolver{T,S} <: KrylovSolver{T,S}
     z  = Vector{T}(undef, memory)
     U  = Vector{T}(undef, div(memory * (memory+1), 2))
     stats = SimpleStats(false, false, T[], T[], T[], "unknown")
-    solver = new{T,S}(Δx, x, w, p, q, V, l, z, U, stats)
+    solver = new{T,FC,S}(Δx, x, w, p, q, V, l, z, U, stats)
     return solver
   end
 
@@ -1438,7 +1469,7 @@ The outer constructors
 
 may be used in order to create these vectors.
 """
-mutable struct GpmrSolver{T,S} <: KrylovSolver{T,S}
+mutable struct GpmrSolver{T,FC,S} <: KrylovSolver{T,FC,S}
   wA    :: S
   wB    :: S
   dA    :: S
@@ -1458,7 +1489,8 @@ mutable struct GpmrSolver{T,S} <: KrylovSolver{T,S}
   stats :: SimpleStats{T}
 
   function GpmrSolver(n, m, memory, S)
-    T  = eltype(S)
+    FC = eltype(S)
+    T  = real(FC)
     wA = S(undef, 0)
     wB = S(undef, 0)
     dA = S(undef, n)
@@ -1476,7 +1508,7 @@ mutable struct GpmrSolver{T,S} <: KrylovSolver{T,S}
     zt = Vector{T}(undef, 2 * memory)
     R  = Vector{T}(undef, memory * (2memory + 1))
     stats = SimpleStats(false, false, T[], T[], T[], "unknown")
-    solver = new{T,S}(wA, wB, dA, dB, Δx, Δy, x, y, q, p, V, U, gs, gc, zt, R, stats)
+    solver = new{T,FC,S}(wA, wB, dA, dB, Δx, Δy, x, y, q, p, V, U, gs, gc, zt, R, stats)
     return solver
   end
 
@@ -1579,8 +1611,8 @@ end
 function show(io :: IO, solver :: KrylovSolver)
   workspace = typeof(solver)
   name_solver = workspace.name.wrapper
-  precision = workspace.parameters[1]
-  architecture = workspace.parameters[2] <: Vector ? "CPU" : "GPU"
+  precision = workspace.parameters[2]
+  architecture = workspace.parameters[3] <: Vector ? "CPU" : "GPU"
   @printf(io, "┌%s┬%s┬%s┐\n", "─"^20, "─"^26, "─"^18)
   @printf(io, "│%20s│%26s│%18s│\n", name_solver, "Precision: $precision", "Architecture: $architecture")
   @printf(io, "├%s┼%s┼%s┤\n", "─"^20, "─"^26, "─"^18)

--- a/src/krylov_utils.jl
+++ b/src/krylov_utils.jl
@@ -1,4 +1,10 @@
 """
+    FloatOrComplex{T}
+Union type of `T` and `Complex{T}` where T is an [`AbstractFloat`](@ref).
+"""
+const FloatOrComplex{T} = Union{T, Complex{T}} where T <: AbstractFloat
+
+"""
     (c, s, ρ) = sym_givens(a, b)
 
 Numerically stable symmetric Givens reflection.

--- a/src/lnlq.jl
+++ b/src/lnlq.jl
@@ -25,10 +25,13 @@
 export lnlq, lnlq!
 
 """
-    (x, y, stats) = lnlq(A, b::AbstractVector{T};
+    (x, y, stats) = lnlq(A, b::AbstractVector{FC};
                          M=I, N=I, sqd::Bool=false, λ::T=zero(T), σ::T=zero(T),
                          atol::T=√eps(T), rtol::T=√eps(T), etolx::T=√eps(T), etoly::T=√eps(T), itmax::Int=0,
-                         transfer_to_craig::Bool=true, verbose::Int=0, history::Bool=false) where T <: AbstractFloat
+                         transfer_to_craig::Bool=true, verbose::Int=0, history::Bool=false)
+
+`T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
+`FC` is `T` or `Complex{T}`.
 
 Find the least-norm solution of the consistent linear system
 
@@ -68,16 +71,16 @@ For instance σ:=(1-1e-7)σₘᵢₙ .
 
 * R. Estrin, D. Orban, M.A. Saunders, [*LNLQ: An Iterative Method for Least-Norm Problems with an Error Minimization Property*](https://doi.org/10.1137/18M1194948), SIAM Journal on Matrix Analysis and Applications, 40(3), pp. 1102--1124, 2019.
 """
-function lnlq(A, b :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
+function lnlq(A, b :: AbstractVector{FC}; kwargs...) where FC <: FloatOrComplex
   solver = LnlqSolver(A, b)
   lnlq!(solver, A, b; kwargs...)
   return (solver.x, solver.y, solver.stats)
 end
 
-function lnlq!(solver :: LnlqSolver{T,S}, A, b :: AbstractVector{T};
+function lnlq!(solver :: LnlqSolver{T,FC,S}, A, b :: AbstractVector{FC};
                M=I, N=I, sqd :: Bool=false, λ :: T=zero(T), σ :: T=zero(T),
                atol :: T=√eps(T), rtol :: T=√eps(T), etolx :: T=√eps(T), etoly :: T=√eps(T), itmax :: Int=0,
-               transfer_to_craig :: Bool=true, verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, S <: DenseVector{T}}
+               transfer_to_craig :: Bool=true, verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: DenseVector{FC}}
 
   m, n = size(A)
   length(b) == m || error("Inconsistent problem size")

--- a/src/lslq.jl
+++ b/src/lslq.jl
@@ -23,12 +23,15 @@ export lslq, lslq!
 
 
 """
-    (x, stats) = lslq(A, b::AbstractVector{T};
+    (x, stats) = lslq(A, b::AbstractVector{FC};
                       M=I, N=I, sqd::Bool=false, λ::T=zero(T),
                       atol::T=√eps(T), btol::T=√eps(T), etol::T=√eps(T),
                       window::Int=5, utol::T=√eps(T), itmax::Int=0,
                       σ::T=zero(T), transfer_to_lsqr::Bool=false, 
-                      conlim::T=1/√eps(T), verbose::Int=0, history::Bool=false) where T <: AbstractFloat
+                      conlim::T=1/√eps(T), verbose::Int=0, history::Bool=false)
+
+`T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
+`FC` is `T` or `Complex{T}`.
 
 Solve the regularized linear least-squares problem
 
@@ -127,18 +130,18 @@ The iterations stop as soon as one of the following conditions holds true:
 * R. Estrin, D. Orban and M. A. Saunders, [*Euclidean-norm error bounds for SYMMLQ and CG*](https://doi.org/10.1137/16M1094816), SIAM Journal on Matrix Analysis and Applications, 40(1), pp. 235--253, 2019.
 * R. Estrin, D. Orban and M. A. Saunders, [*LSLQ: An Iterative Method for Linear Least-Squares with an Error Minimization Property*](https://doi.org/10.1137/17M1113552), SIAM Journal on Matrix Analysis and Applications, 40(1), pp. 254--275, 2019.
 """
-function lslq(A, b :: AbstractVector{T}; window :: Int=5, kwargs...) where T <: AbstractFloat
+function lslq(A, b :: AbstractVector{FC}; window :: Int=5, kwargs...) where FC <: FloatOrComplex
   solver = LslqSolver(A, b, window=window)
   lslq!(solver, A, b; kwargs...)
   return (solver.x, solver.stats)
 end
 
-function lslq!(solver :: LslqSolver{T,S}, A, b :: AbstractVector{T};
+function lslq!(solver :: LslqSolver{T,FC,S}, A, b :: AbstractVector{FC};
                M=I, N=I, sqd :: Bool=false, λ :: T=zero(T),
                atol :: T=√eps(T), btol :: T=√eps(T), etol :: T=√eps(T),
                utol :: T=√eps(T), itmax :: Int=0, σ :: T=zero(T),
                transfer_to_lsqr :: Bool=false, conlim :: T=1/√eps(T),
-               verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, S <: DenseVector{T}}
+               verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: DenseVector{FC}}
 
   m, n = size(A)
   length(b) == m || error("Inconsistent problem size")

--- a/src/lsmr.jl
+++ b/src/lsmr.jl
@@ -26,14 +26,17 @@ export lsmr, lsmr!
 
 
 """
-    (x, stats) = lsmr(A, b::AbstractVector{T};
+    (x, stats) = lsmr(A, b::AbstractVector{FC};
                       M=I, N=I, sqd::Bool=false,
                       λ::T=zero(T), axtol::T=√eps(T), btol::T=√eps(T),
                       atol::T=zero(T), rtol::T=zero(T),
                       etol::T=√eps(T), window::Int=5,
                       itmax::Int=0, conlim::T=1/√eps(T),
                       radius::T=zero(T), verbose::Int=0,
-                      history::Bool=false, callback::Function=(args...) -> false) where T <: AbstractFloat
+                      history::Bool=false, callback::Function=(args...) -> false)
+
+`T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
+`FC` is `T` or `Complex{T}`.
 
 Solve the regularized linear least-squares problem
 
@@ -91,19 +94,19 @@ Note that `history` should be set to `true` to have access to `rNorms` and `ArNo
 
 * D. C.-L. Fong and M. A. Saunders, [*LSMR: An Iterative Algorithm for Sparse Least Squares Problems*](https://doi.org/10.1137/10079687X), SIAM Journal on Scientific Computing, 33(5), pp. 2950--2971, 2011.
 """
-function lsmr(A, b :: AbstractVector{T}; window :: Int=5, kwargs...) where T <: AbstractFloat
+function lsmr(A, b :: AbstractVector{FC}; window :: Int=5, kwargs...) where FC <: FloatOrComplex
   solver = LsmrSolver(A, b, window=window)
   lsmr!(solver, A, b; kwargs...)
   return (solver.x, solver.stats)
 end
 
-function lsmr!(solver :: LsmrSolver{T,S}, A, b :: AbstractVector{T};
+function lsmr!(solver :: LsmrSolver{T,FC,S}, A, b :: AbstractVector{FC};
                M=I, N=I, sqd :: Bool=false,
                λ :: T=zero(T), axtol :: T=√eps(T), btol :: T=√eps(T),
                atol :: T=zero(T), rtol :: T=zero(T),
                etol :: T=√eps(T), itmax :: Int=0, conlim :: T=1/√eps(T),
                radius :: T=zero(T), verbose :: Int=0, history :: Bool=false,
-               callback :: Function = (args...) -> false) where {T <: AbstractFloat, S <: DenseVector{T}}
+               callback :: Function = (args...) -> false) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: DenseVector{FC}}
 
   m, n = size(A)
   length(b) == m || error("Inconsistent problem size")

--- a/src/lsqr.jl
+++ b/src/lsqr.jl
@@ -26,13 +26,16 @@ export lsqr, lsqr!
 
 
 """
-    (x, stats) = lsqr(A, b::AbstractVector{T};
+    (x, stats) = lsqr(A, b::AbstractVector{FC};
                       M=I, N=I, sqd::Bool=false,
                       λ::T=zero(T), axtol::T=√eps(T), btol::T=√eps(T),
                       atol::T=zero(T), rtol::T=zero(T),
                       etol::T=√eps(T), window::Int=5,
                       itmax::Int=0, conlim::T=1/√eps(T),
-                      radius::T=zero(T), verbose::Int=0, history::Bool=false) where T <: AbstractFloat
+                      radius::T=zero(T), verbose::Int=0, history::Bool=false)
+
+`T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
+`FC` is `T` or `Complex{T}`.
 
 Solve the regularized linear least-squares problem
 
@@ -81,18 +84,18 @@ In this case, `N` can still be specified and indicates the weighted norm in whic
 
 * C. C. Paige and M. A. Saunders, [*LSQR: An Algorithm for Sparse Linear Equations and Sparse Least Squares*](https://doi.org/10.1145/355984.355989), ACM Transactions on Mathematical Software, 8(1), pp. 43--71, 1982.
 """
-function lsqr(A, b :: AbstractVector{T}; window :: Int=5, kwargs...) where T <: AbstractFloat
+function lsqr(A, b :: AbstractVector{FC}; window :: Int=5, kwargs...) where FC <: FloatOrComplex
   solver = LsqrSolver(A, b, window=window)
   lsqr!(solver, A, b; kwargs...)
   return (solver.x, solver.stats)
 end
 
-function lsqr!(solver :: LsqrSolver{T,S}, A, b :: AbstractVector{T};
+function lsqr!(solver :: LsqrSolver{T,FC,S}, A, b :: AbstractVector{FC};
                M=I, N=I, sqd :: Bool=false,
                λ :: T=zero(T), axtol :: T=√eps(T), btol :: T=√eps(T),
                atol :: T=zero(T), rtol :: T=zero(T),
                etol :: T=√eps(T), itmax :: Int=0, conlim :: T=1/√eps(T),
-               radius :: T=zero(T), verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, S <: DenseVector{T}}
+               radius :: T=zero(T), verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: DenseVector{FC}}
 
   m, n = size(A)
   length(b) == m || error("Inconsistent problem size")

--- a/src/minres.jl
+++ b/src/minres.jl
@@ -23,13 +23,16 @@ export minres, minres!
 
 
 """
-    (x, stats) = minres(A, b::AbstractVector{T};
+    (x, stats) = minres(A, b::AbstractVector{FC};
                         M=I, λ::T=zero(T), atol::T=√eps(T)/100,
                         rtol::T=√eps(T)/100, ratol :: T=zero(T), 
                         rrtol :: T=zero(T), etol::T=√eps(T),
                         window::Int=5, itmax::Int=0,
                         conlim::T=1/√eps(T), restart::Bool=false,
-                        verbose::Int=0, history::Bool=false) where T <: AbstractFloat
+                        verbose::Int=0, history::Bool=false)
+
+`T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
+`FC` is `T` or `Complex{T}`.
 
 Solve the shifted linear least-squares problem
 
@@ -55,17 +58,17 @@ assumed to be symmetric and positive definite.
 
 * C. C. Paige and M. A. Saunders, [*Solution of Sparse Indefinite Systems of Linear Equations*](https://doi.org/10.1137/0712047), SIAM Journal on Numerical Analysis, 12(4), pp. 617--629, 1975.
 """
-function minres(A, b :: AbstractVector{T}; window :: Int=5, kwargs...) where T <: AbstractFloat
+function minres(A, b :: AbstractVector{FC}; window :: Int=5, kwargs...) where FC <: FloatOrComplex
   solver = MinresSolver(A, b, window=window)
   minres!(solver, A, b; kwargs...)
   return (solver.x, solver.stats)
 end
 
-function minres!(solver :: MinresSolver{T,S}, A, b :: AbstractVector{T};
+function minres!(solver :: MinresSolver{T,FC,S}, A, b :: AbstractVector{FC};
                  M=I, λ :: T=zero(T), atol :: T=√eps(T)/100, rtol :: T=√eps(T)/100, 
                  ratol :: T=zero(T), rrtol :: T=zero(T), etol :: T=√eps(T),
                  itmax :: Int=0, conlim :: T=1/√eps(T), restart :: Bool=false,
-                 verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, S <: DenseVector{T}}
+                 verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: DenseVector{FC}}
 
   n, m = size(A)
   m == n || error("System must be square")

--- a/src/minres_qlp.jl
+++ b/src/minres_qlp.jl
@@ -17,10 +17,13 @@
 export minres_qlp, minres_qlp!
 
 """
-    (x, stats) = minres_qlp(A, b::AbstractVector{T};
+    (x, stats) = minres_qlp(A, b::AbstractVector{FC};
                             M=I, atol::T=√eps(T), rtol::T=√eps(T), λ::T=zero(T),
                             itmax::Int=0, restart::Bool=false,
-                            verbose::Int=0, history::Bool=false) where T <: AbstractFloat
+                            verbose::Int=0, history::Bool=false)
+
+`T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
+`FC` is `T` or `Complex{T}`.
 
 MINRES-QLP is the only method based on the Lanczos process that returns the minimum-norm
 solution on singular inconsistent systems (A + λI)x = b, where λ is a shift parameter.
@@ -36,16 +39,16 @@ M also indicates the weighted norm in which residuals are measured.
 * S.-C. T. Choi, C. C. Paige and M. A. Saunders, [*MINRES-QLP: A Krylov subspace method for indefinite or singular symmetric systems*](https://doi.org/10.1137/100787921), SIAM Journal on Scientific Computing, Vol. 33(4), pp. 1810--1836, 2011.
 * S.-C. T. Choi and M. A. Saunders, [*Algorithm 937: MINRES-QLP for symmetric and Hermitian linear equations and least-squares problems*](https://doi.org/10.1145/2527267), ACM Transactions on Mathematical Software, 40(2), pp. 1--12, 2014.
 """
-function minres_qlp(A, b :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
+function minres_qlp(A, b :: AbstractVector{FC}; kwargs...) where FC <: FloatOrComplex
   solver = MinresQlpSolver(A, b)
   minres_qlp!(solver, A, b; kwargs...)
   return (solver.x, solver.stats)
 end
 
-function minres_qlp!(solver :: MinresQlpSolver{T,S}, A, b :: AbstractVector{T};
+function minres_qlp!(solver :: MinresQlpSolver{T,FC,S}, A, b :: AbstractVector{FC};
                      M=I, atol :: T=√eps(T), rtol :: T=√eps(T), λ ::T=zero(T),
                      itmax :: Int=0, restart :: Bool=false,
-                     verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, S <: DenseVector{T}}
+                     verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: DenseVector{FC}}
 
   n, m = size(A)
   m == n || error("System must be square")

--- a/src/qmr.jl
+++ b/src/qmr.jl
@@ -21,9 +21,12 @@
 export qmr, qmr!
 
 """
-    (x, stats) = qmr(A, b::AbstractVector{T}; c::AbstractVector{T}=b,
+    (x, stats) = qmr(A, b::AbstractVector{FC}; c::AbstractVector{FC}=b,
                      atol::T=√eps(T), rtol::T=√eps(T),
-                     itmax::Int=0, verbose::Int=0, history::Bool=false) where T <: AbstractFloat
+                     itmax::Int=0, verbose::Int=0, history::Bool=false)
+
+`T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
+`FC` is `T` or `Complex{T}`.
 
 Solve the square linear system Ax = b using the QMR method.
 
@@ -37,15 +40,15 @@ When `A` is symmetric and `b = c`, QMR is equivalent to MINRES.
 * R. W. Freund and N. M. Nachtigal, [*An implementation of the QMR method based on coupled two-term recurrences*](https://doi.org/10.1137/0915022), SIAM Journal on Scientific Computing, Vol. 15(2), pp. 313--337, 1994.
 * A. Montoison and D. Orban, [*BiLQ: An Iterative Method for Nonsymmetric Linear Systems with a Quasi-Minimum Error Property*](https://doi.org/10.1137/19M1290991), SIAM Journal on Matrix Analysis and Applications, 41(3), pp. 1145--1166, 2020.
 """
-function qmr(A, b :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
+function qmr(A, b :: AbstractVector{FC}; kwargs...) where FC <: FloatOrComplex
   solver = QmrSolver(A, b)
   qmr!(solver, A, b; kwargs...)
   return (solver.x, solver.stats)
 end
 
-function qmr!(solver :: QmrSolver{T,S}, A, b :: AbstractVector{T}; c :: AbstractVector{T}=b,
+function qmr!(solver :: QmrSolver{T,FC,S}, A, b :: AbstractVector{FC}; c :: AbstractVector{FC}=b,
               atol :: T=√eps(T), rtol :: T=√eps(T),
-              itmax :: Int=0, verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, S <: DenseVector{T}}
+              itmax :: Int=0, verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: DenseVector{FC}}
 
   n, m = size(A)
   m == n || error("System must be square")

--- a/src/symmlq.jl
+++ b/src/symmlq.jl
@@ -13,12 +13,15 @@ export symmlq, symmlq!
 
 
 """
-    (x, stats) = symmlq(A, b::AbstractVector{T};
+    (x, stats) = symmlq(A, b::AbstractVector{FC};
                         M=I, λ::T=zero(T), transfer_to_cg::Bool=true,
                         λest::T=zero(T), atol::T=√eps(T), rtol::T=√eps(T),
                         etol::T=√eps(T), window::Int=0, itmax::Int=0,
                         conlim::T=1/√eps(T), restart::Bool=false,
-                        verbose::Int=0, history::Bool=false) where T <: AbstractFloat
+                        verbose::Int=0, history::Bool=false)
+
+`T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
+`FC` is `T` or `Complex{T}`.
 
 Solve the shifted linear system
 
@@ -36,18 +39,18 @@ assumed to be symmetric and positive definite.
 
 * C. C. Paige and M. A. Saunders, [*Solution of Sparse Indefinite Systems of Linear Equations*](https://doi.org/10.1137/0712047), SIAM Journal on Numerical Analysis, 12(4), pp. 617--629, 1975.
 """
-function symmlq(A, b :: AbstractVector{T}; window :: Int=5, kwargs...) where T <: AbstractFloat
+function symmlq(A, b :: AbstractVector{FC}; window :: Int=5, kwargs...) where FC <: FloatOrComplex
   solver = SymmlqSolver(A, b, window=window)
   symmlq!(solver, A, b; kwargs...)
   return (solver.x, solver.stats)
 end
 
-function symmlq!(solver :: SymmlqSolver{T,S}, A, b :: AbstractVector{T};
+function symmlq!(solver :: SymmlqSolver{T,FC,S}, A, b :: AbstractVector{FC};
                  M=I, λ :: T=zero(T), transfer_to_cg :: Bool=true,
                  λest :: T=zero(T), atol :: T=√eps(T), rtol :: T=√eps(T),
                  etol :: T=√eps(T), itmax :: Int=0,
                  conlim :: T=1/√eps(T), restart :: Bool=false,
-                 verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, S <: DenseVector{T}}
+                 verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: DenseVector{FC}}
 
   m, n = size(A)
   m == n || error("System must be square")

--- a/src/tricg.jl
+++ b/src/tricg.jl
@@ -12,11 +12,14 @@
 export tricg, tricg!
 
 """
-    (x, y, stats) = tricg(A, b::AbstractVector{T}, c::AbstractVector{T};
+    (x, y, stats) = tricg(A, b::AbstractVector{FC}, c::AbstractVector{FC};
                           M=I, N=I, atol::T=√eps(T), rtol::T=√eps(T),
                           spd::Bool=false, snd::Bool=false, flip::Bool=false,
                           τ::T=one(T), ν::T=-one(T), itmax::Int=0, verbose::Int=0,
-                          restart::Bool=false, history::Bool=false) where T <: AbstractFloat
+                          restart::Bool=false, history::Bool=false)
+
+`T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
+`FC` is `T` or `Complex{T}`.
 
 TriCG solves the symmetric linear system
 
@@ -53,17 +56,17 @@ Information will be displayed every `verbose` iterations.
 
 * A. Montoison and D. Orban, [*TriCG and TriMR: Two Iterative Methods for Symmetric Quasi-Definite Systems*](https://doi.org/10.1137/20M1363030), SIAM Journal on Scientific Computing, 43(4), pp. 2502--2525, 2021.
 """
-function tricg(A, b :: AbstractVector{T}, c :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
+function tricg(A, b :: AbstractVector{FC}, c :: AbstractVector{FC}; kwargs...) where FC <: FloatOrComplex
   solver = TricgSolver(A, b)
   tricg!(solver, A, b, c; kwargs...)
   return (solver.x, solver.y, solver.stats)
 end
 
-function tricg!(solver :: TricgSolver{T,S}, A, b :: AbstractVector{T}, c :: AbstractVector{T};
+function tricg!(solver :: TricgSolver{T,FC,S}, A, b :: AbstractVector{FC}, c :: AbstractVector{FC};
                 M=I, N=I, atol :: T=√eps(T), rtol :: T=√eps(T),
                 spd :: Bool=false, snd :: Bool=false, flip :: Bool=false,
                 τ :: T=one(T), ν :: T=-one(T), itmax :: Int=0, verbose :: Int=0,
-                restart :: Bool=false, history :: Bool=false) where {T <: AbstractFloat, S <: DenseVector{T}}
+                restart :: Bool=false, history :: Bool=false) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: DenseVector{FC}}
 
   m, n = size(A)
   length(b) == m || error("Inconsistent problem size")

--- a/src/trilqr.jl
+++ b/src/trilqr.jl
@@ -13,9 +13,12 @@
 export trilqr, trilqr!
 
 """
-    (x, y, stats) = trilqr(A, b::AbstractVector{T}, c::AbstractVector{T};
+    (x, y, stats) = trilqr(A, b::AbstractVector{FC}, c::AbstractVector{FC};
                            atol::T=√eps(T), rtol::T=√eps(T), transfer_to_usymcg::Bool=true,
-                           itmax::Int=0, verbose::Int=0, history::Bool=false) where T <: AbstractFloat
+                           itmax::Int=0, verbose::Int=0, history::Bool=false)
+
+`T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
+`FC` is `T` or `Complex{T}`.
 
 Combine USYMLQ and USYMQR to solve adjoint systems.
 
@@ -32,15 +35,15 @@ USYMCG point, when it exists. The transfer is based on the residual norm.
 
 * A. Montoison and D. Orban, [*BiLQ: An Iterative Method for Nonsymmetric Linear Systems with a Quasi-Minimum Error Property*](https://doi.org/10.1137/19M1290991), SIAM Journal on Matrix Analysis and Applications, 41(3), pp. 1145--1166, 2020.
 """
-function trilqr(A, b :: AbstractVector{T}, c :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
+function trilqr(A, b :: AbstractVector{FC}, c :: AbstractVector{FC}; kwargs...) where FC <: FloatOrComplex
   solver = TrilqrSolver(A, b)
   trilqr!(solver, A, b, c; kwargs...)
   return (solver.x, solver.y, solver.stats)
 end
 
-function trilqr!(solver :: TrilqrSolver{T,S}, A, b :: AbstractVector{T}, c :: AbstractVector{T};
+function trilqr!(solver :: TrilqrSolver{T,FC,S}, A, b :: AbstractVector{FC}, c :: AbstractVector{FC};
                  atol :: T=√eps(T), rtol :: T=√eps(T), transfer_to_usymcg :: Bool=true,
-                 itmax :: Int=0, verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, S <: DenseVector{T}}
+                 itmax :: Int=0, verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: DenseVector{FC}}
 
   m, n = size(A)
   length(b) == m || error("Inconsistent problem size")

--- a/src/trimr.jl
+++ b/src/trimr.jl
@@ -12,11 +12,14 @@
 export trimr, trimr!
 
 """
-    (x, y, stats) = trimr(A, b::AbstractVector{T}, c::AbstractVector{T};
+    (x, y, stats) = trimr(A, b::AbstractVector{FC}, c::AbstractVector{FC};
                           M=I, N=I, atol::T=√eps(T), rtol::T=√eps(T),
                           spd::Bool=false, snd::Bool=false, flip::Bool=false, sp::Bool=false,
                           τ::T=one(T), ν::T=-one(T), itmax::Int=0, verbose::Int=0,
-                          restart::Bool=false, history::Bool=false) where T <: AbstractFloat
+                          restart::Bool=false, history::Bool=false)
+
+`T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
+`FC` is `T` or `Complex{T}`.
 
 TriMR solves the symmetric linear system
 
@@ -53,17 +56,17 @@ Information will be displayed every `verbose` iterations.
 
 * A. Montoison and D. Orban, [*TriCG and TriMR: Two Iterative Methods for Symmetric Quasi-Definite Systems*](https://doi.org/10.1137/20M1363030), SIAM Journal on Scientific Computing, 43(4), pp. 2502--2525, 2021.
 """
-function trimr(A, b :: AbstractVector{T}, c :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
+function trimr(A, b :: AbstractVector{FC}, c :: AbstractVector{FC}; kwargs...) where FC <: FloatOrComplex
   solver = TrimrSolver(A, b)
   trimr!(solver, A, b, c; kwargs...)
   return (solver.x, solver.y, solver.stats)
 end
 
-function trimr!(solver :: TrimrSolver{T,S}, A, b :: AbstractVector{T}, c :: AbstractVector{T};
+function trimr!(solver :: TrimrSolver{T,FC,S}, A, b :: AbstractVector{FC}, c :: AbstractVector{FC};
                 M=I, N=I, atol :: T=√eps(T), rtol :: T=√eps(T),
                 spd :: Bool=false, snd :: Bool=false, flip :: Bool=false, sp :: Bool=false,
                 τ :: T=one(T), ν :: T=-one(T), itmax :: Int=0, verbose :: Int=0,
-                restart :: Bool=false, history :: Bool=false) where {T <: AbstractFloat, S <: DenseVector{T}}
+                restart :: Bool=false, history :: Bool=false) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: DenseVector{FC}}
 
   m, n = size(A)
   length(b) == m || error("Inconsistent problem size")

--- a/src/usymlq.jl
+++ b/src/usymlq.jl
@@ -20,9 +20,12 @@
 export usymlq, usymlq!
 
 """
-    (x, stats) = usymlq(A, b::AbstractVector{T}, c::AbstractVector{T};
+    (x, stats) = usymlq(A, b::AbstractVector{FC}, c::AbstractVector{FC};
                         atol::T=√eps(T), rtol::T=√eps(T), transfer_to_usymcg::Bool=true,
-                        itmax::Int=0, verbose::Int=0, history::Bool=false) where T <: AbstractFloat
+                        itmax::Int=0, verbose::Int=0, history::Bool=false)
+
+`T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
+`FC` is `T` or `Complex{T}`.
 
 Solve the linear system Ax = b using the USYMLQ method.
 
@@ -43,15 +46,15 @@ when it exists. The transfer is based on the residual norm.
 * A. Buttari, D. Orban, D. Ruiz and D. Titley-Peloquin, [*A tridiagonalization method for symmetric saddle-point and quasi-definite systems*](https://doi.org/10.1137/18M1194900), SIAM Journal on Scientific Computing, 41(5), pp. 409--432, 2019.
 * A. Montoison and D. Orban, [*BiLQ: An Iterative Method for Nonsymmetric Linear Systems with a Quasi-Minimum Error Property*](https://doi.org/10.1137/19M1290991), SIAM Journal on Matrix Analysis and Applications, 41(3), pp. 1145--1166, 2020.
 """
-function usymlq(A, b :: AbstractVector{T}, c :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
+function usymlq(A, b :: AbstractVector{FC}, c :: AbstractVector{FC}; kwargs...) where FC <: FloatOrComplex
   solver = UsymlqSolver(A, b)
   usymlq!(solver, A, b, c; kwargs...)
   return (solver.x, solver.stats)
 end
 
-function usymlq!(solver :: UsymlqSolver{T,S}, A, b :: AbstractVector{T}, c :: AbstractVector{T};
+function usymlq!(solver :: UsymlqSolver{T,FC,S}, A, b :: AbstractVector{FC}, c :: AbstractVector{FC};
                  atol :: T=√eps(T), rtol :: T=√eps(T), transfer_to_usymcg :: Bool=true,
-                 itmax :: Int=0, verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, S <: DenseVector{T}}
+                 itmax :: Int=0, verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: DenseVector{FC}}
 
   m, n = size(A)
   length(b) == m || error("Inconsistent problem size")

--- a/src/usymqr.jl
+++ b/src/usymqr.jl
@@ -20,9 +20,12 @@
 export usymqr, usymqr!
 
 """
-    (x, stats) = usymqr(A, b::AbstractVector{T}, c::AbstractVector{T};
+    (x, stats) = usymqr(A, b::AbstractVector{FC}, c::AbstractVector{FC};
                         atol::T=√eps(T), rtol::T=√eps(T),
-                        itmax::Int=0, verbose::Int=0, history::Bool=false) where T <: AbstractFloat
+                        itmax::Int=0, verbose::Int=0, history::Bool=false)
+
+`T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
+`FC` is `T` or `Complex{T}`.
 
 Solve the linear system Ax = b using the USYMQR method.
 
@@ -40,15 +43,15 @@ USYMQR finds the minimum-norm solution if problems are inconsistent.
 * A. Buttari, D. Orban, D. Ruiz and D. Titley-Peloquin, [*A tridiagonalization method for symmetric saddle-point and quasi-definite systems*](https://doi.org/10.1137/18M1194900), SIAM Journal on Scientific Computing, 41(5), pp. 409--432, 2019.
 * A. Montoison and D. Orban, [*BiLQ: An Iterative Method for Nonsymmetric Linear Systems with a Quasi-Minimum Error Property*](https://doi.org/10.1137/19M1290991), SIAM Journal on Matrix Analysis and Applications, 41(3), pp. 1145--1166, 2020.
 """
-function usymqr(A, b :: AbstractVector{T}, c :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
+function usymqr(A, b :: AbstractVector{FC}, c :: AbstractVector{FC}; kwargs...) where FC <: FloatOrComplex
   solver = UsymqrSolver(A, b)
   usymqr!(solver, A, b, c; kwargs...)
   return (solver.x, solver.stats)
 end
 
-function usymqr!(solver :: UsymqrSolver{T,S}, A, b :: AbstractVector{T}, c :: AbstractVector{T};
+function usymqr!(solver :: UsymqrSolver{T,FC,S}, A, b :: AbstractVector{FC}, c :: AbstractVector{FC};
                  atol :: T=√eps(T), rtol :: T=√eps(T),
-                 itmax :: Int=0, verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, S <: DenseVector{T}}
+                 itmax :: Int=0, verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: DenseVector{FC}}
 
   m, n = size(A)
   length(b) == m || error("Inconsistent problem size")


### PR DESCRIPTION
@dpo, @tmigot, @geoffroyleconte
I updated the Krylov methods to support complex numbers.
Can you give your opinion before I "finalize" the update of each method and add the tests ?
Some methods only require a few `abs()` and `conj()` to handle complex linear systems.

I defined a new type :
```
"""
    FloatOrComplex{T}
Union type of `T` and `Complex{T}` where T is an [`AbstractFloat`](@ref).
"""
const FloatOrComplex{T} = Union{T, Complex{T}} where T <: AbstractFloat
```
and  I replaced each method
 ```
xyz(A, b :: AbstractVector{T}; kwargs...) where T <: AbstractFloat
```
by
```
xyz(A, b :: AbstractVector{FC}; kwargs...) where FC <: FloatOrComplex
```

The in-place methods and `KrylovSolvers` are now parametrized by 3 parameters `{T,FC,S}` with `{T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: DenseVector{FC}}`.

@abelsiqueira 
If should be still possible to do
```
KrylovSolver{T,FC,S} <: AbstractJSOSolver{T, S}
```
if you want to do a generic solver. :smiley: 