### PR TITLE
Hotfix for breakdowns in GPMR

### DIFF
--- a/src/gpmr.jl
+++ b/src/gpmr.jl
@@ -363,14 +363,16 @@ function gpmr!(solver :: GpmrSolver{T,S}, A, B, b :: AbstractVector{T}, c :: Abs
       if Haux ≠ 0
         @. V[k+1] = q / Haux  # hₖ₊₁.ₖvₖ₊₁ = q
       else
-        V[k+1] .= zero(T)  # hₖ₊₁.ₖ = 0 ⇔ vₖ₊₁ = 0
+        # Breakdown -- hₖ₊₁.ₖ = ‖q‖₂ = 0 and Auₖ ∈ Span{v₁, ..., vₖ}
+        V[k+1] .= zero(T)  # vₖ₊₁ = 0 such that vₖ₊₁ ⊥ Span{v₁, ..., vₖ}
       end
 
       # fₖ₊₁.ₖ ≠ 0
       if Faux ≠ 0
         @. U[k+1] = p / Faux  # fₖ₊₁.ₖuₖ₊₁ = p
       else
-        U[k+1] .= zero(T)  # fₖ₊₁.ₖ = 0 ⇔ uₖ₊₁ = 0
+        # Breakdown -- fₖ₊₁.ₖ = ‖p‖₂ = 0 and Bvₖ ∈ Span{u₁, ..., uₖ}
+        U[k+1] .= zero(T)  # uₖ₊₁ = 0 such that uₖ₊₁ ⊥ Span{u₁, ..., uₖ}
       end
 
       zt[2k+1] = τbar₂ₖ₊₁

--- a/src/gpmr.jl
+++ b/src/gpmr.jl
@@ -390,7 +390,12 @@ function gpmr!(solver :: GpmrSolver{T,S}, A, B, b :: AbstractVector{T}, c :: Abs
       zt[i] = zt[i] - R[pos] * zt[j]  # ζᵢ ← ζᵢ - rᵢ.ⱼζⱼ
       pos = pos - j + 1               # position of rᵢ.ⱼ₋₁
     end
-    zt[i] = zt[i] / R[pos]            # ζᵢ ← ζᵢ / rᵢ.ᵢ
+    # Rₖ can be singular is the system is inconsistent
+    if R[pos] ≤ eps(T)
+      zt[i] = zero(T)
+    else
+      zt[i] = zt[i] / R[pos]          # ζᵢ ← ζᵢ / rᵢ.ᵢ
+    end
   end
 
   # Compute xₖ and yₖ

--- a/src/gpmr.jl
+++ b/src/gpmr.jl
@@ -360,7 +360,7 @@ function gpmr!(solver :: GpmrSolver{T,S}, A, B, b :: AbstractVector{T}, c :: Abs
       end
 
       # hₖ₊₁.ₖ ≠ 0
-      if Haux ≠ 0
+      if Haux > eps(T)
         @. V[k+1] = q / Haux  # hₖ₊₁.ₖvₖ₊₁ = q
       else
         # Breakdown -- hₖ₊₁.ₖ = ‖q‖₂ = 0 and Auₖ ∈ Span{v₁, ..., vₖ}
@@ -368,7 +368,7 @@ function gpmr!(solver :: GpmrSolver{T,S}, A, B, b :: AbstractVector{T}, c :: Abs
       end
 
       # fₖ₊₁.ₖ ≠ 0
-      if Faux ≠ 0
+      if Faux > eps(T)
         @. U[k+1] = p / Faux  # fₖ₊₁.ₖuₖ₊₁ = p
       else
         # Breakdown -- fₖ₊₁.ₖ = ‖p‖₂ = 0 and Bvₖ ∈ Span{u₁, ..., uₖ}

--- a/src/gpmr.jl
+++ b/src/gpmr.jl
@@ -179,11 +179,12 @@ function gpmr!(solver :: GpmrSolver{T,S}, A, B, b :: AbstractVector{T}, c :: Abs
   gsp && (λ = one(T) ; μ = zero(T))
 
   # Stopping criterion.
+  breakdown = false
   solved = rNorm ≤ ε
   tired = iter ≥ itmax
   status = "unknown"
 
-  while !(solved || tired)
+  while !(solved || tired || breakdown)
 
     # Update iteration index.
     iter = iter + 1
@@ -347,12 +348,13 @@ function gpmr!(solver :: GpmrSolver{T,S}, A, B, b :: AbstractVector{T}, c :: Abs
     nr = nr + 4k-1
 
     # Update stopping criterion.
+    breakdown = Faux ≤ eps(T) && Haux ≤ eps(T)
     solved = rNorm ≤ ε
     tired = iter ≥ itmax
     display(iter, verbose) && @printf("%5d  %7.1e  %7.1e  %7.1e\n", iter, rNorm, Haux, Faux)
 
     # Compute vₖ₊₁ and uₖ₊₁
-    if !(solved || tired)
+    if !(solved || tired || breakdown)
       if iter ≥ mem
         push!(V, S(undef, m))
         push!(U, S(undef, n))
@@ -407,11 +409,13 @@ function gpmr!(solver :: GpmrSolver{T,S}, A, B, b :: AbstractVector{T}, c :: Abs
   restart && @kaxpy!(m, one(T), Δx, x)
   restart && @kaxpy!(n, one(T), Δy, y)
 
-  status = tired ? "maximum number of iterations exceeded" : "solution good enough given atol and rtol"
+  tired     && (status = "maximum number of iterations exceeded")
+  breakdown && (status = "found approximate least-squares solution")
+  solved    && (status = "solution good enough given atol and rtol")
 
   # Update stats
   stats.solved = solved
-  stats.inconsistent = false
+  stats.inconsistent = !solved && breakdown
   stats.status = status
   return solver
 end

--- a/src/gpmr.jl
+++ b/src/gpmr.jl
@@ -172,8 +172,8 @@ function gpmr!(solver :: GpmrSolver{T,S}, A, B, b :: AbstractVector{T}, c :: Abs
   zt[1] = β
   zt[2] = γ
 
-  (verbose > 0) && @printf("%5s  %7s\n", "k", "‖rₖ‖")
-  display(iter, verbose) && @printf("%5d  %7.1e\n", iter, rNorm)
+  (verbose > 0) && @printf("%5s  %7s  %7s  %7s\n", "k", "‖rₖ‖", "hₖ₊₁.ₖ", "fₖ₊₁.ₖ")
+  display(iter, verbose) && @printf("%5d  %7.1e  %7s  %7s\n", iter, rNorm, "✗ ✗ ✗ ✗", "✗ ✗ ✗ ✗")
 
   # Determine λ and μ associated to generalized saddle point systems.
   gsp && (λ = one(T) ; μ = zero(T))
@@ -349,7 +349,7 @@ function gpmr!(solver :: GpmrSolver{T,S}, A, B, b :: AbstractVector{T}, c :: Abs
     # Update stopping criterion.
     solved = rNorm ≤ ε
     tired = iter ≥ itmax
-    display(iter, verbose) && @printf("%5d  %7.1e\n", iter, rNorm)
+    display(iter, verbose) && @printf("%5d  %7.1e  %7.1e  %7.1e\n", iter, rNorm, Haux, Faux)
 
     # Compute vₖ₊₁ and uₖ₊₁
     if !(solved || tired)
@@ -358,8 +358,21 @@ function gpmr!(solver :: GpmrSolver{T,S}, A, B, b :: AbstractVector{T}, c :: Abs
         push!(U, S(undef, n))
         push!(zt, zero(T), zero(T))
       end
-      @. V[k+1] = q / Haux  # hₖ₊₁.ₖvₖ₊₁ = q
-      @. U[k+1] = p / Faux  # fₖ₊₁.ₖuₖ₊₁ = p
+
+      # hₖ₊₁.ₖ ≠ 0
+      if Haux ≠ 0
+        @. V[k+1] = q / Haux  # hₖ₊₁.ₖvₖ₊₁ = q
+      else
+        V[k+1] .= zero(T)  # hₖ₊₁.ₖ = 0 ⇔ vₖ₊₁ = 0
+      end
+
+      # fₖ₊₁.ₖ ≠ 0
+      if Faux ≠ 0
+        @. U[k+1] = p / Faux  # fₖ₊₁.ₖuₖ₊₁ = p
+      else
+        U[k+1] .= zero(T)  # fₖ₊₁.ₖ = 0 ⇔ uₖ₊₁ = 0
+      end
+
       zt[2k+1] = τbar₂ₖ₊₁
       zt[2k+2] = τbar₂ₖ₊₂
     end

--- a/test/test_gpmr.jl
+++ b/test/test_gpmr.jl
@@ -61,6 +61,9 @@
     p = rank(K)
     @test(p < n)
     x, y, stats = gpmr(A, A', b, c)
+    r =  d - K * [x; y]
+    Aresid = norm(K' * r) / norm(K' * d)
+    @test(Aresid ≤ gpmr_tol)
     @test(stats.inconsistent)
   end
 

--- a/test/test_gpmr.jl
+++ b/test/test_gpmr.jl
@@ -52,6 +52,16 @@
     r =  d - K * [x; y]
     resid = norm(r) / norm(d)
     @test(resid ≤ gpmr_tol)
+
+    # Test inconsistent linear systems
+    A, b, c = ssy_mo_breakdown(transpose)
+    K = [I A; A' I]
+    d = [b; c]
+    n, m = size(K)
+    p = rank(K)
+    @test(p < n)
+    x, y, stats = gpmr(A, A', b, c)
+    @test(stats.inconsistent)
   end
 
   # Test underdetermined adjoint systems.

--- a/test/test_gpmr.jl
+++ b/test/test_gpmr.jl
@@ -41,6 +41,17 @@
     @test_throws ErrorException("c must be nonzero") gpmr(A, B, b, c)
     b .= 0
     @test_throws ErrorException("b must be nonzero") gpmr(A, B, b, c)
+
+    # Test breakdowns
+    A, b, c = ssy_mo_breakdown(transpose)
+    λ = 1.0
+    μ = -1.0
+    K = [I A; A' -I]
+    d = [b; c]
+    x, y, stats = gpmr(A, A', b, c, λ=λ, μ=μ)
+    r =  d - K * [x; y]
+    resid = norm(r) / norm(d)
+    @test(resid ≤ gpmr_tol)
   end
 
   # Test underdetermined adjoint systems.

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -331,3 +331,16 @@ function jacobi(A; T=Float64, pd=true)
   P⁻¹ = Diagonal(J)
   return P⁻¹
 end
+
+# Generate a breakdown in the orthogonal tridiagonalization process and the orthogonal Hessenberg reduction process.
+function ssy_mo_breakdown(transpose :: Bool=false)
+  if transpose
+    A = [1.0 -1.0; 0.0 1.0; -1.0 0.0]
+  else
+    A = [1.0 0.0 -1.0; -1.0 1.0 0.0]
+  end
+  n, m = size(A)
+  b = ones(n)
+  c = ones(m)
+  return A, b, c
+end


### PR DESCRIPTION
close #466 

@dpo 
Our orthogonal Hessenberg process continues if `hₖ₊₁.ₖ = 0` or `fₖ₊₁.ₖ = 0`.
We just need to not normalize `vₖ₊₁` or `uₖ₊₁` if we encounter these cases.

In our article, we propose to handle breakdowns theoretically like this
```
"""In case of breakdown, which happens if Auₖ ∈ Span{v₁ , ... , vₖ} or Bvₖ ∈ Span{u₁ , ... , uₖ},
we choose an arbitrary unit vₖ₊₁ ⊥ Span{v₁, ... , vₖ} or uₖ₊₁ ⊥ Span{u₁, ... , uₖ}
and set βₖ₊₁ = 0 or γₖ₊₁ = 0, respectively."""
```
in the proof of the orthogonal Hessenberg process (GPMR paper).
For this reason,  the process should be stopped after `p := min{m,n}` iterations.

But numerically, it also works to set `βₖ₊₁ = vₖ₊₁ = 0` if `Auₖ ∈ Span{v₁ , ... , vₖ}` or `γₖ₊₁ = uₖ₊₁ = 0` if `Bvₖ ∈ Span{u₁ , ... , uₖ}`.
We can continue the process until `max{m,n}`.
At `max{m,n}`, in the worst case, `hₖ₊₁.ₖ = fₖ₊₁.ₖ = 0` and the exact solution is found.
It's the missing piece to prove the convergence of GPMR ! 