### PR TITLE
Remove unnecessary eltype checks of preconditioners

### DIFF
--- a/src/gmres.jl
+++ b/src/gmres.jl
@@ -60,8 +60,6 @@ function gmres!(solver :: GmresSolver{T,S}, A, b :: AbstractVector{T};
   # Check type consistency
   eltype(A) == T || error("eltype(A) ≠ $T")
   ktypeof(b) == S || error("ktypeof(b) ≠ $S")
-  MisI || (promote_type(eltype(M), T) == T) || error("eltype(M) can't be promoted to $T")
-  NisI || (promote_type(eltype(N), T) == T) || error("eltype(N) can't be promoted to $T")
 
   # Set up workspace.
   allocate_if(!MisI  , solver, :q , S, n)


### PR DESCRIPTION
These aren't even used and should not be expected to be defined. Matrix-free preconditioners, like geometric multigrid, do not necessarily have a sense of what eltype is.