### PR TITLE
Fix the documentation

### DIFF
--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -9,9 +9,4 @@ Pages = ["reference.md"]
 ## Index
 
 ```@index
-Pages = ["reference.md"]
-```
-
-```@autodocs
-Modules = [Krylov]
 ```

--- a/src/krylov_utils.jl
+++ b/src/krylov_utils.jl
@@ -1,6 +1,6 @@
 """
     FloatOrComplex{T}
-Union type of `T` and `Complex{T}` where T is an [`AbstractFloat`](@ref).
+Union type of `T` and `Complex{T}` where T is an `AbstractFloat`.
 """
 const FloatOrComplex{T} = Union{T, Complex{T}} where T <: AbstractFloat
 


### PR DESCRIPTION
@dpo, Documenter.jl is not able to display docstrings of function defined as:
```
"""
My function foo
"""
function foo end
```
if we have duplicates.
I didn't find how to solve this problem with removing the `@autodocs` block.

The docstring of `minres`, `gmres`, ... are not display anymore.