### PR TITLE
Add a new macro @kdotr

### DIFF
--- a/src/krylov_utils.jl
+++ b/src/krylov_utils.jl
@@ -213,6 +213,9 @@ Create an AbstractVector of storage type `S` of length `n` only composed of one.
 @inline krylov_dot(n :: Integer, x :: Vector{T}, dx :: Integer, y :: Vector{T}, dy :: Integer) where T <: BLAS.BlasComplex = BLAS.dotc(n, x, dx, y, dy)
 @inline krylov_dot(n :: Integer, x :: AbstractVector{T}, dx :: Integer, y :: AbstractVector{T}, dy :: Integer) where T <: Number = dot(x, y)
 
+@inline krylov_dotr(n :: Integer, x :: AbstractVector{T}, dx :: Integer, y :: AbstractVector{T}, dy :: Integer) where T <: AbstractFloat = krylov_dot(n, x, dx, y, dy)
+@inline krylov_dotr(n :: Integer, x :: AbstractVector{Complex{T}}, dx :: Integer, y :: AbstractVector{Complex{T}}, dy :: Integer) where T <: AbstractFloat = real(krylov_dot(n, x, dx, y, dy))
+
 @inline krylov_norm2(n :: Integer, x :: Vector{T}, dx :: Integer) where T <: BLAS.BlasFloat = BLAS.nrm2(n, x, dx)
 @inline krylov_norm2(n :: Integer, x :: AbstractVector{T}, dx :: Integer) where T <: Number = norm(x)
 
@@ -237,6 +240,10 @@ Create an AbstractVector of storage type `S` of length `n` only composed of one.
 
 macro kdot(n, x, y)
   return esc(:(krylov_dot($n, $x, 1, $y, 1)))
+end
+
+macro kdotr(n, x, y)
+  return esc(:(krylov_dotr($n, $x, 1, $y, 1)))
 end
 
 macro knrm2(n, x)


### PR DESCRIPTION
The function `dot(x,y)` with complex vectors `x` and `y` returns a complex number but we often use it to compute the square of a norm ([1](https://github.com/JuliaSmoothOptimizers/Krylov.jl/pull/513/files#diff-1c53f5530b6a52bd5ac553b00751b0edec2a0247374486956b59a1b1de58a436R237),[2](https://github.com/JuliaSmoothOptimizers/Krylov.jl/pull/513/files#diff-1c53f5530b6a52bd5ac553b00751b0edec2a0247374486956b59a1b1de58a436R246)) or p'Ap with hermitian positive definite matrices `A` ([3](https://github.com/JuliaSmoothOptimizers/Krylov.jl/pull/490/files#diff-95df883ef1fb65ddd8cf36cf67c8360830ddc4236f149c591f604a50a55852d9R121)).
In these cases, the result of the dot product is a complex number with an imaginary part equals to 0.

For all methods, I added `real(dot(x,y))` when it was needed but It seems more relevant to add a macro **@kdotr**.
It will be easier to understand the code and we can use the multiple dispatch to avoid the call to the `real` function when real linear systems are solved. 