### PR TITLE
Add niterations, Aprod, Atprod and Bprod functions

### DIFF
--- a/src/bicgstab.jl
+++ b/src/bicgstab.jl
@@ -99,6 +99,7 @@ function bicgstab!(solver :: BicgstabSolver{T,S}, A, b :: AbstractVector{T}; c :
   rNorm = @knrm2(n, r)
   history && push!(rNorms, rNorm)
   if rNorm == 0
+    stats.niter = 0
     stats.solved, stats.inconsistent = true, false
     stats.status = "x = 0 is a zero-residual solution"
     return solver
@@ -113,6 +114,7 @@ function bicgstab!(solver :: BicgstabSolver{T,S}, A, b :: AbstractVector{T}; c :
 
   next_ρ = @kdot(n, r, c)  # ρ₁ = ⟨r₀,r̅₀⟩
   if next_ρ == 0
+    stats.niter = 0
     stats.solved, stats.inconsistent = false, false
     stats.status = "Breakdown bᵀc = 0"
     return solver
@@ -163,6 +165,7 @@ function bicgstab!(solver :: BicgstabSolver{T,S}, A, b :: AbstractVector{T}; c :
   status = tired ? "maximum number of iterations exceeded" : (breakdown ? "breakdown αₖ == 0" : "solution good enough given atol and rtol")
 
   # Update stats
+  stats.niter = iter
   stats.solved = solved
   stats.inconsistent = false
   stats.status = status

--- a/src/bilq.jl
+++ b/src/bilq.jl
@@ -72,6 +72,7 @@ function bilq!(solver :: BilqSolver{T,S}, A, b :: AbstractVector{T}; c :: Abstra
 
   history && push!(rNorms, bNorm)
   if bNorm == 0
+    stats.niter = 0
     stats.solved = true
     stats.inconsistent = false
     stats.status = "x = 0 is a zero-residual solution"
@@ -88,6 +89,7 @@ function bilq!(solver :: BilqSolver{T,S}, A, b :: AbstractVector{T}; c :: Abstra
   # Initialize the Lanczos biorthogonalization process.
   bᵗc = @kdot(n, b, c)  # ⟨b,c⟩
   if bᵗc == 0
+    stats.niter = 0
     stats.solved = false
     stats.inconsistent = false
     stats.status = "Breakdown bᵀc = 0"
@@ -271,6 +273,7 @@ function bilq!(solver :: BilqSolver{T,S}, A, b :: AbstractVector{T}; c :: Abstra
   solved_cg && (status = "solution xᶜ good enough given atol and rtol")
 
   # Update stats
+  stats.niter = iter
   stats.solved = solved_lq || solved_cg
   stats.inconsistent = false
   stats.status = status

--- a/src/bilqr.jl
+++ b/src/bilqr.jl
@@ -91,6 +91,7 @@ function bilqr!(solver :: BilqrSolver{T,S}, A, b :: AbstractVector{T}, c :: Abst
   # Initialize the Lanczos biorthogonalization process.
   bᵗc = @kdot(n, b, c)  # ⟨b,c⟩
   if bᵗc == 0
+    stats.niter = 0
     stats.solved_primal = false
     stats.solved_dual = false
     stats.status = "Breakdown bᵀc = 0"
@@ -374,6 +375,7 @@ function bilqr!(solver :: BilqrSolver{T,S}, A, b :: AbstractVector{T}, c :: Abst
   solved_cg_tol  && solved_qr_mach && (status = "Found a primal solution xᶜ good enough given atol and rtol and an approximate zero-residual dual solutions t")
 
   # Update stats
+  stats.niter = iter
   stats.status = status
   stats.solved_primal = solved_primal
   stats.solved_dual = solved_dual

--- a/src/cg.jl
+++ b/src/cg.jl
@@ -90,7 +90,8 @@ function cg!(solver :: CgSolver{T,S}, A, b :: AbstractVector{T};
   γ = @kdot(n, r, z)
   rNorm = sqrt(γ)
   history && push!(rNorms, rNorm)
-  if γ == 0 
+  if γ == 0
+    stats.niter = 0
     stats.solved, stats.inconsistent = true, false
     stats.status = "x = 0 is a zero-residual solution"
     return solver
@@ -175,6 +176,7 @@ function cg!(solver :: CgSolver{T,S}, A, b :: AbstractVector{T};
   restart && @kaxpy!(n, one(T), Δx, x)
 
   # Update stats
+  stats.niter = iter
   stats.solved = solved
   stats.inconsistent = inconsistent
   stats.status = status

--- a/src/cg_lanczos.jl
+++ b/src/cg_lanczos.jl
@@ -80,6 +80,7 @@ function cg_lanczos!(solver :: CgLanczosSolver{T,S}, A, b :: AbstractVector{T};
   rNorm = σ
   history && push!(rNorms, rNorm)
   if β == 0
+    stats.niter = 0
     stats.solved = true
     stats.Anorm = zero(T)
     stats.indefinite = false
@@ -157,6 +158,7 @@ function cg_lanczos!(solver :: CgLanczosSolver{T,S}, A, b :: AbstractVector{T};
   status = tired ? "maximum number of iterations exceeded" : (check_curvature & indefinite) ? "negative curvature" : "solution good enough given atol and rtol"
 
   # Update stats. TODO: Estimate Acond.
+  stats.niter = iter
   stats.solved = solved
   stats.Anorm = sqrt(Anorm2)
   stats.indefinite = indefinite
@@ -241,6 +243,7 @@ function cg_lanczos!(solver :: CgLanczosShiftSolver{T,S}, A, b :: AbstractVector
   indefinite .= false
 
   if β == 0
+    stats.niter = 0
     stats.solved = true
     stats.status = "x = 0 is a zero-residual solution"
     return solver
@@ -353,6 +356,7 @@ function cg_lanczos!(solver :: CgLanczosShiftSolver{T,S}, A, b :: AbstractVector
   status = tired ? "maximum number of iterations exceeded" : "solution good enough given atol and rtol"
 
   # Update stats. TODO: Estimate Anorm and Acond.
+  stats.niter = iter
   stats.solved = solved
   stats.status = status
   return solver

--- a/src/cgls.jl
+++ b/src/cgls.jl
@@ -97,6 +97,7 @@ function cgls!(solver :: CglsSolver{T,S}, A, b :: AbstractVector{T};
   r .= b
   bNorm = @knrm2(m, r)   # Marginally faster than norm(b)
   if bNorm == 0
+    stats.niter = 0
     stats.solved, stats.inconsistent = true, false
     stats.status = "x = 0 is a zero-residual solution"
     history && push!(rNorms, zero(T))
@@ -160,6 +161,7 @@ function cgls!(solver :: CglsSolver{T,S}, A, b :: AbstractVector{T};
   status = on_boundary ? "on trust-region boundary" : (tired ? "maximum number of iterations exceeded" : "solution good enough given atol and rtol")
 
   # Update stats
+  stats.niter = iter
   stats.solved = solved
   stats.inconsistent = false
   stats.status = status

--- a/src/cgne.jl
+++ b/src/cgne.jl
@@ -108,6 +108,7 @@ function cgne!(solver :: CgneSolver{T,S}, A, b :: AbstractVector{T};
   rNorm = @knrm2(m, r)   # Marginally faster than norm(r)
   history && push!(rNorms, rNorm)
   if rNorm == 0
+    stats.niter = 0
     stats.solved, stats.inconsistent = true, false
     stats.status = "x = 0 is a zero-residual solution"
     return solver
@@ -167,6 +168,7 @@ function cgne!(solver :: CgneSolver{T,S}, A, b :: AbstractVector{T};
   status = tired ? "maximum number of iterations exceeded" : (inconsistent ? "system probably inconsistent" : "solution good enough given atol and rtol")
 
   # Update stats
+  stats.niter = iter
   stats.solved = solved
   stats.inconsistent = inconsistent
   stats.status = status

--- a/src/cgs.jl
+++ b/src/cgs.jl
@@ -90,6 +90,7 @@ function cgs!(solver :: CgsSolver{T,S}, A, b :: AbstractVector{T}; c :: Abstract
   rNorm = @knrm2(n, r)
   history && push!(rNorms, rNorm)
   if rNorm == 0
+    stats.niter = 0
     stats.solved, stats.inconsistent = true, false
     stats.status = "x = 0 is a zero-residual solution"
     return solver
@@ -98,6 +99,7 @@ function cgs!(solver :: CgsSolver{T,S}, A, b :: AbstractVector{T}; c :: Abstract
   # Compute ρ₀ = ⟨ r₀,̅r₀ ⟩
   ρ = @kdot(n, r, c)
   if ρ == 0
+    stats.niter = 0
     stats.solved, stats.inconsistent = false, false
     stats.status = "Breakdown bᵀc = 0"
     return solver
@@ -163,6 +165,7 @@ function cgs!(solver :: CgsSolver{T,S}, A, b :: AbstractVector{T}; c :: Abstract
   status = tired ? "maximum number of iterations exceeded" : (breakdown ? "breakdown αₖ == 0" : "solution good enough given atol and rtol")
 
   # Update stats
+  stats.niter = iter
   stats.solved = solved
   stats.inconsistent = false
   stats.status = status

--- a/src/cr.jl
+++ b/src/cr.jl
@@ -79,7 +79,8 @@ function cr!(solver :: CrSolver{T,S}, A, b :: AbstractVector{T};
   mul!(r, M, b)  # initial residual r = M * (b - Ax) = M * b
   mul!(Ar, A, r)
   ρ = @kdot(n, r, Ar)
-  if ρ == 0 
+  if ρ == 0
+    stats.niter = 0
     stats.solved, stats.inconsistent = true, false
     stats.status = "x = 0 is a zero-residual solution"
     history && push!(rNorms, ρ)
@@ -276,6 +277,7 @@ function cr!(solver :: CrSolver{T,S}, A, b :: AbstractVector{T};
   status = npcurv ? "nonpositive curvature" : (on_boundary ? "on trust-region boundary" : (tired ? "maximum number of iterations exceeded" : "solution good enough given atol and rtol"))
 
   # Update stats
+  stats.niter = iter
   stats.solved = solved
   stats.inconsistent = false
   stats.status = status

--- a/src/craig.jl
+++ b/src/craig.jl
@@ -141,6 +141,7 @@ function craig!(solver :: CraigSolver{T,S}, A, b :: AbstractVector{T};
   rNorm  = β₁
   history && push!(rNorms, rNorm)
   if β₁ == 0
+    stats.niter = 0
     stats.solved, stats.inconsistent = true, false
     stats.status = "x = 0 is a zero-residual solution"
     return solver
@@ -310,6 +311,7 @@ function craig!(solver :: CraigSolver{T,S}, A, b :: AbstractVector{T};
   inconsistent  && (status = "system may be inconsistent")
 
   # Update stats
+  stats.niter = iter
   stats.solved = solved
   stats.inconsistent = inconsistent
   stats.status = status

--- a/src/craigmr.jl
+++ b/src/craigmr.jl
@@ -138,6 +138,7 @@ function craigmr!(solver :: CraigmrSolver{T,S}, A, b :: AbstractVector{T};
   MisI || mul!(u, M, Mu)
   β = sqrt(@kdot(m, u, Mu))
   if β == 0
+    stats.niter = 0
     stats.solved, stats.inconsistent = true, false
     history && push!(rNorms, β)
     history && push!(ArNorms, zero(T))
@@ -164,6 +165,7 @@ function craigmr!(solver :: CraigmrSolver{T,S}, A, b :: AbstractVector{T};
 
   # Aᵀb = 0 so x = 0 is a minimum least-squares solution
   if α == 0
+    stats.niter = 0
     stats.solved, stats.inconsistent = true, false
     history && push!(rNorms, β)
     history && push!(ArNorms, zero(T))
@@ -310,6 +312,7 @@ function craigmr!(solver :: CraigmrSolver{T,S}, A, b :: AbstractVector{T};
   status = tired ? "maximum number of iterations exceeded" : (solved ? "found approximate minimum-norm solution" : "found approximate minimum least-squares solution")
 
   # Update stats
+  stats.niter = iter
   stats.solved = solved
   stats.inconsistent = inconsistent
   stats.status = status

--- a/src/crls.jl
+++ b/src/crls.jl
@@ -92,6 +92,7 @@ function crls!(solver :: CrlsSolver{T,S}, A, b :: AbstractVector{T};
   rNorm = bNorm  # + λ * ‖x0‖ if x0 ≠ 0 and λ > 0.
   history && push!(rNorms, rNorm)
   if bNorm == 0
+    stats.niter = 0
     stats.solved, stats.inconsistent = true, false
     stats.status = "x = 0 is a zero-residual solution"
     history && push!(ArNorms, zero(T))
@@ -185,6 +186,7 @@ function crls!(solver :: CrlsSolver{T,S}, A, b :: AbstractVector{T};
   status = psd ? "zero-curvature encountered" : (on_boundary ? "on trust-region boundary" : (tired ? "maximum number of iterations exceeded" : "solution good enough given atol and rtol"))
 
   # Update stats
+  stats.niter = iter
   stats.solved = solved
   stats.inconsistent = false
   stats.status = status

--- a/src/crmr.jl
+++ b/src/crmr.jl
@@ -107,6 +107,7 @@ function crmr!(solver :: CrmrSolver{T,S}, A, b :: AbstractVector{T};
   rNorm = bNorm  # + λ * ‖x0‖ if x0 ≠ 0 and λ > 0.
   history && push!(rNorms, rNorm)
   if bNorm == 0
+    stats.niter = 0
     stats.solved, stats.inconsistent = true, false
     stats.status = "x = 0 is a zero-residual solution"
     history && push!(ArNorms, zero(T))
@@ -165,6 +166,7 @@ function crmr!(solver :: CrmrSolver{T,S}, A, b :: AbstractVector{T};
   status = tired ? "maximum number of iterations exceeded" : (inconsistent ? "system probably inconsistent but least squares/norm solution found" : "solution good enough given atol and rtol")
 
   # Update stats
+  stats.niter = iter
   stats.solved = solved
   stats.inconsistent = inconsistent
   stats.status = status

--- a/src/diom.jl
+++ b/src/diom.jl
@@ -88,6 +88,7 @@ function diom!(solver :: DiomSolver{T,S}, A, b :: AbstractVector{T};
   rNorm = @knrm2(n, r₀) # β = ‖r₀‖₂
   history && push!(rNorms, rNorm)
   if rNorm == 0
+    stats.niter = 0
     stats.solved, stats.inconsistent = true, false
     stats.status = "x = 0 is a zero-residual solution"
     return solver
@@ -205,6 +206,7 @@ function diom!(solver :: DiomSolver{T,S}, A, b :: AbstractVector{T};
   restart && @kaxpy!(n, one(T), Δx, x)
 
   # Update stats
+  stats.niter = iter
   stats.solved = solved
   stats.inconsistent = false
   stats.status = status

--- a/src/dqgmres.jl
+++ b/src/dqgmres.jl
@@ -86,6 +86,7 @@ function dqgmres!(solver :: DqgmresSolver{T,S}, A, b :: AbstractVector{T};
   rNorm = @knrm2(n, r₀) # β = ‖r₀‖₂
   history && push!(rNorms, rNorm)
   if rNorm == 0
+    stats.niter = 0
     stats.solved, stats.inconsistent = true, false
     stats.status = "x = 0 is a zero-residual solution"
     return solver
@@ -211,6 +212,7 @@ function dqgmres!(solver :: DqgmresSolver{T,S}, A, b :: AbstractVector{T};
   restart && @kaxpy!(n, one(T), Δx, x)
 
   # Update stats
+  stats.niter = iter
   stats.solved = solved
   stats.inconsistent = false
   stats.status = status

--- a/src/fom.jl
+++ b/src/fom.jl
@@ -86,6 +86,7 @@ function fom!(solver :: FomSolver{T,S}, A, b :: AbstractVector{T};
   rNorm = β
   history && push!(rNorms, β)
   if β == 0
+    stats.niter = 0
     stats.solved, stats.inconsistent = true, false
     stats.status = "x = 0 is a zero-residual solution"
     return solver
@@ -219,6 +220,7 @@ function fom!(solver :: FomSolver{T,S}, A, b :: AbstractVector{T};
   restart && @kaxpy!(n, one(T), Δx, x)
 
   # Update stats
+  stats.niter = iter
   stats.solved = solved
   stats.inconsistent = !solved && breakdown
   stats.status = status

--- a/src/gmres.jl
+++ b/src/gmres.jl
@@ -86,6 +86,7 @@ function gmres!(solver :: GmresSolver{T,S}, A, b :: AbstractVector{T};
   rNorm = β
   history && push!(rNorms, β)
   if β == 0
+    stats.niter = 0
     stats.solved, stats.inconsistent = true, false
     stats.status = "x = 0 is a zero-residual solution"
     return solver
@@ -233,6 +234,7 @@ function gmres!(solver :: GmresSolver{T,S}, A, b :: AbstractVector{T};
   restart && @kaxpy!(n, one(T), Δx, x)
 
   # Update stats
+  stats.niter = iter
   stats.solved = solved
   stats.inconsistent = !solved && breakdown
   stats.status = status

--- a/src/gpmr.jl
+++ b/src/gpmr.jl
@@ -422,6 +422,7 @@ function gpmr!(solver :: GpmrSolver{T,S}, A, B, b :: AbstractVector{T}, c :: Abs
   solved    && (status = "solution good enough given atol and rtol")
 
   # Update stats
+  stats.niter = iter
   stats.solved = solved
   stats.inconsistent = !solved && breakdown
   stats.status = status

--- a/src/krylov_solvers.jl
+++ b/src/krylov_solvers.jl
@@ -1587,11 +1587,11 @@ for (KS, fun, nsol, nA, nAt) in [
   @eval begin
     @inline solve!(solver :: $KS, args...; kwargs...) = $(fun)(solver, args...; kwargs...)
     @inline statistics(solver :: $KS) = solver.stats
-    @inline niterations(solver :: $KS) = stats.niter
-    @inline Aprod(solver :: $KS) = $nA * stats.niter
-    @inline Atprod(solver :: $KS) = $nAt * stats.niter
+    @inline niterations(solver :: $KS) = solver.stats.niter
+    @inline Aprod(solver :: $KS) = $nA * solver.stats.niter
+    @inline Atprod(solver :: $KS) = $nAt * solver.stats.niter
     if $KS == GpmrSolver
-      @inline Bprod(solver :: $KS) = 1 * stats.niter
+      @inline Bprod(solver :: $KS) = solver.stats.niter
     end
     @inline nsolution(solver :: $KS) = $nsol
     ($nsol == 1) && @inline solution(solver :: $KS) = solver.x

--- a/src/krylov_stats.jl
+++ b/src/krylov_stats.jl
@@ -3,6 +3,7 @@ abstract type KrylovStats{T} end
 
 """
 Type for statistics returned by the majority of Krylov solvers, the attributes are:
+- niter
 - solved
 - inconsistent
 - residuals
@@ -11,6 +12,7 @@ Type for statistics returned by the majority of Krylov solvers, the attributes a
 - status
 """
 mutable struct SimpleStats{T} <: KrylovStats{T}
+  niter        :: Int
   solved       :: Bool
   inconsistent :: Bool
   residuals    :: Vector{T}
@@ -21,6 +23,7 @@ end
 
 """
 Type for statistics returned by CG-LANCZOS, the attributes are:
+- niter
 - solved
 - residuals
 - indefinite
@@ -29,6 +32,7 @@ Type for statistics returned by CG-LANCZOS, the attributes are:
 - status
 """
 mutable struct LanczosStats{T} <: KrylovStats{T}
+  niter      :: Int
   solved     :: Bool
   residuals  :: Vector{T}
   indefinite :: Bool
@@ -39,6 +43,7 @@ end
 
 """
 Type for statistics returned by CG-LANCZOS with shifts, the attributes are:
+- niter
 - solved
 - residuals
 - indefinite
@@ -47,6 +52,7 @@ Type for statistics returned by CG-LANCZOS with shifts, the attributes are:
 - status
 """
 mutable struct LanczosShiftStats{T} <: KrylovStats{T}
+  niter      :: Int
   solved     :: Bool
   residuals  :: Vector{Vector{T}}
   indefinite :: BitVector
@@ -63,6 +69,7 @@ end
 
 """
 Type for statistics returned by SYMMLQ, the attributes are:
+- niter
 - solved
 - residuals
 - residualscg
@@ -73,6 +80,7 @@ Type for statistics returned by SYMMLQ, the attributes are:
 - status
 """
 mutable struct SymmlqStats{T} <: KrylovStats{T}
+  niter       :: Int
   solved      :: Bool
   residuals   :: Vector{T}
   residualscg :: Vector{Union{T, Missing}}
@@ -85,6 +93,7 @@ end
 
 """
 Type for statistics returned by adjoint systems solvers BiLQR and TriLQR, the attributes are:
+- niter
 - solved_primal
 - solved_dual
 - residuals_primal
@@ -92,6 +101,7 @@ Type for statistics returned by adjoint systems solvers BiLQR and TriLQR, the at
 - status
 """
 mutable struct AdjointStats{T} <: KrylovStats{T}
+  niter            :: Int
   solved_primal    :: Bool
   solved_dual      :: Bool
   residuals_primal :: Vector{T}
@@ -101,6 +111,7 @@ end
 
 """
 Type for statistics returned by the LNLQ method, the attributes are:
+- niter
 - solved
 - residuals
 - error_with_bnd
@@ -109,6 +120,7 @@ Type for statistics returned by the LNLQ method, the attributes are:
 - status
 """
 mutable struct LNLQStats{T} <: KrylovStats{T}
+  niter          :: Int
   solved         :: Bool
   residuals      :: Vector{T}
   error_with_bnd :: Bool
@@ -119,6 +131,7 @@ end
 
 """
 Type for statistics returned by the LSLQ method, the attributes are:
+- niter
 - solved
 - inconsistent
 - residuals
@@ -130,6 +143,7 @@ Type for statistics returned by the LSLQ method, the attributes are:
 - status
 """
 mutable struct LSLQStats{T} <: KrylovStats{T}
+  niter          :: Int
   solved         :: Bool
   inconsistent   :: Bool
   residuals      :: Vector{T}

--- a/src/lnlq.jl
+++ b/src/lnlq.jl
@@ -134,6 +134,7 @@ function lnlq!(solver :: LnlqSolver{T,S}, A, b :: AbstractVector{T};
 
   bNorm = @knrm2(m, b)
   if bNorm == 0
+    stats.niter = 0
     stats.solved = true
     stats.error_with_bnd = false
     history && push!(rNorms, bNorm)
@@ -463,6 +464,7 @@ function lnlq!(solver :: LnlqSolver{T,S}, A, b :: AbstractVector{T};
   solved_cg && (status = "solutions (xᶜ, yᶜ) good enough for the tolerances given")
 
   # Update stats
+  stats.niter = iter
   stats.solved = solved_lq || solved_cg
   stats.error_with_bnd = complex_error_bnd
   stats.status = status

--- a/src/lslq.jl
+++ b/src/lslq.jl
@@ -186,6 +186,7 @@ function lslq!(solver :: LslqSolver{T,S}, A, b :: AbstractVector{T};
   MisI || mul!(u, M, Mu)
   β₁ = sqrt(@kdot(m, u, Mu))
   if β₁ == 0
+    stats.niter = 0
     stats.solved, stats.inconsistent = true, false
     stats.error_with_bnd = false
     history && push!(rNorms, zero(T))
@@ -204,6 +205,7 @@ function lslq!(solver :: LslqSolver{T,S}, A, b :: AbstractVector{T};
 
   # Aᵀb = 0 so x = 0 is a minimum least-squares solution
   if α == 0
+    stats.niter = 0
     stats.solved, stats.inconsistent = true, false
     stats.error_with_bnd = false
     history && push!(rNorms, β₁)
@@ -434,6 +436,7 @@ function lslq!(solver :: LslqSolver{T,S}, A, b :: AbstractVector{T};
   fwd_err_ubnd  && (status = "forward error upper bound small enough")
 
   # Update stats
+  stats.niter = iter
   stats.solved = solved
   stats.inconsistent = !zero_resid
   stats.error_with_bnd = complex_error_bnd

--- a/src/lsmr.jl
+++ b/src/lsmr.jl
@@ -148,6 +148,7 @@ function lsmr!(solver :: LsmrSolver{T,S}, A, b :: AbstractVector{T};
   MisI || mul!(u, M, Mu)
   β₁ = sqrt(@kdot(m, u, Mu))
   if β₁ == 0
+    stats.niter = 0
     stats.solved, stats.inconsistent = true, false
     stats.status = "x = 0 is a zero-residual solution"
     history && push!(rNorms, zero(T))
@@ -204,6 +205,7 @@ function lsmr!(solver :: LsmrSolver{T,S}, A, b :: AbstractVector{T};
 
   # Aᵀb = 0 so x = 0 is a minimum least-squares solution
   if α == 0
+    stats.niter = 0
     stats.solved, stats.inconsistent = true, false
     stats.status = "x = 0 is a minimum least-squares solution"
     return solver
@@ -358,6 +360,7 @@ function lsmr!(solver :: LsmrSolver{T,S}, A, b :: AbstractVector{T};
   user_requested_exit && (status = "user-requested exit")
 
   # Update stats
+  stats.niter = iter
   stats.solved = solved
   stats.inconsistent = !zero_resid
   stats.status = status

--- a/src/lsqr.jl
+++ b/src/lsqr.jl
@@ -138,6 +138,7 @@ function lsqr!(solver :: LsqrSolver{T,S}, A, b :: AbstractVector{T};
   MisI || mul!(u, M, Mu)
   β₁ = sqrt(@kdot(m, u, Mu))
   if β₁ == 0
+    stats.niter = 0
     stats.solved, stats.inconsistent = true, false
     stats.status = "x = 0 is a zero-residual solution"
     history && push!(rNorms, zero(T))
@@ -182,6 +183,7 @@ function lsqr!(solver :: LsqrSolver{T,S}, A, b :: AbstractVector{T};
   history && push!(ArNorms, ArNorm)
   # Aᵀb = 0 so x = 0 is a minimum least-squares solution
   if α == 0
+    stats.niter = 0
     stats.solved, stats.inconsistent = true, false
     stats.status = "x = 0 is a minimum least-squares solution"
     return solver
@@ -341,6 +343,7 @@ function lsqr!(solver :: LsqrSolver{T,S}, A, b :: AbstractVector{T};
   on_boundary   && (status = "on trust-region boundary")
 
   # Update stats
+  stats.niter = iter
   stats.solved = solved
   stats.inconsistent = !zero_resid
   stats.status = status

--- a/src/minres.jl
+++ b/src/minres.jl
@@ -117,6 +117,7 @@ function minres!(solver :: MinresSolver{T,S}, A, b :: AbstractVector{T};
   β₁ = @kdot(m, r1, v)
   β₁ < 0 && error("Preconditioner is not positive definite")
   if β₁ == 0
+    stats.niter = 0
     stats.solved, stats.inconsistent = true, false
     stats.status = "x = 0 is a zero-residual solution"
     history && push!(rNorms, β₁)
@@ -264,6 +265,7 @@ function minres!(solver :: MinresSolver{T,S}, A, b :: AbstractVector{T};
 
     if iter == 1 && β / β₁ ≤ 10 * ϵM
       # Aᵀb = 0 so x = 0 is a minimum least-squares solution
+      stats.niter = 0
       stats.solved, stats.inconsistent = true, true
       stats.status = "x is a minimum least-squares solution"
       return solver
@@ -303,6 +305,7 @@ function minres!(solver :: MinresSolver{T,S}, A, b :: AbstractVector{T};
   restart && @kaxpy!(n, one(T), Δx, x)
 
   # Update stats
+  stats.niter = iter
   stats.solved = solved
   stats.inconsistent = !zero_resid
   stats.status = status

--- a/src/minres_qlp.jl
+++ b/src/minres_qlp.jl
@@ -99,6 +99,7 @@ function minres_qlp!(solver :: MinresQlpSolver{T,S}, A, b :: AbstractVector{T};
   rNorm = βₖ
   history && push!(rNorms, rNorm)
   if rNorm == 0
+    stats.niter = 0
     stats.solved, stats.inconsistent = true, false
     stats.status = "x = 0 is a zero-residual solution"
     return solver
@@ -344,6 +345,7 @@ function minres_qlp!(solver :: MinresQlpSolver{T,S}, A, b :: AbstractVector{T};
   restart && @kaxpy!(n, one(T), Δx, x)
 
  # Update stats
+  stats.niter = iter
   stats.solved = solved
   stats.inconsistent = inconsistent
   stats.status = status

--- a/src/qmr.jl
+++ b/src/qmr.jl
@@ -78,6 +78,7 @@ function qmr!(solver :: QmrSolver{T,S}, A, b :: AbstractVector{T}; c :: Abstract
   rNorm = @knrm2(n, b)  # ‖r₀‖
   history && push!(rNorms, rNorm)
   if rNorm == 0
+    stats.niter = 0
     stats.solved = true
     stats.inconsistent = false
     stats.status = "x = 0 is a zero-residual solution"
@@ -94,6 +95,7 @@ function qmr!(solver :: QmrSolver{T,S}, A, b :: AbstractVector{T}; c :: Abstract
   # Initialize the Lanczos biorthogonalization process.
   bᵗc = @kdot(n, b, c)  # ⟨b,c⟩
   if bᵗc == 0
+    stats.niter = 0
     stats.solved = false
     stats.inconsistent = false
     stats.status = "Breakdown bᵀc = 0"
@@ -263,6 +265,7 @@ function qmr!(solver :: QmrSolver{T,S}, A, b :: AbstractVector{T}; c :: Abstract
   solved    && (status = "solution good enough given atol and rtol")
 
   # Update stats
+  stats.niter = iter
   stats.solved = solved
   stats.inconsistent = false
   stats.status = status

--- a/src/symmlq.jl
+++ b/src/symmlq.jl
@@ -99,6 +99,7 @@ function symmlq!(solver :: SymmlqSolver{T,S}, A, b :: AbstractVector{T};
   MisI || mul!(vold, M, Mvold)
   β₁ = @kdot(m, vold, Mvold)
   if β₁ == 0
+    stats.niter = 0
     stats.solved = true
     stats.Anorm = T(NaN)
     stats.Acond = T(NaN)
@@ -357,6 +358,7 @@ function symmlq!(solver :: SymmlqSolver{T,S}, A, b :: AbstractVector{T};
   restart && @kaxpy!(n, one(T), Δx, x)
 
   # Update stats
+  stats.niter = iter
   stats.solved = solved
   stats.Anorm = ANorm
   stats.Acond = Acond

--- a/src/tricg.jl
+++ b/src/tricg.jl
@@ -350,6 +350,7 @@ function tricg!(solver :: TricgSolver{T,S}, A, b :: AbstractVector{T}, c :: Abst
   restart && @kaxpy!(n, one(T), Δy, yₖ)
 
   # Update stats
+  stats.niter = iter
   stats.solved = solved
   stats.inconsistent = false
   stats.status = status

--- a/src/trilqr.jl
+++ b/src/trilqr.jl
@@ -357,6 +357,7 @@ function trilqr!(solver :: TrilqrSolver{T,S}, A, b :: AbstractVector{T}, c :: Ab
   solved_cg_tol  && solved_qr_mach && (status = "Found a primal solution xᶜ good enough given atol and rtol and an approximate zero-residual dual solutions t")
 
   # Update stats
+  stats.niter = iter
   stats.status = status
   stats.solved_primal = solved_primal
   stats.solved_dual = solved_dual

--- a/src/trimr.jl
+++ b/src/trimr.jl
@@ -454,6 +454,7 @@ function trimr!(solver :: TrimrSolver{T,S}, A, b :: AbstractVector{T}, c :: Abst
   restart && @kaxpy!(n, one(T), Δy, yₖ)
 
   # Update stats
+  stats.niter = iter
   stats.solved = solved
   stats.inconsistent = false
   stats.status = status

--- a/src/usymlq.jl
+++ b/src/usymlq.jl
@@ -84,6 +84,7 @@ function usymlq!(solver :: UsymlqSolver{T,S}, A, b :: AbstractVector{T}, c :: Ab
   bNorm = @knrm2(m, b)
   history && push!(rNorms, bNorm)
   if bNorm == 0
+    stats.niter = 0
     stats.solved = true
     stats.inconsistent = false
     stats.status = "x = 0 is a zero-residual solution"
@@ -266,6 +267,7 @@ function usymlq!(solver :: UsymlqSolver{T,S}, A, b :: AbstractVector{T}, c :: Ab
   solved_cg && (status = "solution xᶜ good enough given atol and rtol")
 
   # Update stats
+  stats.niter = iter
   stats.solved = solved_lq || solved_cg
   stats.inconsistent = false
   stats.status = status

--- a/src/usymqr.jl
+++ b/src/usymqr.jl
@@ -81,6 +81,7 @@ function usymqr!(solver :: UsymqrSolver{T,S}, A, b :: AbstractVector{T}, c :: Ab
   rNorm = @knrm2(m, b)
   history && push!(rNorms, rNorm)
   if rNorm == 0
+    stats.niter = 0
     stats.solved = true
     stats.inconsistent = false
     stats.status = "x = 0 is a zero-residual solution"
@@ -254,6 +255,7 @@ function usymqr!(solver :: UsymqrSolver{T,S}, A, b :: AbstractVector{T}, c :: Ab
   status = tired ? "maximum number of iterations exceeded" : "solution good enough given atol and rtol"
 
   # Update stats
+  stats.niter = iter
   stats.solved = solved
   stats.inconsistent = inconsistent
   stats.status = status

--- a/test/test_solvers.jl
+++ b/test/test_solvers.jl
@@ -51,96 +51,160 @@
     c  = 3 * c
 
     solver = solve!(cg_solver, A, b)
+    niter = niterations(solver)
+    @test niter > 0
+    @test Aprod(solver) == niter
+    @test Atprod(solver) == 0
     @test statistics(solver) === solver.stats
     @test solution(solver, 1) === solver.x
     @test nsolution(solver) == 1
     @test issolved(solver)
 
     solver = solve!(symmlq_solver, A, b)
+    niter = niterations(solver)
+    @test niter > 0
+    @test Aprod(solver) == niter
+    @test Atprod(solver) == 0
     @test statistics(solver) === solver.stats
     @test solution(solver, 1) === solver.x
     @test nsolution(solver) == 1
     @test issolved(solver)
 
     solver = solve!(minres_solver, A, b)
+    niter = niterations(solver)
+    @test niter > 0
+    @test Aprod(solver) == niter
+    @test Atprod(solver) == 0
     @test statistics(solver) === solver.stats
     @test solution(solver, 1) === solver.x
     @test nsolution(solver) == 1
     @test issolved(solver)
 
     solver = solve!(cg_lanczos_solver, A, b)
+    niter = niterations(solver)
+    @test niter > 0
+    @test Aprod(solver) == niter
+    @test Atprod(solver) == 0
     @test statistics(solver) === solver.stats
     @test solution(solver, 1) === solver.x
     @test nsolution(solver) == 1
     @test issolved(solver)
 
     solver = solve!(cg_lanczos_shift_solver, A, b, shifts)
+    niter = niterations(solver)
+    @test niter > 0
+    @test Aprod(solver) == niter
+    @test Atprod(solver) == 0
     @test statistics(solver) === solver.stats
     @test solution(solver, 1) === solver.x
     @test nsolution(solver) == 1
     @test issolved(solver)
 
     solver = solve!(diom_solver, A, b)
+    niter = niterations(solver)
+    @test niter > 0
+    @test Aprod(solver) == niter
+    @test Atprod(solver) == 0
     @test statistics(solver) === solver.stats
     @test solution(solver, 1) === solver.x
     @test nsolution(solver) == 1
     @test issolved(solver)
 
     solver = solve!(fom_solver, A, b)
+    niter = niterations(solver)
+    @test niter > 0
+    @test Aprod(solver) == niter
+    @test Atprod(solver) == 0
     @test statistics(solver) === solver.stats
     @test solution(solver, 1) === solver.x
     @test nsolution(solver) == 1
     @test issolved(solver)
 
     solver = solve!(dqgmres_solver, A, b)
+    niter = niterations(solver)
+    @test niter > 0
+    @test Aprod(solver) == niter
+    @test Atprod(solver) == 0
     @test statistics(solver) === solver.stats
     @test solution(solver, 1) === solver.x
     @test nsolution(solver) == 1
     @test issolved(solver)
 
     solver = solve!(gmres_solver, A, b)
+    niter = niterations(solver)
+    @test niter > 0
+    @test Aprod(solver) == niter
+    @test Atprod(solver) == 0
     @test statistics(solver) === solver.stats
     @test solution(solver, 1) === solver.x
     @test nsolution(solver) == 1
     @test issolved(solver)
 
     solver = solve!(cr_solver, A, b)
+    niter = niterations(solver)
+    @test niter > 0
+    @test Aprod(solver) == niter
+    @test Atprod(solver) == 0
     @test statistics(solver) === solver.stats
     @test solution(solver, 1) === solver.x
     @test nsolution(solver) == 1
     @test issolved(solver)
 
     solver = solve!(crmr_solver, Au, c)
+    niter = niterations(solver)
+    @test niter > 0
+    @test Aprod(solver) == niter
+    @test Atprod(solver) == niter
     @test statistics(solver) === solver.stats
     @test solution(solver, 1) === solver.x
     @test nsolution(solver) == 1
     @test issolved(solver)
 
     solver = solve!(cgs_solver, A, b)
+    niter = niterations(solver)
+    @test niter > 0
+    @test Aprod(solver) == 2 * niter
+    @test Atprod(solver) == 0
     @test statistics(solver) === solver.stats
     @test solution(solver, 1) === solver.x
     @test nsolution(solver) == 1
     @test issolved(solver)
 
     solver = solve!(bicgstab_solver, A, b)
+    niter = niterations(solver)
+    @test niter > 0
+    @test Aprod(solver) == 2 * niter
+    @test Atprod(solver) == 0
     @test statistics(solver) === solver.stats
     @test solution(solver, 1) === solver.x
     @test nsolution(solver) == 1
     @test issolved(solver)
 
     solver = solve!(craigmr_solver, Au, c)
+    niter = niterations(solver)
+    @test niter > 0
+    @test Aprod(solver) == niter
+    @test Atprod(solver) == niter
     @test statistics(solver) === solver.stats
     @test solution(solver, 1) === solver.x
     @test nsolution(solver) == 2
     @test issolved(solver)
 
     solver = solve!(cgne_solver, Au, c)
+    niter = niterations(solver)
+    @test niter > 0
+    @test Aprod(solver) == niter
+    @test Atprod(solver) == niter
     @test statistics(solver) === solver.stats
     @test solution(solver, 1) === solver.x
     @test nsolution(solver) == 1
     @test issolved(solver)
 
     solver = solve!(lnlq_solver, Au, c)
+    niter = niterations(solver)
+    @test niter > 0
+    @test Aprod(solver) == niter
+    @test Atprod(solver) == niter
     @test statistics(solver) === solver.stats
     @test solution(solver, 1) === solver.x
     @test solution(solver, 2) === solver.y
@@ -148,6 +212,10 @@
     @test issolved(solver)
 
     solver = solve!(craig_solver, Au, c)
+    niter = niterations(solver)
+    @test niter > 0
+    @test Aprod(solver) == niter
+    @test Atprod(solver) == niter
     @test statistics(solver) === solver.stats
     @test solution(solver, 1) === solver.x
     @test solution(solver, 2) === solver.y
@@ -155,42 +223,70 @@
     @test issolved(solver)
 
     solver = solve!(lslq_solver, Ao, b)
+    niter = niterations(solver)
+    @test niter > 0
+    @test Aprod(solver) == niter
+    @test Atprod(solver) == niter
     @test statistics(solver) === solver.stats
     @test solution(solver, 1) === solver.x
     @test nsolution(solver) == 1
     @test issolved(solver)
 
     solver = solve!(cgls_solver, Ao, b)
+    niter = niterations(solver)
+    @test niter > 0
+    @test Aprod(solver) == niter
+    @test Atprod(solver) == niter
     @test statistics(solver) === solver.stats
     @test solution(solver, 1) === solver.x
     @test nsolution(solver) == 1
     @test issolved(solver)
 
     solver = solve!(lsqr_solver, Ao, b)
+    niter = niterations(solver)
+    @test niter > 0
+    @test Aprod(solver) == niter
+    @test Atprod(solver) == niter
     @test statistics(solver) === solver.stats
     @test solution(solver, 1) === solver.x
     @test nsolution(solver) == 1
     @test issolved(solver)
 
     solver = solve!(crls_solver, Ao, b)
+    niter = niterations(solver)
+    @test niter > 0
+    @test Aprod(solver) == niter
+    @test Atprod(solver) == niter
     @test statistics(solver) === solver.stats
     @test solution(solver, 1) === solver.x
     @test nsolution(solver) == 1
     @test issolved(solver)
 
     solver = solve!(lsmr_solver, Ao, b)
+    niter = niterations(solver)
+    @test niter > 0
+    @test Aprod(solver) == niter
+    @test Atprod(solver) == niter
     @test statistics(solver) === solver.stats
     @test solution(solver, 1) === solver.x
     @test nsolution(solver) == 1
     @test issolved(solver)
 
     solver = solve!(usymqr_solver, Ao, b, c)
+    niter = niterations(solver)
+    @test niter > 0
+    @test Aprod(solver) == niter
+    @test Atprod(solver) == niter
     @test statistics(solver) === solver.stats
     @test solution(solver, 1) === solver.x
     @test nsolution(solver) == 1
     @test issolved(solver)
 
     solver = solve!(trilqr_solver, A, b, b)
+    niter = niterations(solver)
+    @test niter > 0
+    @test Aprod(solver) == niter
+    @test Atprod(solver) == niter
     @test statistics(solver) === solver.stats
     @test solution(solver, 1) === solver.x
     @test solution(solver, 2) === solver.y
@@ -200,12 +296,20 @@
     @test issolved(solver)
 
     solver = solve!(bilq_solver, A, b)
+    niter = niterations(solver)
+    @test niter > 0
+    @test Aprod(solver) == niter
+    @test Atprod(solver) == niter
     @test statistics(solver) === solver.stats
     @test solution(solver, 1) === solver.x
     @test nsolution(solver) == 1
     @test issolved(solver)
 
     solver = solve!(bilqr_solver, A, b, b)
+    niter = niterations(solver)
+    @test niter > 0
+    @test Aprod(solver) == niter
+    @test Atprod(solver) == niter
     @test statistics(solver) === solver.stats
     @test solution(solver, 1) === solver.x
     @test solution(solver, 2) === solver.y
@@ -215,24 +319,40 @@
     @test issolved(solver)
 
     solver = solve!(minres_qlp_solver, A, b)
+    niter = niterations(solver)
+    @test niter > 0
+    @test Aprod(solver) == niter
+    @test Atprod(solver) == 0
     @test statistics(solver) === solver.stats
     @test solution(solver, 1) === solver.x
     @test nsolution(solver) == 1
     @test issolved(solver)
 
     solver = solve!(qmr_solver, A, b)
+    niter = niterations(solver)
+    @test niter > 0
+    @test Aprod(solver) == niter
+    @test Atprod(solver) == niter
     @test statistics(solver) === solver.stats
     @test solution(solver, 1) === solver.x
     @test nsolution(solver) == 1
     @test issolved(solver)
 
     solver = solve!(usymlq_solver, Au, c, b)
+    niter = niterations(solver)
+    @test niter > 0
+    @test Aprod(solver) == niter
+    @test Atprod(solver) == niter
     @test statistics(solver) === solver.stats
     @test solution(solver, 1) === solver.x
     @test nsolution(solver) == 1
     @test issolved(solver)
 
     solver = solve!(tricg_solver, Au, c, b)
+    niter = niterations(solver)
+    @test niter > 0
+    @test Aprod(solver) == niter
+    @test Atprod(solver) == niter
     @test statistics(solver) === solver.stats
     @test solution(solver, 1) === solver.x
     @test solution(solver, 2) === solver.y
@@ -240,6 +360,10 @@
     @test issolved(solver)
 
     solver = solve!(trimr_solver, Au, c, b)
+    niter = niterations(solver)
+    @test niter > 0
+    @test Aprod(solver) == niter
+    @test Atprod(solver) == niter
     @test statistics(solver) === solver.stats
     @test solution(solver, 1) === solver.x
     @test solution(solver, 2) === solver.y
@@ -247,6 +371,11 @@
     @test issolved(solver)
 
     solver = solve!(gpmr_solver, Ao, Au, b, c)
+    niter = niterations(solver)
+    @test niter > 0
+    @test Aprod(solver) == niter
+    @test Atprod(solver) == 0
+    @test Bprod(solver) == niter
     @test statistics(solver) === solver.stats
     @test solution(solver, 1) === solver.x
     @test solution(solver, 2) === solver.y

--- a/test/test_stats.jl
+++ b/test/test_stats.jl
@@ -1,10 +1,11 @@
 @testset "stats" begin
-  stats = Krylov.SimpleStats(true, true, Float64[1.0], Float64[2.0], Float64[], "t")
+  stats = Krylov.SimpleStats(0, true, true, Float64[1.0], Float64[2.0], Float64[], "t")
   io = IOBuffer()
   show(io, stats)
   showed = String(take!(io))
   storage_type = typeof(stats)
   expected = """Simple stats
+  niter: 0
   solved: true
   inconsistent: true
   residuals: [ 1.0e+00 ]
@@ -16,12 +17,13 @@
   check_reset(stats)
   @test (VERSION < v"1.5") || (@allocated Krylov.reset!(stats)) == 0
 
-  stats = Krylov.LanczosStats(true, Float64[3.0], true, NaN, NaN, "t")
+  stats = Krylov.LanczosStats(0, true, Float64[3.0], true, NaN, NaN, "t")
   io = IOBuffer()
   show(io, stats)
   showed = String(take!(io))
   storage_type = typeof(stats)
   expected = """Lanczos stats
+  niter: 0
   solved: true
   residuals: [ 3.0e+00 ]
   indefinite: true
@@ -33,12 +35,13 @@
   check_reset(stats)
   @test (VERSION < v"1.5") || (@allocated Krylov.reset!(stats)) == 0
 
-  stats = Krylov.LanczosShiftStats(true, [Float64[0.9, 0.5], Float64[0.6, 0.4, 0.1]], BitVector([false, true]), NaN, NaN, "t")
+  stats = Krylov.LanczosShiftStats(0, true, [Float64[0.9, 0.5], Float64[0.6, 0.4, 0.1]], BitVector([false, true]), NaN, NaN, "t")
   io = IOBuffer()
   show(io, stats)
   showed = String(take!(io))
   storage_type = typeof(stats)
   expected = """LanczosShift stats
+  niter: 0
   solved: true
   residuals: [[0.9, 0.5], [0.6, 0.4, 0.1]]
   indefinite: Bool[0, 1]
@@ -49,12 +52,13 @@
   Krylov.reset!(stats)
   @test (VERSION < v"1.5") || (@allocated Krylov.reset!(stats)) == 0
 
-  stats = Krylov.SymmlqStats(true, Float64[4.0], Union{Float64,Missing}[5.0, missing], Float64[6.0], Union{Float64,Missing}[7.0, missing], NaN, NaN, "t")
+  stats = Krylov.SymmlqStats(0, true, Float64[4.0], Union{Float64,Missing}[5.0, missing], Float64[6.0], Union{Float64,Missing}[7.0, missing], NaN, NaN, "t")
   io = IOBuffer()
   show(io, stats)
   showed = String(take!(io))
   storage_type = typeof(stats)
   expected = """Symmlq stats
+  niter: 0
   solved: true
   residuals: [ 4.0e+00 ]
   residuals (cg): [ 5.0e+00  ✗✗✗✗ ]
@@ -68,12 +72,13 @@
   check_reset(stats)
   @test (VERSION < v"1.5") || (@allocated Krylov.reset!(stats)) == 0
 
-  stats = Krylov.AdjointStats(true, true, Float64[8.0], Float64[9.0], "t")
+  stats = Krylov.AdjointStats(0, true, true, Float64[8.0], Float64[9.0], "t")
   io = IOBuffer()
   show(io, stats)
   showed = String(take!(io))
   storage_type = typeof(stats)
   expected = """Adjoint stats
+  niter: 0
   solved primal: true
   solved dual: true
   residuals primal: [ 8.0e+00 ]
@@ -84,12 +89,13 @@
   check_reset(stats)
   @test (VERSION < v"1.5") || (@allocated Krylov.reset!(stats)) == 0
 
-  stats = Krylov.LNLQStats(true, Float64[10.0], false, Float64[11.0], Float64[12.0], "t")
+  stats = Krylov.LNLQStats(0, true, Float64[10.0], false, Float64[11.0], Float64[12.0], "t")
   io = IOBuffer()
   show(io, stats)
   showed = String(take!(io))
   storage_type = typeof(stats)
   expected = """LNLQ stats
+  niter: 0
   solved: true
   residuals: [ 1.0e+01 ]
   error with bnd: false
@@ -101,12 +107,13 @@
   check_reset(stats)
   @test (VERSION < v"1.5") || (@allocated Krylov.reset!(stats)) == 0
 
-  stats = Krylov.LSLQStats(true, false, Float64[13.0], Float64[14.0], Float64[15.0], false, Float64[16.0], Float64[17.0], "t")
+  stats = Krylov.LSLQStats(0, true, false, Float64[13.0], Float64[14.0], Float64[15.0], false, Float64[16.0], Float64[17.0], "t")
   io = IOBuffer()
   show(io, stats)
   showed = String(take!(io))
   storage_type = typeof(stats)
   expected = """LSLQ stats
+  niter: 0
   solved: true
   inconsistent: false
   residuals: [ 1.3e+01 ]


### PR DESCRIPTION
fix #476 

@dpo, @geoffroyleconte, @tmigot, @abelsiqueira, @AntoninKns 
I updated the `KrylovStats` to store the number of iterations.
We don't need anymore to set `history=true` and compute `niter = length(stats.residuals) - 1)`.
We can directly recover `niter` with `stats.niter`.

The number of iterations is not a relevant metric in practice (https://github.com/JuliaSmoothOptimizers/Krylov.jl/issues/13, https://github.com/JuliaSmoothOptimizers/Krylov.jl/pull/232) but thanks to the `KrylovSolvers`, we can easily determine the number of operator-vector products with `A` and `A'`. :smiley: 
You just need to call `Aprod(solver)` and `Atprod(solver)`.