### PR TITLE
[QMR / GMRES / BICGSTAB] Support of complex numbers

### DIFF
--- a/src/bicgstab.jl
+++ b/src/bicgstab.jl
@@ -88,9 +88,9 @@ function bicgstab!(solver :: BicgstabSolver{T,FC,S}, A, b :: AbstractVector{FC};
   y = NisI ? p : solver.yz
   z = NisI ? s : solver.yz
 
-  x .= zero(FC)   # x₀
-  s .= zero(FC)   # s₀
-  v .= zero(FC)   # v₀
+  x .= zero(FC)  # x₀
+  s .= zero(FC)  # s₀
+  v .= zero(FC)  # v₀
   mul!(r, M, b)  # r₀
   p .= r         # p₁
 
@@ -111,7 +111,7 @@ function bicgstab!(solver :: BicgstabSolver{T,FC,S}, A, b :: AbstractVector{FC};
   itmax == 0 && (itmax = 2*n)
 
   ε = atol + rtol * rNorm
-  (verbose > 0) && @printf("%5s  %7s  %8s  %8s\n", "k", "‖rₖ‖", "‖αₖ‖", "‖ωₖ‖")
+  (verbose > 0) && @printf("%5s  %7s  %8s  %8s\n", "k", "‖rₖ‖", "|αₖ|", "|ωₖ|")
   display(iter, verbose) && @printf("%5d  %7.1e  %8.1e  %8.1e\n", iter, rNorm, abs(α), abs(ω))
 
   next_ρ = @kdot(n, c, r)  # ρ₁ = ⟨r̅₀,r₀⟩
@@ -149,7 +149,7 @@ function bicgstab!(solver :: BicgstabSolver{T,FC,S}, A, b :: AbstractVector{FC};
     next_ρ = @kdot(n, c, r)              # ρₖ₊₁ = ⟨r̅₀,rₖ⟩
     β = (next_ρ / ρ) * (α / ω)           # βₖ₊₁ = (ρₖ₊₁ / ρₖ) * (αₖ / ωₖ)
     @kaxpy!(n, -ω, v, p)                 # pₐᵤₓ = pₖ - ωₖvₖ
-    @kaxpby!(n, one(FC), r, β, p)         # pₖ₊₁ = rₖ₊₁ + βₖ₊₁pₐᵤₓ
+    @kaxpby!(n, one(FC), r, β, p)        # pₖ₊₁ = rₖ₊₁ + βₖ₊₁pₐᵤₓ
 
     # Compute residual norm ‖rₖ‖₂.
     rNorm = @knrm2(n, r)

--- a/src/gmres.jl
+++ b/src/gmres.jl
@@ -61,7 +61,7 @@ function gmres!(solver :: GmresSolver{T,FC,S}, A, b :: AbstractVector{FC};
   NisI = (N === I)
 
   # Check type consistency
-  eltype(A) == T || error("eltype(A) ≠ $T")
+  eltype(A) == FC || error("eltype(A) ≠ $FC")
   ktypeof(b) == S || error("ktypeof(b) ≠ $S")
 
   # Set up workspace.
@@ -77,10 +77,10 @@ function gmres!(solver :: GmresSolver{T,FC,S}, A, b :: AbstractVector{FC};
 
   # Initial solution x₀ and residual r₀.
   restart && (Δx .= x)
-  x .= zero(T)            # x₀
+  x .= zero(FC)            # x₀
   if restart
     mul!(w, A, Δx)
-    @kaxpby!(n, one(T), b, -one(T), w)
+    @kaxpby!(n, one(FC), b, -one(FC), w)
   else
     w .= b
   end
@@ -105,12 +105,12 @@ function gmres!(solver :: GmresSolver{T,FC,S}, A, b :: AbstractVector{FC};
   nr = 0           # Number of coefficients stored in Rₖ.
   mem = length(c)  # Memory
   for i = 1 : mem
-    V[i] .= zero(T)  # Orthogonal basis of Kₖ(M⁻¹AN⁻¹, M⁻¹b).
+    V[i] .= zero(FC)  # Orthogonal basis of Kₖ(M⁻¹AN⁻¹, M⁻¹b).
   end
-  s .= zero(T)  # Givens sines used for the factorization QₖRₖ = Hₖ₊₁.ₖ.
+  s .= zero(FC)  # Givens sines used for the factorization QₖRₖ = Hₖ₊₁.ₖ.
   c .= zero(T)  # Givens cosines used for the factorization QₖRₖ = Hₖ₊₁.ₖ.
-  R .= zero(T)  # Upper triangular matrix Rₖ.
-  z .= zero(T)  # Right-hand of the least squares problem min ‖Hₖ₊₁.ₖyₖ - βe₁‖₂.
+  R .= zero(FC)  # Upper triangular matrix Rₖ.
+  z .= zero(FC)  # Right-hand of the least squares problem min ‖Hₖ₊₁.ₖyₖ - βe₁‖₂.
 
   # Initial ζ₁ and V₁
   z[1] = β
@@ -130,9 +130,9 @@ function gmres!(solver :: GmresSolver{T,FC,S}, A, b :: AbstractVector{FC};
     # Update workspace if more storage is required
     if iter > mem
       for i = 1 : iter
-        push!(R, zero(T))
+        push!(R, zero(FC))
       end
-      push!(s, zero(T))
+      push!(s, zero(FC))
       push!(c, zero(T))
     end
 
@@ -164,7 +164,7 @@ function gmres!(solver :: GmresSolver{T,FC,S}, A, b :: AbstractVector{FC};
     # [sᵢ -cᵢ] [rᵢ₊₁.ₖ]   [r̄ᵢ₊₁.ₖ]
     for i = 1 : iter-1
       Rtmp      = c[i] * R[nr+i] + s[i] * R[nr+i+1]
-      R[nr+i+1] = s[i] * R[nr+i] - c[i] * R[nr+i+1]
+      R[nr+i+1] = conj(s[i]) * R[nr+i] - c[i] * R[nr+i+1]
       R[nr+i]   = Rtmp
     end
 
@@ -174,7 +174,7 @@ function gmres!(solver :: GmresSolver{T,FC,S}, A, b :: AbstractVector{FC};
     (c[iter], s[iter], R[nr+iter]) = sym_givens(R[nr+iter], Hbis)
 
     # Update zₖ = (Qₖ)ᵀβe₁
-    ζₖ₊₁    = s[iter] * z[iter]
+    ζₖ₊₁    = conj(s[iter]) * z[iter]
     z[iter] = c[iter] * z[iter]
 
     # Update residual norm estimate.
@@ -212,7 +212,7 @@ function gmres!(solver :: GmresSolver{T,FC,S}, A, b :: AbstractVector{FC};
       pos = pos - j + 1
     end
     # Rₖ can be singular is the system is inconsistent
-    if R[pos] ≤ eps(T)
+    if abs(R[pos]) ≤ eps(T)
       y[i] = zero(T)
     else
       y[i] = y[i] / R[pos]  # yᵢ ← yᵢ / rᵢᵢ

--- a/src/krylov_solvers.jl
+++ b/src/krylov_solvers.jl
@@ -1387,9 +1387,9 @@ mutable struct GmresSolver{T,FC,S} <: KrylovSolver{T,FC,S}
   q     :: S
   V     :: Vector{S}
   c     :: Vector{T}
-  s     :: Vector{T}
-  z     :: Vector{T}
-  R     :: Vector{T}
+  s     :: Vector{FC}
+  z     :: Vector{FC}
+  R     :: Vector{FC}
   stats :: SimpleStats{T}
 
   function GmresSolver(n, m, memory, S)
@@ -1402,9 +1402,9 @@ mutable struct GmresSolver{T,FC,S} <: KrylovSolver{T,FC,S}
     q  = S(undef, 0)
     V  = [S(undef, n) for i = 1 : memory]
     c  = Vector{T}(undef, memory)
-    s  = Vector{T}(undef, memory)
-    z  = Vector{T}(undef, memory)
-    R  = Vector{T}(undef, div(memory * (memory+1), 2))
+    s  = Vector{FC}(undef, memory)
+    z  = Vector{FC}(undef, memory)
+    R  = Vector{FC}(undef, div(memory * (memory+1), 2))
     stats = SimpleStats(false, false, T[], T[], T[], "unknown")
     solver = new{T,FC,S}(Δx, x, w, p, q, V, c, s, z, R, stats)
     return solver

--- a/src/qmr.jl
+++ b/src/qmr.jl
@@ -114,7 +114,7 @@ function qmr!(solver :: QmrSolver{T,FC,S}, A, b :: AbstractVector{FC}; c :: Abst
   wₖ₋₂ .= zero(FC)             # Column k-2 of Wₖ = Vₖ(Rₖ)⁻¹
   wₖ₋₁ .= zero(FC)             # Column k-1 of Wₖ = Vₖ(Rₖ)⁻¹
   ζbarₖ = βₖ                   # ζbarₖ is the last component of z̅ₖ = (Qₖ)ᵀβ₁e₁
-  τₖ = real(@kdot(n, vₖ, vₖ))  # τₖ is used for the residual norm estimate
+  τₖ = @kdotr(n, vₖ, vₖ)       # τₖ is used for the residual norm estimate
 
   # Stopping criterion.
   solved    = rNorm ≤ ε
@@ -236,7 +236,7 @@ function qmr!(solver :: QmrSolver{T,FC,S}, A, b :: AbstractVector{FC}; c :: Abst
     end
 
     # Compute τₖ₊₁ = τₖ + ‖vₖ₊₁‖²
-    τₖ₊₁ = τₖ + real(@kdot(n, vₖ, vₖ))
+    τₖ₊₁ = τₖ + @kdotr(n, vₖ, vₖ)
 
     # Compute ‖rₖ‖ ≤ |ζbarₖ₊₁|√τₖ₊₁
     rNorm = abs(ζbarₖ₊₁) * √τₖ₊₁

--- a/src/qmr.jl
+++ b/src/qmr.jl
@@ -63,7 +63,7 @@ function qmr!(solver :: QmrSolver{T,FC,S}, A, b :: AbstractVector{FC}; c :: Abst
   (verbose > 0) && @printf("QMR: system of size %d\n", n)
 
   # Check type consistency
-  eltype(A) == T || error("eltype(A) ≠ $T")
+  eltype(A) == FC || error("eltype(A) ≠ $FC")
   ktypeof(b) == S || error("ktypeof(b) ≠ $S")
   ktypeof(c) == S || error("ktypeof(c) ≠ $S")
 
@@ -77,7 +77,7 @@ function qmr!(solver :: QmrSolver{T,FC,S}, A, b :: AbstractVector{FC}; c :: Abst
   reset!(stats)
 
   # Initial solution x₀ and residual norm ‖r₀‖.
-  x .= zero(T)
+  x .= zero(FC)
   rNorm = @knrm2(n, b)  # ‖r₀‖
   history && push!(rNorms, rNorm)
   if rNorm == 0
@@ -105,14 +105,14 @@ function qmr!(solver :: QmrSolver{T,FC,S}, A, b :: AbstractVector{FC}; c :: Abst
 
   βₖ = √(abs(bᵗc))            # β₁γ₁ = bᵀc
   γₖ = bᵗc / βₖ               # β₁γ₁ = bᵀc
-  vₖ₋₁ .= zero(T)             # v₀ = 0
-  uₖ₋₁ .= zero(T)             # u₀ = 0
+  vₖ₋₁ .= zero(FC)            # v₀ = 0
+  uₖ₋₁ .= zero(FC)            # u₀ = 0
   vₖ .= b ./ βₖ               # v₁ = b / β₁
   uₖ .= c ./ γₖ               # u₁ = c / γ₁
-  cₖ₋₂ = cₖ₋₁ = cₖ = zero(T)  # Givens cosines used for the QR factorization of Tₖ₊₁.ₖ
-  sₖ₋₂ = sₖ₋₁ = sₖ = zero(T)  # Givens sines used for the QR factorization of Tₖ₊₁.ₖ
-  wₖ₋₂ .= zero(T)             # Column k-2 of Wₖ = Vₖ(Rₖ)⁻¹
-  wₖ₋₁ .= zero(T)             # Column k-1 of Wₖ = Vₖ(Rₖ)⁻¹
+  cₖ₋₂ = cₖ₋₁ = cₖ = zero(FC) # Givens cosines used for the QR factorization of Tₖ₊₁.ₖ
+  sₖ₋₂ = sₖ₋₁ = sₖ = zero(FC) # Givens sines used for the QR factorization of Tₖ₊₁.ₖ
+  wₖ₋₂ .= zero(FC)            # Column k-2 of Wₖ = Vₖ(Rₖ)⁻¹
+  wₖ₋₁ .= zero(FC)            # Column k-1 of Wₖ = Vₖ(Rₖ)⁻¹
   ζbarₖ = βₖ                  # ζbarₖ is the last component of z̅ₖ = (Qₖ)ᵀβ₁e₁
   τₖ = @kdot(n, vₖ, vₖ)       # τₖ is used for the residual norm estimate
 
@@ -133,15 +133,15 @@ function qmr!(solver :: QmrSolver{T,FC,S}, A, b :: AbstractVector{FC}; c :: Abst
     mul!(q, A , vₖ)  # Forms vₖ₊₁ : q ← Avₖ
     mul!(p, Aᵀ, uₖ)  # Forms uₖ₊₁ : p ← Aᵀuₖ
 
-    @kaxpy!(n, -γₖ, vₖ₋₁, q)  # q ← q - γₖ * vₖ₋₁
+    @kaxpy!(n, -conj(γₖ), vₖ₋₁, q)  # q ← q - γₖ * vₖ₋₁
     @kaxpy!(n, -βₖ, uₖ₋₁, p)  # p ← p - βₖ * uₖ₋₁
 
     αₖ = @kdot(n, q, uₖ)      # αₖ = qᵀuₖ
 
-    @kaxpy!(n, -αₖ, vₖ, q)    # q ← q - αₖ * vₖ
+    @kaxpy!(n, -conj(αₖ), vₖ, q)    # q ← q - αₖ * vₖ
     @kaxpy!(n, -αₖ, uₖ, p)    # p ← p - αₖ * uₖ
 
-    qᵗp = @kdot(n, p, q)      # qᵗp  = ⟨q,p⟩
+    qᵗp = @kdot(n, q, p)      # qᵗp  = ⟨q,p⟩
     βₖ₊₁ = √(abs(qᵗp))        # βₖ₊₁ = √(|qᵗp|)
     γₖ₊₁ = qᵗp / βₖ₊₁         # γₖ₊₁ = qᵗp / βₖ₊₁
 
@@ -164,17 +164,17 @@ function qmr!(solver :: QmrSolver{T,FC,S}, A, b :: AbstractVector{FC}; c :: Abst
     if iter ≥ 3
       # [cₖ₋₂  sₖ₋₂] [0 ] = [  ϵₖ₋₂ ]
       # [sₖ₋₂ -cₖ₋₂] [γₖ]   [λbarₖ₋₁]
-      ϵₖ₋₂    =  sₖ₋₂ * γₖ
-      λbarₖ₋₁ = -cₖ₋₂ * γₖ
+      ϵₖ₋₂    =  sₖ₋₂ * conj(γₖ)
+      λbarₖ₋₁ = -cₖ₋₂ * conj(γₖ)
     end
 
     # Apply previous Givens reflections Qₖ₋₁.ₖ
     if iter ≥ 2
-      iter == 2 && (λbarₖ₋₁ = γₖ)
+      iter == 2 && (λbarₖ₋₁ = conj(γₖ))
       # [cₖ₋₁  sₖ₋₁] [λbarₖ₋₁] = [λₖ₋₁ ]
       # [sₖ₋₁ -cₖ₋₁] [   αₖ  ]   [δbarₖ]
-      λₖ₋₁  = cₖ₋₁ * λbarₖ₋₁ + sₖ₋₁ * αₖ
-      δbarₖ = sₖ₋₁ * λbarₖ₋₁ - cₖ₋₁ * αₖ
+      λₖ₋₁  = cₖ₋₁ * λbarₖ₋₁ + sₖ₋₁ * conj(αₖ)
+      δbarₖ = conj(sₖ₋₁) * λbarₖ₋₁ - cₖ₋₁ * conj(αₖ)
 
       # Update sₖ₋₂ and cₖ₋₂.
       sₖ₋₂ = sₖ₋₁
@@ -182,7 +182,7 @@ function qmr!(solver :: QmrSolver{T,FC,S}, A, b :: AbstractVector{FC}; c :: Abst
     end
 
     # Compute and apply current Givens reflection Qₖ.ₖ₊₁
-    iter == 1 && (δbarₖ = αₖ)
+    iter == 1 && (δbarₖ = conj(αₖ))
     # [cₖ  sₖ] [δbarₖ] = [δₖ]
     # [sₖ -cₖ] [βₖ₊₁ ]   [0 ]
     (cₖ, sₖ, δₖ) = sym_givens(δbarₖ, βₖ₊₁)
@@ -193,7 +193,7 @@ function qmr!(solver :: QmrSolver{T,FC,S}, A, b :: AbstractVector{FC}; c :: Abst
     # [cₖ  sₖ] [ζbarₖ] = [   ζₖ  ]
     # [sₖ -cₖ] [  0  ]   [ζbarₖ₊₁]
     ζₖ      = cₖ * ζbarₖ
-    ζbarₖ₊₁ = sₖ * ζbarₖ
+    ζbarₖ₊₁ = conj(sₖ) * ζbarₖ
 
     # Update sₖ₋₁ and cₖ₋₁.
     sₖ₋₁ = sₖ
@@ -203,14 +203,14 @@ function qmr!(solver :: QmrSolver{T,FC,S}, A, b :: AbstractVector{FC}; c :: Abst
     # w₁ = v₁ / δ₁
     if iter == 1
       wₖ = wₖ₋₁
-      @kaxpy!(n, one(T), vₖ, wₖ)
+      @kaxpy!(n, one(FC), vₖ, wₖ)
       @. wₖ = wₖ / δₖ
     end
     # w₂ = (v₂ - λ₁w₁) / δ₂
     if iter == 2
       wₖ = wₖ₋₂
       @kaxpy!(n, -λₖ₋₁, wₖ₋₁, wₖ)
-      @kaxpy!(n, one(T), vₖ, wₖ)
+      @kaxpy!(n, one(FC), vₖ, wₖ)
       @. wₖ = wₖ / δₖ
     end
     # wₖ = (vₖ - λₖ₋₁wₖ₋₁ - ϵₖ₋₂wₖ₋₂) / δₖ
@@ -218,7 +218,7 @@ function qmr!(solver :: QmrSolver{T,FC,S}, A, b :: AbstractVector{FC}; c :: Abst
       @kscal!(n, -ϵₖ₋₂, wₖ₋₂)
       wₖ = wₖ₋₂
       @kaxpy!(n, -λₖ₋₁, wₖ₋₁, wₖ)
-      @kaxpy!(n, one(T), vₖ, wₖ)
+      @kaxpy!(n, one(FC), vₖ, wₖ)
       @. wₖ = wₖ / δₖ
     end
 
@@ -230,7 +230,7 @@ function qmr!(solver :: QmrSolver{T,FC,S}, A, b :: AbstractVector{FC}; c :: Abst
     @. vₖ₋₁ = vₖ  # vₖ₋₁ ← vₖ
     @. uₖ₋₁ = uₖ  # uₖ₋₁ ← uₖ
 
-    if qᵗp ≠ zero(T)
+    if qᵗp ≠ zero(FC)
       @. vₖ = q / βₖ₊₁  # βₖ₊₁vₖ₊₁ = q
       @. uₖ = p / γₖ₊₁  # γₖ₊₁uₖ₊₁ = p
     end
@@ -239,7 +239,7 @@ function qmr!(solver :: QmrSolver{T,FC,S}, A, b :: AbstractVector{FC}; c :: Abst
     τₖ₊₁ = τₖ + @kdot(n, vₖ, vₖ)
 
     # Compute ‖rₖ‖ ≤ |ζbarₖ₊₁|√τₖ₊₁
-    rNorm = abs(ζbarₖ₊₁) * √τₖ₊₁
+    rNorm = abs(ζbarₖ₊₁) * √abs(τₖ₊₁)
     history && push!(rNorms, rNorm)
 
     # Update directions for x.

--- a/test/test_bicgstab.jl
+++ b/test/test_bicgstab.jl
@@ -1,7 +1,7 @@
 @testset "bicgstab" begin
   bicgstab_tol = 1.0e-6
 
-    for FC in (Float64,)
+    for FC in (Float64, ComplexF64)
     @testset "Data Type: $FC" begin
 
       # Symmetric and positive definite system.

--- a/test/test_gmres.jl
+++ b/test/test_gmres.jl
@@ -1,7 +1,7 @@
 @testset "gmres" begin
   gmres_tol = 1.0e-6
 
-  for FC in (Float64,)
+  for FC in (Float64, ComplexF64)
     @testset "Data Type: $FC" begin
 
       # Symmetric and positive definite system.

--- a/test/test_qmr.jl
+++ b/test/test_qmr.jl
@@ -1,7 +1,7 @@
 @testset "qmr" begin
   qmr_tol = 1.0e-6
 
-  for FC in (Float64,)
+  for FC in (Float64, ComplexF64)
     @testset "Data Type: $FC" begin
 
       # Symmetric and positive definite system.

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -328,7 +328,7 @@ function small_sqd(transpose :: Bool=false; FC=Float64)
   return A, b, c, M, N
 end
 
-# FCest restart feature with linear systems of size n³.
+# Test restart feature with linear systems of size n³.
 function restart(n :: Int=32; FC=Float64)
   A = get_div_grad(n, n, n)
   b = A * ones(n^3)

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -103,7 +103,7 @@ end
 # Large-scale unsymmetric systems generated with Kronecker products.
 function kron_unsymmetric(n :: Int=64; FC=Float64)
   N = n^3
-  A = spdiagm(-1 => fill(-1.0, n - 1), 0 => fill(3.0, n), 1 => fill(-2.0, n - 1))
+  A = spdiagm(-1 => fill(-one(FC), n - 1), 0 => fill(FC(3.0), n), 1 => fill(FC(-2.0), n - 1))
   Id = eye(n)
   A = kron(A, Id) + kron(Id, A)
   A = kron(A, Id) + kron(Id, A)
@@ -115,16 +115,16 @@ end
 # Symmetric, indefinite and almost singular systems.
 function almost_singular(n :: Int=16; FC=Float64)
   A = get_div_grad(n, n, n)
-  A = A - 5 * I
-  b = A * ones(n^3)
+  A = FC.(A) - 5 * I
+  b = A * ones(FC, n^3)
   return A, b
 end
 
 # Symmetric, singular and consistent systems.
 function singular_consistent(n :: Int=10; FC=Float64)
-  A = [1.0*i*j for i=1:n, j=1:n] + 5 * eye(n)
-  A[:,1] .= A[:,2] .= A[2,:] .= A[1,:] .= 1.0
-  b = A * ones(n)
+  A = [FC(i*j) for i=1:n, j=1:n] + 5 * eye(n)
+  A[:,1] .= A[:,2] .= A[2,:] .= A[1,:] .= one(FC)
+  b = A * ones(FC, n)
   return A, b
 end
 
@@ -155,7 +155,7 @@ end
 # Underdetermined consistent adjoint systems.
 function underdetermined_adjoint(n :: Int=100, m :: Int=200; FC=Float64)
   n < m || error("Square or overdetermined system!")
-  A = [i == j ? 10.0 : i < j ? 1.0 : -1.0 for i=1:n, j=1:m]
+  A = [i == j ? FC(10.0) : i < j ? one(FC) : -one(FC) for i=1:n, j=1:m]
   b = A * [1:m;]
   c = A' * [-n:-1;]
   return A, b, c
@@ -163,7 +163,7 @@ end
 
 # Square consistent adjoint systems.
 function square_adjoint(n :: Int=100; FC=Float64)
-  A = [i == j ? 10.0 : i < j ? 1.0 : -1.0 for i=1:n, j=1:n]
+  A = [i == j ? FC(10.0) : i < j ? one(FC) : -one(FC) for i=1:n, j=1:n]
   b = A * [1:n;]
   c = A' * [-n:-1;]
   return A, b, c
@@ -171,16 +171,16 @@ end
 
 # Adjoint systems with Ax = b underdetermined consistent and Aᵀt = c overdetermined insconsistent.
 function rectangular_adjoint(n :: Int=10, m :: Int=25; FC=Float64)
-  Aᵀ, c = over_inconsistent(m, n)
+  Aᵀ, c = over_inconsistent(m, n; FC=FC)
   A = adjoint(Aᵀ)
-  b = A * ones(m)
+  b = A * ones(FC, m)
   return A, b, c
 end
 
 # Overdetermined consistent adjoint systems.
 function overdetermined_adjoint(n :: Int=200, m :: Int=100; FC=Float64)
   n > m || error("Underdetermined or square system!")
-  A = [i == j ? 10.0 : i < j ? 1.0 : -1.0 for i=1:n, j=1:m]
+  A = [i == j ? FC(10.0) : i < j ? one(FC) : -one(FC) for i=1:n, j=1:m]
   b = A * [1:m;]
   c = A' * [-n:-1;]
   return A, b, c
@@ -244,18 +244,18 @@ end
 
 # Square and preconditioned problems.
 function square_preconditioned(n :: Int=10; FC=Float64)
-  A   = ones(n, n) + (n-1) * eye(n)
-  b   = 10.0 * [1:n;]
-  M⁻¹ = 1/n * eye(n)
+  A   = ones(FC, n, n) + (n-1) * eye(n)
+  b   = FC(10.0) * [1:n;]
+  M⁻¹ = FC(1/n) * eye(n)
   return A, b, M⁻¹
 end
 
 # Square problems with two preconditioners.
 function two_preconditioners(n :: Int=10, m :: Int=20; FC=Float64)
-  A   = ones(n, n) + (n-1) * eye(n)
-  b   = ones(n)
-  M⁻¹ = 1/√n * eye(n)
-  N⁻¹ = 1/√m * eye(n)
+  A   = ones(FC, n, n) + (n-1) * eye(n)
+  b   = ones(FC, n)
+  M⁻¹ = FC(1/√n) * eye(n)
+  N⁻¹ = FC(1/√m) * eye(n)
   return A, b, M⁻¹, N⁻¹
 end
 
@@ -268,8 +268,8 @@ end
 
 # Regularized problems.
 function regularization(n :: Int=5; FC=Float64)
-  A = [2^(i/j)*j + (-1)^(i-j) * n*(i-1) for i = 1:n, j = 1:n]
-  b = ones(n)
+  A = FC[2^(i/j)*j + (-1)^(i-j) * n*(i-1) for i = 1:n, j = 1:n]
+  b = ones(FC, n)
   λ = 4.0
   return A, b, λ
 end
@@ -328,7 +328,7 @@ function small_sqd(transpose :: Bool=false; FC=Float64)
   return A, b, c, M, N
 end
 
-# Test restart feature with linear systems of size n³.
+# FCest restart feature with linear systems of size n³.
 function restart(n :: Int=32; FC=Float64)
   A = get_div_grad(n, n, n)
   b = A * ones(n^3)


### PR DESCRIPTION
This PR adds complex support for the following solvers:
* `qmr`
* `gmres`
* `bicgstab`

The intent is to show what it would take to start to address #103 , namely, the following for the remaining solvers:

* Separating the type of the history `T` (as in `SimpleStats{T}`) from the type parameter of the eltype the solver expects. This involves adding an additional solver type parameter
* Minor adjustments to the solver to respect solving over complex matrices.

As part of this PR, the type restrictions in `krylov_utils.jl` were relaxed, and meaningful tests for complex matrices were added.