### PR TITLE
Update docstrings of LSLQ, LSQR, LSMR

### DIFF
--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -504,11 +504,10 @@ b = MatrixMarket.mmread(joinpath(path[1], "$(matrix.name[1])_b.mtx"))[:]
 (m, n) = size(A)
 @printf("System size: %d rows and %d columns\n", m, n)
 
-# Define a regularization parameter and a preconditioner.
+# Define a regularization parameter.
 λ = 1.0e-3
-λ > 0.0 && (N = I / λ)
 
-(x, stats) = lsqr(A, b, λ=λ, sqd=λ > 0, atol=0.0, btol=0.0, N=N)
+(x, stats) = lsqr(A, b, λ=λ, atol=0.0, btol=0.0)
 show(stats)
 resid = norm(A' * (A * x - b) + λ * x) / norm(b)
 @printf("LSQR: Relative residual: %8.1e\n", resid)
@@ -531,11 +530,10 @@ b = MatrixMarket.mmread(joinpath(path[1], "$(matrix.name[1])_b.mtx"))[:]
 (m, n) = size(A)
 @printf("System size: %d rows and %d columns\n", m, n)
 
-# Define a regularization parameter and a preconditioner.
+# Define a regularization parameter.
 λ = 1.0e-3
-λ > 0.0 && (N = I / λ)
 
-(x, stats) = lsmr(A, b, λ=λ, sqd=λ > 0, atol=0.0, btol=0.0, N=N)
+(x, stats) = lsmr(A, b, λ=λ, atol=0.0, btol=0.0)
 show(stats)
 resid = norm(A' * (A * x - b) + λ * x) / norm(b)
 @printf("LSMR: Relative residual: %8.1e\n", resid)

--- a/docs/src/factorization-free.md
+++ b/docs/src/factorization-free.md
@@ -13,7 +13,7 @@ Some methods only require `A * v` products, whereas other ones also require `A' 
 | DIOM, FOM, DQGMRES, GMRES              | BiLQ, QMR, BiLQR, USYMLQ, USYMQR, TriLQR |
 | CGS, BICGSTAB                          | TriCG, TriMR, USYMLQR                    |
 
-We strongly recommend [LinearOperators.jl](https://github.com/JuliaSmoothOptimizers/LinearOperators.jl) to model matrix-free operators, but other packages such as [LinearMaps.jl](https://github.com/Jutho/LinearMaps.jl), [DiffEqOperators.jl](https://github.com/SciML/DiffEqOperators.jl) or your own operator can be used as well.
+We strongly recommend [LinearOperators.jl](https://github.com/JuliaSmoothOptimizers/LinearOperators.jl) to model matrix-free operators, but other packages such as [LinearMaps.jl](https://github.com/JuliaLinearAlgebra/LinearMaps.jl), [DiffEqOperators.jl](https://github.com/SciML/DiffEqOperators.jl) or your own operator can be used as well.
 
 With `LinearOperators.jl`, operators are defined as
 

--- a/src/lsmr.jl
+++ b/src/lsmr.jl
@@ -27,8 +27,8 @@ export lsmr, lsmr!
 
 """
     (x, stats) = lsmr(A, b::AbstractVector{T};
-                      M=I, N=I, sqd::Bool=false,
-                      λ::T=zero(T), axtol::T=√eps(T), btol::T=√eps(T),
+                      M=I, N=I, sqd::Bool=false, λ::T=zero(T),
+                      axtol::T=√eps(T), btol::T=√eps(T),
                       atol::T=zero(T), rtol::T=zero(T),
                       etol::T=√eps(T), window::Int=5,
                       itmax::Int=0, conlim::T=1/√eps(T),
@@ -53,24 +53,23 @@ LSMR can be also used to find a null vector of a singular matrix A
 by solving the problem `min ‖Aᵀx - b‖` with any nonzero vector `b`.
 At a minimizer, the residual vector `r = b - Aᵀx` will satisfy `Ar = 0`.
 
-Preconditioners M and N may be provided in the form of linear operators and are
-assumed to be symmetric and positive definite. If `sqd` is set to `true`,
-we solve the symmetric and quasi-definite system
+If `λ > 0`, we solve the symmetric and quasi-definite system
 
-    [ E    A ] [ r ]   [ b ]
-    [ Aᵀ  -F ] [ x ] = [ 0 ],
+    [ E      A ] [ r ]   [ b ]
+    [ Aᵀ  -λ²F ] [ x ] = [ 0 ],
 
 where E and F are symmetric and positive definite.
+Preconditioners M = E⁻¹ ≻ 0 and N = F⁻¹ ≻ 0 may be provided in the form of linear operators.
+If `sqd=true`, `λ` is set to the common value `1`.
+
 The system above represents the optimality conditions of
 
-    minimize ‖b - Ax‖²_E⁻¹ + ‖x‖²_F.
+    minimize ‖b - Ax‖²_E⁻¹ + λ²‖x‖²_F.
 
 For a symmetric and positive definite matrix `K`, the K-norm of a vector `x` is `‖x‖²_K = xᵀKx`.
-LSMR is then equivalent to applying MINRES to `(AᵀE⁻¹A + F)x = AᵀE⁻¹b` with `r = E⁻¹(b - Ax)`.
-Preconditioners M = E⁻¹ ≻ 0 and N = F⁻¹ ≻ 0 may be provided in the form of linear operators.
+LSMR is then equivalent to applying MINRES to `(AᵀE⁻¹A + λ²F)x = AᵀE⁻¹b` with `r = E⁻¹(b - Ax)`.
 
-If `sqd` is set to `false` (the default), we solve the symmetric and
-indefinite system
+If `λ = 0`, we solve the symmetric and indefinite system
 
     [ E    A ] [ r ]   [ b ]
     [ Aᵀ   0 ] [ x ] = [ 0 ].
@@ -105,8 +104,8 @@ where `args` and `kwargs` are arguments and keyword arguments of [`lsmr`](@ref).
 See [`LsmrSolver`](@ref) for more details about the `solver`.
 """
 function lsmr!(solver :: LsmrSolver{T,S}, A, b :: AbstractVector{T};
-               M=I, N=I, sqd :: Bool=false,
-               λ :: T=zero(T), axtol :: T=√eps(T), btol :: T=√eps(T),
+               M=I, N=I, sqd :: Bool=false, λ :: T=zero(T),
+               axtol :: T=√eps(T), btol :: T=√eps(T),
                atol :: T=zero(T), rtol :: T=zero(T),
                etol :: T=√eps(T), itmax :: Int=0, conlim :: T=1/√eps(T),
                radius :: T=zero(T), verbose :: Int=0, history :: Bool=false,
@@ -115,6 +114,10 @@ function lsmr!(solver :: LsmrSolver{T,S}, A, b :: AbstractVector{T};
   m, n = size(A)
   length(b) == m || error("Inconsistent problem size")
   (verbose > 0) && @printf("LSMR: system of %d equations in %d variables\n", m, n)
+
+  # Check sqd and λ parameters
+  sqd && (λ ≠ 0) && error("sqd cannot be set to true if λ ≠ 0 !")
+  sqd && (λ = one(T))
 
   # Tests M = Iₙ and N = Iₘ
   MisI = (M === I)
@@ -137,8 +140,6 @@ function lsmr!(solver :: LsmrSolver{T,S}, A, b :: AbstractVector{T};
   u = MisI ? Mu : solver.u
   v = NisI ? Nv : solver.v
 
-  # If solving an SQD system, set regularization to 1.
-  sqd && (λ = one(T))
   ctol = conlim > 0 ? 1/conlim : zero(T)
   x .= zero(T)
 

--- a/src/lsqr.jl
+++ b/src/lsqr.jl
@@ -27,8 +27,8 @@ export lsqr, lsqr!
 
 """
     (x, stats) = lsqr(A, b::AbstractVector{T};
-                      M=I, N=I, sqd::Bool=false,
-                      λ::T=zero(T), axtol::T=√eps(T), btol::T=√eps(T),
+                      M=I, N=I, sqd::Bool=false, λ::T=zero(T),
+                      axtol::T=√eps(T), btol::T=√eps(T),
                       atol::T=zero(T), rtol::T=zero(T),
                       etol::T=√eps(T), window::Int=5,
                       itmax::Int=0, conlim::T=1/√eps(T),
@@ -48,24 +48,23 @@ LSQR is formally equivalent to applying CG to the normal equations
 LSQR produces monotonic residuals ‖r‖₂ but not optimality residuals ‖Aᵀr‖₂.
 It is formally equivalent to CGLS, though can be slightly more accurate.
 
-Preconditioners M and N may be provided in the form of linear operators and are
-assumed to be symmetric and positive definite. If `sqd` is set to `true`,
-we solve the symmetric and quasi-definite system
+If `λ > 0`, LSQR solves the symmetric and quasi-definite system
 
-    [ E    A ] [ r ]   [ b ]
-    [ Aᵀ  -F ] [ x ] = [ 0 ],
+    [ E      A ] [ r ]   [ b ]
+    [ Aᵀ  -λ²F ] [ x ] = [ 0 ],
 
 where E and F are symmetric and positive definite.
+Preconditioners M = E⁻¹ ≻ 0 and N = F⁻¹ ≻ 0 may be provided in the form of linear operators.
+If `sqd=true`, `λ` is set to the common value `1`.
+
 The system above represents the optimality conditions of
 
-    minimize ‖b - Ax‖²_E⁻¹ + ‖x‖²_F.
+    minimize ‖b - Ax‖²_E⁻¹ + λ²‖x‖²_F.
 
 For a symmetric and positive definite matrix `K`, the K-norm of a vector `x` is `‖x‖²_K = xᵀKx`.
-LSQR is then equivalent to applying CG to `(AᵀE⁻¹A + F)x = AᵀE⁻¹b` with `r = E⁻¹(b - Ax)`.
-Preconditioners M = E⁻¹ ≻ 0 and N = F⁻¹ ≻ 0 may be provided in the form of linear operators.
+LSQR is then equivalent to applying CG to `(AᵀE⁻¹A + λ²F)x = AᵀE⁻¹b` with `r = E⁻¹(b - Ax)`.
 
-If `sqd` is set to `false` (the default), we solve the symmetric and
-indefinite system
+If `λ = 0`, we solve the symmetric and indefinite system
 
     [ E    A ] [ r ]   [ b ]
     [ Aᵀ   0 ] [ x ] = [ 0 ].
@@ -95,8 +94,8 @@ where `args` and `kwargs` are arguments and keyword arguments of [`lsqr`](@ref).
 See [`LsqrSolver`](@ref) for more details about the `solver`.
 """
 function lsqr!(solver :: LsqrSolver{T,S}, A, b :: AbstractVector{T};
-               M=I, N=I, sqd :: Bool=false,
-               λ :: T=zero(T), axtol :: T=√eps(T), btol :: T=√eps(T),
+               M=I, N=I, sqd :: Bool=false, λ :: T=zero(T),
+               axtol :: T=√eps(T), btol :: T=√eps(T),
                atol :: T=zero(T), rtol :: T=zero(T),
                etol :: T=√eps(T), itmax :: Int=0, conlim :: T=1/√eps(T),
                radius :: T=zero(T), verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, S <: DenseVector{T}}
@@ -104,6 +103,10 @@ function lsqr!(solver :: LsqrSolver{T,S}, A, b :: AbstractVector{T};
   m, n = size(A)
   length(b) == m || error("Inconsistent problem size")
   (verbose > 0) && @printf("LSQR: system of %d equations in %d variables\n", m, n)
+
+  # Check sqd and λ parameters
+  sqd && (λ ≠ 0) && error("sqd cannot be set to true if λ ≠ 0 !")
+  sqd && (λ = one(T))
 
   # Tests M = Iₙ and N = Iₘ
   MisI = (M === I)
@@ -126,8 +129,6 @@ function lsqr!(solver :: LsqrSolver{T,S}, A, b :: AbstractVector{T};
   u = MisI ? Mu : solver.u
   v = NisI ? Nv : solver.v
 
-  # If solving an SQD system, set regularization to 1.
-  sqd && (λ = one(T))
   λ² = λ * λ
   ctol = conlim > 0 ? 1/conlim : zero(T)
   x .= zero(T)

--- a/test/test_lslq.jl
+++ b/test/test_lslq.jl
@@ -77,6 +77,12 @@
     resid = norm(A' * r - N * x_lq) / norm(b)
     @test(resid ≤ lslq_tol)
 
+    λ = 4.0
+    (x_lq, stats) = lslq(A, b, M=M⁻¹, N=N⁻¹, λ=λ, transfer_to_lsqr=transfer_to_lsqr)
+    r = M⁻¹ * (b - A * x_lq)
+    resid = norm(A' * r - λ^2 * N * x_lq) / norm(b)
+    @test(resid ≤ lslq_tol)
+
     # Test dimension of additional vectors
     for transpose ∈ (false, true)
       A, b, c, D = small_sp(transpose)

--- a/test/test_lsmr.jl
+++ b/test/test_lsmr.jl
@@ -72,6 +72,12 @@
   resid = norm(A' * r - N * x) / norm(b)
   @test(resid ≤ lsmr_tol)
 
+  λ = 4.0
+  (x, stats) = lsmr(A, b, M=M⁻¹, N=N⁻¹, λ=λ)
+  r = M⁻¹ * (b - A * x)
+  resid = norm(A' * r - λ^2 * N * x) / norm(b)
+  @test(resid ≤ lsmr_tol)
+
   # Test dimension of additional vectors
   for transpose ∈ (false, true)
     A, b, c, D = small_sp(transpose)

--- a/test/test_lsqr.jl
+++ b/test/test_lsqr.jl
@@ -72,6 +72,12 @@
   resid = norm(A' * r - N * x) / norm(b)
   @test(resid ≤ lsqr_tol)
 
+  λ = 4.0
+  (x, stats) = lsqr(A, b, M=M⁻¹, N=N⁻¹, λ=λ)
+  r = M⁻¹ * (b - A * x)
+  resid = norm(A' * r - λ^2 * N * x) / norm(b)
+  @test(resid ≤ lsqr_tol)
+
   # Test dimension of additional vectors
   for transpose ∈ (false, true)
     A, b, c, D = small_sp(transpose)


### PR DESCRIPTION
@geoffroyleconte 
The `sqd` parameter was only used to set `λ=1`.
I propose to use `λ` parameter directly.