### PR TITLE
Add partial reorthogonalization in DIOM and DQGMRES

### DIFF
--- a/src/diom.jl
+++ b/src/diom.jl
@@ -13,7 +13,8 @@ export diom, diom!
 """
     (x, stats) = diom(A, b::AbstractVector{FC}; memory::Int=20,
                       M=I, N=I, atol::T=√eps(T), rtol::T=√eps(T),
-                      itmax::Int=0, verbose::Int=0, history::Bool=false)
+                      reorthogonalization::Bool=false, itmax::Int=0,
+                      verbose::Int=0, history::Bool=false)
 
 `T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
 `FC` is `T` or `Complex{T}`.
@@ -24,6 +25,8 @@ DIOM only orthogonalizes the new vectors of the Krylov basis against the `memory
 If CG is well defined on `Ax = b` and `memory = 2`, DIOM is theoretically equivalent to CG.
 If `k ≤ memory` where `k` is the number of iterations, DIOM is theoretically equivalent to FOM.
 Otherwise, DIOM interpolates between CG and FOM and is similar to CG with partial reorthogonalization.
+
+Partial reorthogonalization is available with the `reorthogonalization` option.
 
 An advantage of DIOM is that nonsymmetric or symmetric indefinite or both nonsymmetric
 and indefinite systems of linear equations can be handled by this single algorithm.
@@ -78,7 +81,8 @@ end
 
 function diom!(solver :: DiomSolver{T,FC,S}, A, b :: AbstractVector{FC};
                M=I, N=I, atol :: T=√eps(T), rtol :: T=√eps(T),
-               itmax :: Int=0, verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: DenseVector{FC}}
+               reorthogonalization :: Bool=false, itmax :: Int=0,
+               verbose :: Int=0, history :: Bool=false) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: DenseVector{FC}}
 
   m, n = size(A)
   m == n || error("System must be square")
@@ -171,6 +175,18 @@ function diom!(solver :: DiomSolver{T,FC,S}, A, b :: AbstractVector{FC};
       H[diag] = @kdot(n, w, V[ipos]) # hᵢ.ₘ = ⟨M⁻¹AN⁻¹vₘ , vᵢ⟩
       @kaxpy!(n, -H[diag], V[ipos], w) # w ← w - hᵢ.ₘ * vᵢ
     end
+
+    # Partial reorthogonalization of the Krylov basis.
+    if reorthogonalization
+      for i = max(1, iter-mem+1) : iter
+        ipos = mod(i-1, mem) + 1
+        diag = iter - i + 2
+        Htmp = @kdot(n, w, V[ipos])
+        H[diag] += Htmp
+        @kaxpy!(n, -Htmp, V[ipos], w)
+      end
+    end
+
     # Compute hₘ₊₁.ₘ and vₘ₊₁.
     H[1] = @knrm2(n, w) # hₘ₊₁.ₘ = ‖vₘ₊₁‖₂
     if H[1] ≠ 0 # hₘ₊₁.ₘ = 0 ⇒ "lucky breakdown"

--- a/test/test_diom.jl
+++ b/test/test_diom.jl
@@ -46,7 +46,7 @@
 
       # Symmetric indefinite variant, almost singular.
       A, b = almost_singular(FC=FC)
-      (x, stats) = diom(A, b)
+      (x, stats) = diom(A, b, reorthogonalization=true)
       r = b - A * x
       resid = norm(r) / norm(b)
       @test(resid ≤ diom_tol)

--- a/test/test_dqgmres.jl
+++ b/test/test_dqgmres.jl
@@ -46,10 +46,10 @@
 
       # Symmetric indefinite variant, almost singular.
       A, b = almost_singular(FC=FC)
-      (x, stats) = dqgmres(A, b)
+      (x, stats) = dqgmres(A, b, reorthogonalization=true)
       r = b - A * x
       resid = norm(r) / norm(b)
-      @test(resid ≤ 100 * dqgmres_tol)
+      @test(resid ≤ dqgmres_tol)
       @test(stats.solved)
 
       # Test b == 0


### PR DESCRIPTION
@geoffroyleconte 
I added partial reorthogonalization in DIOM and DQGMRES.
You should try DIOM and DQGMRES with `memory=2` and `reorthogonalization=true`.
You will have a more stable version of `CG` and `MINRES` for the same storage requierements.