### PR TITLE
[MINRES] Move restart option to MinresSolver

### DIFF
--- a/src/krylov_solvers.jl
+++ b/src/krylov_solvers.jl
@@ -65,8 +65,8 @@ mutable struct MinresSolver{T,FC,S} <: KrylovSolver{T,FC,S}
   y       :: S
   v       :: S
   err_vec :: Vector{T}
-  stats   :: SimpleStats{T}
   restart :: Bool
+  stats   :: SimpleStats{T}
 
   function MinresSolver(n, m, S; window :: Int=5)
     FC = eltype(S)
@@ -81,7 +81,7 @@ mutable struct MinresSolver{T,FC,S} <: KrylovSolver{T,FC,S}
     v  = S(undef, 0)
     err_vec = zeros(T, window)
     stats = SimpleStats(0, false, false, T[], T[], T[], "unknown")
-    solver = new{T,FC,S}(Δx, x, r1, r2, w1, w2, y, v, err_vec, stats, false)
+    solver = new{T,FC,S}(Δx, x, r1, r2, w1, w2, y, v, err_vec, false, stats)
     return solver
   end
 

--- a/src/krylov_solvers.jl
+++ b/src/krylov_solvers.jl
@@ -56,17 +56,17 @@ The outer constructors
 may be used in order to create these vectors.
 """
 mutable struct MinresSolver{T,FC,S} <: KrylovSolver{T,FC,S}
-  Δx      :: S
-  x       :: S
-  r1      :: S
-  r2      :: S
-  w1      :: S
-  w2      :: S
-  y       :: S
-  v       :: S
-  err_vec :: Vector{T}
-  restart :: Bool
-  stats   :: SimpleStats{T}
+  Δx         :: S
+  x          :: S
+  r1         :: S
+  r2         :: S
+  w1         :: S
+  w2         :: S
+  y          :: S
+  v          :: S
+  err_vec    :: Vector{T}
+  warm_start :: Bool
+  stats      :: SimpleStats{T}
 
   function MinresSolver(n, m, S; window :: Int=5)
     FC = eltype(S)
@@ -1672,13 +1672,14 @@ for (KS, fun, nsol, nA, nAt) in [
     end
     if $KS == MinresSolver
       function warm_start!(solver :: $KS, x0)
+        n = length(solver.x)
+        length(x0) == n || error("x0 should have size $n")
         if length(solver.Δx) == 0
           S = typeof(solver.x)
-          n = length(solver.x)
           allocate_if(true, solver, :Δx, S, n)
         end
         solver.Δx .= x0
-        solver.restart = true
+        solver.warm_start = true
       end
     end
     @inline nsolution(solver :: $KS) = $nsol

--- a/src/minres.jl
+++ b/src/minres.jl
@@ -92,7 +92,6 @@ function minres!(solver :: MinresSolver{T,FC,S}, A, b :: AbstractVector{FC};
 
   # Set up workspace.
   allocate_if(!MisI  , solver, :v , S, n)
-  allocate_if(restart, solver, :Δx, S, n)
   Δx, x, r1, r2, w1, w2, y = solver.Δx, solver.x, solver.r1, solver.r2, solver.w1, solver.w2, solver.y
   err_vec, stats = solver.err_vec, solver.stats
   rNorms, ArNorms, Aconds = stats.residuals, stats.Aresiduals, stats.Acond

--- a/src/minres.jl
+++ b/src/minres.jl
@@ -58,7 +58,7 @@ MINRES can be warm-started from an initial guess `x0` with the method
 
     (x, stats) =  minres(A, b, x0; kwargs...)
 
-where `kwargs` are the same keyword arguments as the first `minres` method presented above.
+where `kwargs` are the same keyword arguments as above.
 
 #### Reference
 

--- a/src/minres.jl
+++ b/src/minres.jl
@@ -70,7 +70,7 @@ function minres(A, b :: AbstractVector{FC}; window :: Int=5, kwargs...) where FC
   return (solver.x, solver.stats)
 end
 
-function minres(A, b :: AbstractVector{FC}, x0 :: AbstractVector{FC0}; window :: Int=5, kwargs...) where {FC <: FloatOrComplex, FC0 <: FloatOrComplex}
+function minres(A, b :: AbstractVector{FC}, x0 :: AbstractVector; window :: Int=5, kwargs...) where FC <: FloatOrComplex
   solver = MinresSolver(A, b, window=window)
   minres!(solver, A, b, x0; kwargs...)
   return (solver.x, solver.stats)
@@ -330,7 +330,7 @@ function minres!(solver :: MinresSolver{T,FC,S}, A, b :: AbstractVector{FC};
   return solver
 end
 
-function minres!(solver :: MinresSolver{T,FC,S}, A, b :: AbstractVector{FC}, x0::AbstractVector{FC0}; kwargs...) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: DenseVector{FC}, FC0 <: FloatOrComplex}
+function minres!(solver :: MinresSolver{T,FC,S}, A, b :: AbstractVector{FC}, x0::AbstractVector; kwargs...) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: DenseVector{FC}}
   warm_start!(solver, x0)
   return minres!(solver, A, b; kwargs...)
 end

--- a/src/minres.jl
+++ b/src/minres.jl
@@ -91,7 +91,6 @@ function minres!(solver :: MinresSolver{T,FC,S}, A, b :: AbstractVector{FC};
                  history :: Bool=false) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: DenseVector{FC}}
 
   n, m = size(A)
-  warm_start = solver.warm_start
   m == n || error("System must be square")
   length(b) == n || error("Inconsistent problem size")
   (verbose > 0) && @printf("MINRES: system of size %d\n", n)
@@ -106,6 +105,7 @@ function minres!(solver :: MinresSolver{T,FC,S}, A, b :: AbstractVector{FC};
   # Set up workspace.
   allocate_if(!MisI  , solver, :v , S, n)
   Δx, x, r1, r2, w1, w2, y = solver.Δx, solver.x, solver.r1, solver.r2, solver.w1, solver.w2, solver.y
+  warm_start = solver.warm_start
   err_vec, stats = solver.err_vec, solver.stats
   rNorms, ArNorms, Aconds = stats.residuals, stats.Aresiduals, stats.Acond
   reset!(stats)
@@ -330,8 +330,7 @@ function minres!(solver :: MinresSolver{T,FC,S}, A, b :: AbstractVector{FC};
   return solver
 end
 
-function minres!(solver :: MinresSolver{T,FC,S}, A, b :: AbstractVector{FC}, x0::AbstractVector{FC0};
-                 kwargs...) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: DenseVector{FC}, FC0 <: FloatOrComplex}
+function minres!(solver :: MinresSolver{T,FC,S}, A, b :: AbstractVector{FC}, x0::AbstractVector{FC0}; kwargs...) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: DenseVector{FC}, FC0 <: FloatOrComplex}
   warm_start!(solver, x0)
   return minres!(solver, A, b; kwargs...)
 end

--- a/test/test_minres.jl
+++ b/test/test_minres.jl
@@ -74,7 +74,11 @@
       solver = MinresSolver(A, b)
       minres!(solver, A, b, itmax=50)
       @test !solver.stats.solved
-      minres!(solver, A, b, restart=true)
+      @test solver.restart == false
+      warm_start!(solver, solver.x)
+      @test solver.restart == true
+      minres!(solver, A, b)
+      @test solver.restart == false
       r = b - A * solver.x
       resid = norm(r) / norm(b)
       @test(resid ≤ minres_tol)

--- a/test/test_minres.jl
+++ b/test/test_minres.jl
@@ -74,14 +74,16 @@
       solver = MinresSolver(A, b)
       minres!(solver, A, b, itmax=50)
       @test !solver.stats.solved
-      @test solver.restart == false
-      warm_start!(solver, solver.x)
-      @test solver.restart == true
-      minres!(solver, A, b)
-      @test solver.restart == false
-      r = b - A * solver.x
-      resid = norm(r) / norm(b)
-      @test(resid ≤ minres_tol)
+      @test solver.warm_start == false
+      (x, stats) = minres(A, b, solver.x)
+      r1 = b - A * x
+      minres!(solver, A, b, solver.x)
+      @test solver.warm_start == false
+      r2 = b - A * solver.x
+      resid1 = norm(r1) / norm(b)
+      resid2 = norm(r2) / norm(b)
+      @test(resid1 ≤ minres_tol)
+      @test(resid2 ≤ minres_tol)
       @test solver.stats.solved
     end
   end

--- a/test/test_solvers.jl
+++ b/test/test_solvers.jl
@@ -447,7 +447,7 @@ function test_solvers(FC)
   │           y│    Vector{$FC}│               64│
   │           v│    Vector{$FC}│                0│
   │     err_vec│     Vector{$T}│                5│
-  │     restart│           Bool│                0│
+  │  warm_start│           Bool│                0│
   └────────────┴───────────────┴─────────────────┘
   """
   @test reduce(replace, [" " => "", "\n" => "", "─" => ""], init=showed) == reduce(replace, [" " => "", "\n" => "", "─" => ""], init=expected)

--- a/test/test_solvers.jl
+++ b/test/test_solvers.jl
@@ -447,7 +447,7 @@ function test_solvers(FC)
   │           y│    Vector{$FC}│               64│
   │           v│    Vector{$FC}│                0│
   │     err_vec│     Vector{$T}│                5│
-  |     restart│           Bool│                0|
+  │     restart│           Bool│                0│
   └────────────┴───────────────┴─────────────────┘
   """
   @test reduce(replace, [" " => "", "\n" => "", "─" => ""], init=showed) == reduce(replace, [" " => "", "\n" => "", "─" => ""], init=expected)

--- a/test/test_solvers.jl
+++ b/test/test_solvers.jl
@@ -447,6 +447,7 @@ function test_solvers(FC)
   │           y│    Vector{$FC}│               64│
   │           v│    Vector{$FC}│                0│
   │     err_vec│     Vector{$T}│                5│
+  |     restart│           Bool│                0|
   └────────────┴───────────────┴─────────────────┘
   """
   @test reduce(replace, [" " => "", "\n" => "", "─" => ""], init=showed) == reduce(replace, [" " => "", "\n" => "", "─" => ""], init=expected)


### PR DESCRIPTION
I found the use of the restart option not convenient to write generic code. Also the fact that the `restart` parameter was in the arguments of the function was misleading because it was not possible to restart `minres` (the not in-place version) (correct me if I'm wrong).

I added a function `warm_start!(solver, x0)` that is used to tell MINRES to solve the problem from x0. 
`MinresSolver` has now an attribute `restart` set to false by default. When using `warm_start!`, it is set to true. After `minres!` is called, it is set to false again.

If we agree to merge with, we could do the same for all other Krylov solvers by adding a method to the `warm_start!` function.