### PR TITLE
fix `zero_resid` in `lslq` and `lsmr`

### DIFF
--- a/src/lslq.jl
+++ b/src/lslq.jl
@@ -417,7 +417,8 @@ function lslq!(solver :: LslqSolver{T,S}, A, b :: AbstractVector{T};
     zero_resid_lim = (test1 ≤ rtol)
 
     ill_cond = ill_cond_mach || ill_cond_lim
-    solved = solved_mach || solved_lim || zero_resid_mach || zero_resid_lim || fwd_err_lbnd || fwd_err_ubnd
+    zero_resid = zero_resid_mach || zero_resid_lim
+    solved = solved_mach || solved_lim || zero_resid || fwd_err_lbnd || fwd_err_ubnd
 
     iter = iter + 1
   end

--- a/src/lsmr.jl
+++ b/src/lsmr.jl
@@ -345,7 +345,8 @@ function lsmr!(solver :: LsmrSolver{T,S}, A, b :: AbstractVector{T};
     user_requested_exit = callback(solver, iter) :: Bool
 
     ill_cond = ill_cond_mach | ill_cond_lim
-    solved = solved_mach | solved_lim | solved_opt | zero_resid_mach | zero_resid_lim | fwd_err | on_boundary
+    zero_resid = zero_resid_mach | zero_resid_lim
+    solved = solved_mach | solved_lim | solved_opt | zero_resid | fwd_err | on_boundary
   end
   (verbose > 0) && @printf("\n")
 

--- a/test/test_solvers.jl
+++ b/test/test_solvers.jl
@@ -862,11 +862,11 @@
     └────────────────────┴──────────────────────────┴──────────────────┘
     Simple stats
     solved: true
-    inconsistent: true
+    inconsistent: false
     residuals: []
     Aresiduals: []
     κ₂(A): []
-    status: found approximate minimum least-squares solution"""
+    status: found approximate zero-residual solution"""
     @test strip.(split(chomp(showed), "\n")) == strip.(split(chomp(expected), "\n"))
 
     io = IOBuffer()


### PR DESCRIPTION
After #469 , I checked the other methods and found these two with the same issue.