### PR TITLE
Replace mul! by mulorldiv! for preconditioners

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -20,7 +20,7 @@ makedocs(
            "In-place methods" => "inplace.md",
            "GPU support" => "gpu.md",
            "Warm start" => "warm_start.md",
-           "Factorization-free operators" => "factorization-free.md",
+           "Matrix-free operators" => "matrix-free.md",
            "Callbacks" => "callbacks.md",
            "Performance tips" => "tips.md",
            "Tutorial" => "examples.md",

--- a/docs/src/inplace.md
+++ b/docs/src/inplace.md
@@ -50,7 +50,7 @@ Krylov.issolved
 ## Examples
 
 We illustrate the use of in-place Krylov solvers with two well-known optimization methods.
-The details of the optimization methods are described in the section about [Factorization-free operators](@ref factorization-free).
+The details of the optimization methods are described in the section about [Factorization-free operators](@ref matrix-free).
 
 ### Example 1: Newton's method for convex optimization without linesearch
 

--- a/docs/src/matrix-free.md
+++ b/docs/src/matrix-free.md
@@ -1,8 +1,8 @@
-## [Factorization-free operators](@id factorization-free)
+## [Matrix-free operators](@id matrix-free)
 
-All methods are factorization free, which means that you only need to provide operator-vector products.
+All methods are matrix-free, which means that you only need to provide operator-vector products.
 
-The `A`, `M` or `N` input arguments of Krylov.jl solvers can be any object that represents a linear operator. That object must implement `mul!`, for multiplication with a vector, `size()` and `eltype()`. For certain methods it must also implement `adjoint()`.
+The `A` or `B` input arguments of Krylov.jl solvers can be any object that represents a linear operator. That object must implement `mul!`, for multiplication with a vector, `size()` and `eltype()`. For certain methods it must also implement `adjoint()`.
 
 Some methods only require `A * v` products, whereas other ones also require `A' * u` products. In the latter case, `adjoint(A)` must also be implemented.
 
@@ -12,6 +12,8 @@ Some methods only require `A * v` products, whereas other ones also require `A' 
 | SYMMLQ, CG-LANCZOS, MINRES, MINRES-QLP | LSLQ, LSQR, LSMR, LNLQ, CRAIG, CRAIGMR   |
 | DIOM, FOM, DQGMRES, GMRES              | BiLQ, QMR, BiLQR, USYMLQ, USYMQR, TriLQR |
 | CGS, BICGSTAB                          | TriCG, TriMR, USYMLQR                    |
+
+Preconditioners `M`, `N`, `C`, `D`, `E` or `F` can be also linear operators and must implement `mul!` or `ldiv!`.
 
 We strongly recommend [LinearOperators.jl](https://github.com/JuliaSmoothOptimizers/LinearOperators.jl) to model matrix-free operators, but other packages such as [LinearMaps.jl](https://github.com/JuliaLinearAlgebra/LinearMaps.jl), [DiffEqOperators.jl](https://github.com/SciML/DiffEqOperators.jl) or your own operator can be used as well.
 

--- a/src/cg.jl
+++ b/src/cg.jl
@@ -21,7 +21,7 @@ export cg, cg!
                     M=I, atol::T=√eps(T), rtol::T=√eps(T),
                     itmax::Int=0, radius::T=zero(T), linesearch::Bool=false,
                     verbose::Int=0, history::Bool=false,
-                    callback=solver->false)
+                    ldiv::Bool=false, callback=solver->false)
 
 `T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
 `FC` is `T` or `Complex{T}`.
@@ -84,7 +84,7 @@ function cg!(solver :: CgSolver{T,FC,S}, A, b :: AbstractVector{FC};
              M=I, atol :: T=√eps(T), rtol :: T=√eps(T),
              itmax :: Int=0, radius :: T=zero(T), linesearch :: Bool=false,
              verbose :: Int=0, history :: Bool=false,
-             callback = solver -> false) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: DenseVector{FC}}
+             ldiv :: Bool=false, callback = solver -> false) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: DenseVector{FC}}
 
   linesearch && (radius > 0) && error("`linesearch` set to `true` but trust-region radius > 0")
 
@@ -115,7 +115,7 @@ function cg!(solver :: CgSolver{T,FC,S}, A, b :: AbstractVector{FC};
   else
     r .= b
   end
-  MisI || mul!(z, M, r)
+  MisI || mulorldiv!(z, M, r, ldiv)
   p .= z
   γ = @kdotr(n, r, z)
   rNorm = sqrt(γ)
@@ -178,7 +178,7 @@ function cg!(solver :: CgSolver{T,FC,S}, A, b :: AbstractVector{FC};
 
     @kaxpy!(n,  α,  p, x)
     @kaxpy!(n, -α, Ap, r)
-    MisI || mul!(z, M, r)
+    MisI || mulorldiv!(z, M, r, ldiv)
     γ_next = @kdotr(n, r, z)
     rNorm = sqrt(γ_next)
     history && push!(rNorms, rNorm)

--- a/src/cr.jl
+++ b/src/cr.jl
@@ -18,7 +18,7 @@ export cr, cr!
     (x, stats) = cr(A, b::AbstractVector{FC};
                     M=I, atol::T=√eps(T), rtol::T=√eps(T), γ::T=√eps(T), itmax::Int=0,
                     radius::T=zero(T), verbose::Int=0, linesearch::Bool=false, history::Bool=false,
-                    callback=solver->false)
+                    ldiv::Bool=false, callback=solver->false)
 
 `T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
 `FC` is `T` or `Complex{T}`.
@@ -82,7 +82,7 @@ end
 function cr!(solver :: CrSolver{T,FC,S}, A, b :: AbstractVector{FC};
              M=I, atol :: T=√eps(T), rtol :: T=√eps(T), γ :: T=√eps(T), itmax :: Int=0,
              radius :: T=zero(T), verbose :: Int=0, linesearch :: Bool=false, history :: Bool=false,
-             callback = solver -> false) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: DenseVector{FC}}
+             ldiv :: Bool=false, callback = solver -> false) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: DenseVector{FC}}
 
   linesearch && (radius > 0) && error("'linesearch' set to 'true' but radius > 0")
   n, m = size(A)
@@ -113,7 +113,7 @@ function cr!(solver :: CrSolver{T,FC,S}, A, b :: AbstractVector{FC};
   else
     p .= b
   end
-  mul!(r, M, p)
+  mulorldiv!(r, M, p, ldiv)
   mul!(Ar, A, r)
   ρ = @kdotr(n, r, Ar)
 
@@ -170,7 +170,7 @@ function cr!(solver :: CrSolver{T,FC,S}, A, b :: AbstractVector{FC};
     elseif pAp ≤ 0 && radius == 0
       error("Indefinite system and no trust region")
     end
-    MisI || mul!(Mq, M, q)
+    MisI || mulorldiv!(Mq, M, q, ldiv)
 
     if radius > 0
       (verbose > 0) && @printf("radius = %8.1e > 0 and ‖x‖ = %8.1e\n", radius, xNorm)

--- a/src/dqgmres.jl
+++ b/src/dqgmres.jl
@@ -15,7 +15,7 @@ export dqgmres, dqgmres!
                          M=I, N=I, atol::T=√eps(T), rtol::T=√eps(T),
                          reorthogonalization::Bool=false, itmax::Int=0,
                          verbose::Int=0, history::Bool=false,
-                         callback=solver->false)
+                         ldiv::Bool=false, callback=solver->false)
 
 `T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
 `FC` is `T` or `Complex{T}`.
@@ -87,7 +87,7 @@ function dqgmres!(solver :: DqgmresSolver{T,FC,S}, A, b :: AbstractVector{FC};
                   M=I, N=I, atol :: T=√eps(T), rtol :: T=√eps(T),
                   reorthogonalization :: Bool=false, itmax :: Int=0,
                   verbose :: Int=0, history :: Bool=false,
-                  callback = solver -> false) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: DenseVector{FC}}
+                  ldiv :: Bool=false, callback = solver -> false) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: DenseVector{FC}}
 
   m, n = size(A)
   m == n || error("System must be square")
@@ -121,9 +121,8 @@ function dqgmres!(solver :: DqgmresSolver{T,FC,S}, A, b :: AbstractVector{FC};
   else
     t .= b
   end
-  MisI || mul!(r₀, M, t)  # M⁻¹(b - Ax₀)
-  # Compute β
-  rNorm = @knrm2(n, r₀) # β = ‖r₀‖₂
+  MisI || mulorldiv!(r₀, M, t, ldiv)  # M⁻¹(b - Ax₀)
+  rNorm = @knrm2(n, r₀)               # β = ‖r₀‖₂
   history && push!(rNorms, rNorm)
   if rNorm == 0
     stats.niter = 0
@@ -176,9 +175,9 @@ function dqgmres!(solver :: DqgmresSolver{T,FC,S}, A, b :: AbstractVector{FC};
 
     # Incomplete Arnoldi procedure.
     z = NisI ? V[pos] : solver.z
-    NisI || mul!(z, N, V[pos])  # N⁻¹vₘ, forms pₘ
-    mul!(t, A, z)               # AN⁻¹vₘ
-    MisI || mul!(w, M, t)       # M⁻¹AN⁻¹vₘ, forms vₘ₊₁
+    NisI || mulorldiv!(z, N, V[pos], ldiv)  # N⁻¹vₘ, forms pₘ
+    mul!(t, A, z)                           # AN⁻¹vₘ
+    MisI || mulorldiv!(w, M, t, ldiv)       # M⁻¹AN⁻¹vₘ, forms vₘ₊₁
     for i = max(1, iter-mem+1) : iter
       ipos = mod(i-1, mem) + 1 # Position corresponding to vᵢ in the circular stack V.
       diag = iter - i + 2

--- a/src/gmres.jl
+++ b/src/gmres.jl
@@ -15,7 +15,7 @@ export gmres, gmres!
                        M=I, N=I, atol::T=√eps(T), rtol::T=√eps(T),
                        reorthogonalization::Bool=false, itmax::Int=0,
                        restart::Bool=false, verbose::Int=0, history::Bool=false,
-                       callback=solver->false)
+                       ldiv::Bool=false, callback=solver->false)
 
 `T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
 `FC` is `T` or `Complex{T}`.
@@ -85,7 +85,7 @@ function gmres!(solver :: GmresSolver{T,FC,S}, A, b :: AbstractVector{FC};
                 M=I, N=I, atol :: T=√eps(T), rtol :: T=√eps(T),
                 reorthogonalization :: Bool=false, itmax :: Int=0,
                 restart :: Bool=false, verbose :: Int=0, history :: Bool=false,
-                callback = solver -> false) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: DenseVector{FC}}
+                ldiv :: Bool=false, callback = solver -> false) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: DenseVector{FC}}
 
   m, n = size(A)
   m == n || error("System must be square")
@@ -124,8 +124,8 @@ function gmres!(solver :: GmresSolver{T,FC,S}, A, b :: AbstractVector{FC};
   else
     w .= b
   end
-  MisI || mul!(r₀, M, w)  # r₀ = M⁻¹(b - Ax₀)
-  β = @knrm2(n, r₀)       # β = ‖r₀‖₂
+  MisI || mulorldiv!(r₀, M, w, ldiv)  # r₀ = M⁻¹(b - Ax₀)
+  β = @knrm2(n, r₀)                   # β = ‖r₀‖₂
 
   rNorm = β
   history && push!(rNorms, β)
@@ -180,7 +180,7 @@ function gmres!(solver :: GmresSolver{T,FC,S}, A, b :: AbstractVector{FC};
       if npass ≥ 1
         mul!(w, A, x)
         @kaxpby!(n, one(FC), b, -one(FC), w)
-        MisI || mul!(r₀, M, w)
+        MisI || mulorldiv!(r₀, M, w, ldiv)
       end
     end
 
@@ -210,9 +210,9 @@ function gmres!(solver :: GmresSolver{T,FC,S}, A, b :: AbstractVector{FC};
 
       # Continue the Arnoldi process.
       p = NisI ? V[inner_iter] : solver.p
-      NisI || mul!(p, N, V[inner_iter])  # p ← N⁻¹vₖ
-      mul!(w, A, p)                      # w ← AN⁻¹vₖ
-      MisI || mul!(q, M, w)              # q ← M⁻¹AN⁻¹vₖ
+      NisI || mulorldiv!(p, N, V[inner_iter], ldiv)  # p ← N⁻¹vₖ
+      mul!(w, A, p)                                  # w ← AN⁻¹vₖ
+      MisI || mulorldiv!(q, M, w, ldiv)              # q ← M⁻¹AN⁻¹vₖ
       for i = 1 : inner_iter
         R[nr+i] = @kdot(n, V[i], q)      # hᵢₖ = qᵀvᵢ
         @kaxpy!(n, -R[nr+i], V[i], q)    # q ← q - hᵢₖvᵢ
@@ -305,7 +305,7 @@ function gmres!(solver :: GmresSolver{T,FC,S}, A, b :: AbstractVector{FC};
     end
     if !NisI
       solver.p .= xr
-      mul!(xr, N, solver.p)
+      mulorldiv!(xr, N, solver.p, ldiv)
     end
     restart && @kaxpy!(n, one(FC), xr, x)
 

--- a/src/krylov_utils.jl
+++ b/src/krylov_utils.jl
@@ -222,6 +222,8 @@ Create an AbstractVector of storage type `S` of length `n` only composed of one.
 
 @inline kdisplay(iter, verbose) = (verbose > 0) && (mod(iter, verbose) == 0)
 
+@inline mulorldiv!(y, P, x, ldiv::Bool) = ldiv ? ldiv!(y, P, x) : mul!(y, P, x)
+
 @inline krylov_dot(n :: Integer, x :: Vector{T}, dx :: Integer, y :: Vector{T}, dy :: Integer) where T <: BLAS.BlasReal = BLAS.dot(n, x, dx, y, dy)
 @inline krylov_dot(n :: Integer, x :: Vector{T}, dx :: Integer, y :: Vector{T}, dy :: Integer) where T <: BLAS.BlasComplex = BLAS.dotc(n, x, dx, y, dy)
 @inline krylov_dot(n :: Integer, x :: AbstractVector{T}, dx :: Integer, y :: AbstractVector{T}, dy :: Integer) where T <: Number = dot(x, y)

--- a/src/lsmr.jl
+++ b/src/lsmr.jl
@@ -33,7 +33,8 @@ export lsmr, lsmr!
                       etol::T=√eps(T), window::Int=5,
                       itmax::Int=0, conlim::T=1/√eps(T),
                       radius::T=zero(T), verbose::Int=0,
-                      history::Bool=false, callback=solver->false)
+                      history::Bool=false, ldiv::Bool=false,
+                      callback=solver->false)
 
 `T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
 `FC` is `T` or `Complex{T}`.
@@ -114,7 +115,7 @@ function lsmr!(solver :: LsmrSolver{T,FC,S}, A, b :: AbstractVector{FC};
                atol :: T=zero(T), rtol :: T=zero(T),
                etol :: T=√eps(T), itmax :: Int=0, conlim :: T=1/√eps(T),
                radius :: T=zero(T), verbose :: Int=0, history :: Bool=false,
-               callback = solver -> false) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: DenseVector{FC}}
+               ldiv :: Bool=false, callback = solver -> false) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: DenseVector{FC}}
 
   m, n = size(A)
   length(b) == m || error("Inconsistent problem size")
@@ -151,7 +152,7 @@ function lsmr!(solver :: LsmrSolver{T,FC,S}, A, b :: AbstractVector{FC};
   # Initialize Golub-Kahan process.
   # β₁ M u₁ = b.
   Mu .= b
-  MisI || mul!(u, M, Mu)
+  MisI || mulorldiv!(u, M, Mu, ldiv)
   β₁ = sqrt(@kdotr(m, u, Mu))
   if β₁ == 0
     stats.niter = 0
@@ -167,7 +168,7 @@ function lsmr!(solver :: LsmrSolver{T,FC,S}, A, b :: AbstractVector{FC};
   MisI || @kscal!(m, one(FC)/β₁, Mu)
   mul!(Aᵀu, Aᵀ, u)
   Nv .= Aᵀu
-  NisI || mul!(v, N, Nv)
+  NisI || mulorldiv!(v, N, Nv, ldiv)
   α = sqrt(@kdotr(n, v, Nv))
 
   ζbar = α * β
@@ -241,7 +242,7 @@ function lsmr!(solver :: LsmrSolver{T,FC,S}, A, b :: AbstractVector{FC};
     # 1. βₖ₊₁Muₖ₊₁ = Avₖ - αₖMuₖ
     mul!(Av, A, v)
     @kaxpby!(m, one(FC), Av, -α, Mu)
-    MisI || mul!(u, M, Mu)
+    MisI || mulorldiv!(u, M, Mu, ldiv)
     β = sqrt(@kdotr(m, u, Mu))
     if β ≠ 0
       @kscal!(m, one(FC)/β, u)
@@ -250,7 +251,7 @@ function lsmr!(solver :: LsmrSolver{T,FC,S}, A, b :: AbstractVector{FC};
       # 2. αₖ₊₁Nvₖ₊₁ = Aᵀuₖ₊₁ - βₖ₊₁Nvₖ
       mul!(Aᵀu, Aᵀ, u)
       @kaxpby!(n, one(FC), Aᵀu, -β, Nv)
-      NisI || mul!(v, N, Nv)
+      NisI || mulorldiv!(v, N, Nv, ldiv)
       α = sqrt(@kdotr(n, v, Nv))
       if α ≠ 0
         @kscal!(n, one(FC)/α, v)

--- a/src/minres.jl
+++ b/src/minres.jl
@@ -29,7 +29,7 @@ export minres, minres!
                         rrtol :: T=zero(T), etol::T=√eps(T),
                         window::Int=5, itmax::Int=0,
                         conlim::T=1/√eps(T), verbose::Int=0,
-                        history::Bool=false,
+                        history::Bool=false, ldiv::Bool=false,
                         callback=solver->false)
 
 `T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
@@ -102,7 +102,7 @@ function minres!(solver :: MinresSolver{T,FC,S}, A, b :: AbstractVector{FC};
                  M=I, λ :: T=zero(T), atol :: T=√eps(T)/100, rtol :: T=√eps(T)/100, 
                  ratol :: T=zero(T), rrtol :: T=zero(T), etol :: T=√eps(T),
                  itmax :: Int=0, conlim :: T=1/√eps(T), verbose :: Int=0,
-                 history :: Bool=false, callback = solver -> false) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: DenseVector{FC}}
+                 history :: Bool=false, ldiv :: Bool=false, callback = solver -> false) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: DenseVector{FC}}
 
   n, m = size(A)
   m == n || error("System must be square")
@@ -142,7 +142,7 @@ function minres!(solver :: MinresSolver{T,FC,S}, A, b :: AbstractVector{FC};
   # Initialize Lanczos process.
   # β₁ M v₁ = b.
   r2 .= r1
-  MisI || mul!(v, M, r1)
+  MisI || mulorldiv!(v, M, r1, ldiv)
   β₁ = @kdotr(m, r1, v)
   β₁ < 0 && error("Preconditioner is not positive definite")
   if β₁ == 0
@@ -227,7 +227,7 @@ function minres!(solver :: MinresSolver{T,FC,S}, A, b :: AbstractVector{FC};
 
     @. r1 = r2
     @. r2 = y
-    MisI || mul!(v, M, r2)
+    MisI || mulorldiv!(v, M, r2, ldiv)
     oldβ = β
     β = @kdotr(n, r2, v)
     β < 0 && error("Preconditioner is not positive definite")

--- a/src/minres_qlp.jl
+++ b/src/minres_qlp.jl
@@ -21,7 +21,7 @@ export minres_qlp, minres_qlp!
                             M=I, atol::T=√eps(T), rtol::T=√eps(T),
                             ctol::T=√eps(T), λ::T=zero(T), itmax::Int=0,
                             verbose::Int=0, history::Bool=false,
-                            callback=solver->false)
+                            ldiv::Bool=false, callback=solver->false)
 
 `T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
 `FC` is `T` or `Complex{T}`.
@@ -83,7 +83,7 @@ function minres_qlp!(solver :: MinresQlpSolver{T,FC,S}, A, b :: AbstractVector{F
                      M=I, atol :: T=√eps(T), rtol :: T=√eps(T),
                      ctol :: T=√eps(T), λ ::T=zero(T), itmax :: Int=0,
                      verbose :: Int=0, history :: Bool=false,
-                     callback = solver -> false) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: DenseVector{FC}}
+                     ldiv :: Bool=false, callback = solver -> false) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: DenseVector{FC}}
 
   n, m = size(A)
   m == n || error("System must be square")
@@ -119,7 +119,7 @@ function minres_qlp!(solver :: MinresQlpSolver{T,FC,S}, A, b :: AbstractVector{F
   end
 
   # β₁v₁ = Mb
-  MisI || mul!(vₖ, M, M⁻¹vₖ)
+  MisI || mulorldiv!(vₖ, M, M⁻¹vₖ, ldiv)
   βₖ = sqrt(@kdotr(n, vₖ, M⁻¹vₖ))
   if βₖ ≠ 0
     @kscal!(n, one(FC) / βₖ, M⁻¹vₖ)
@@ -196,7 +196,7 @@ function minres_qlp!(solver :: MinresQlpSolver{T,FC,S}, A, b :: AbstractVector{F
 
     @kaxpy!(n, -αₖ, M⁻¹vₖ, p)  # p ← p - αₖM⁻¹vₖ
 
-    MisI || mul!(vₖ₊₁, M, p)   # βₖ₊₁vₖ₊₁ = MAvₖ - γₖvₖ₋₁ - αₖvₖ
+    MisI || mulorldiv!(vₖ₊₁, M, p, ldiv)  # βₖ₊₁vₖ₊₁ = MAvₖ - γₖvₖ₋₁ - αₖvₖ
 
     βₖ₊₁ = sqrt(@kdotr(m, vₖ₊₁, p))
 

--- a/src/trimr.jl
+++ b/src/trimr.jl
@@ -17,7 +17,7 @@ export trimr, trimr!
                           spd::Bool=false, snd::Bool=false, flip::Bool=false, sp::Bool=false,
                           τ::T=one(T), ν::T=-one(T), itmax::Int=0,
                           verbose::Int=0, history::Bool=false,
-                          callback=solver->false)
+                          ldiv::Bool=false, callback=solver->false)
 
 `T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
 `FC` is `T` or `Complex{T}`.
@@ -102,7 +102,7 @@ function trimr!(solver :: TrimrSolver{T,FC,S}, A, b :: AbstractVector{FC}, c :: 
                 spd :: Bool=false, snd :: Bool=false, flip :: Bool=false, sp :: Bool=false,
                 τ :: T=one(T), ν :: T=-one(T), itmax :: Int=0,
                 verbose :: Int=0, history :: Bool=false,
-                callback = solver -> false) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: DenseVector{FC}}
+                ldiv :: Bool=false, callback = solver -> false) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: DenseVector{FC}}
 
   m, n = size(A)
   length(b) == m || error("Inconsistent problem size")
@@ -181,7 +181,7 @@ function trimr!(solver :: TrimrSolver{T,FC,S}, A, b :: AbstractVector{FC}, c :: 
 
   # β₁Ev₁ = b ↔ β₁v₁ = Mb
   M⁻¹vₖ .= b₀
-  MisI || mul!(vₖ, M, M⁻¹vₖ)
+  MisI || mulorldiv!(vₖ, M, M⁻¹vₖ, ldiv)
   βₖ = sqrt(@kdotr(m, vₖ, M⁻¹vₖ))  # β₁ = ‖v₁‖_E
   if βₖ ≠ 0
     @kscal!(m, one(FC) / βₖ, M⁻¹vₖ)
@@ -192,7 +192,7 @@ function trimr!(solver :: TrimrSolver{T,FC,S}, A, b :: AbstractVector{FC}, c :: 
 
   # γ₁Fu₁ = c ↔ γ₁u₁ = Nc
   N⁻¹uₖ .= c₀
-  NisI || mul!(uₖ, N, N⁻¹uₖ)
+  NisI || mulorldiv!(uₖ, N, N⁻¹uₖ, ldiv)
   γₖ = sqrt(@kdotr(n, uₖ, N⁻¹uₖ))  # γ₁ = ‖u₁‖_F
   if γₖ ≠ 0
     @kscal!(n, one(FC) / γₖ, N⁻¹uₖ)
@@ -260,8 +260,8 @@ function trimr!(solver :: TrimrSolver{T,FC,S}, A, b :: AbstractVector{FC}, c :: 
     @kaxpy!(n, -conj(αₖ), N⁻¹uₖ, p)  # p ← p - ᾱₖ * N⁻¹uₖ
 
     # Compute vₖ₊₁ and uₖ₊₁
-    MisI || mul!(vₖ₊₁, M, q)  # βₖ₊₁vₖ₊₁ = MAuₖ  - γₖvₖ₋₁ - αₖvₖ
-    NisI || mul!(uₖ₊₁, N, p)  # γₖ₊₁uₖ₊₁ = NAᵀvₖ - βₖuₖ₋₁ - ᾱₖuₖ
+    MisI || mulorldiv!(vₖ₊₁, M, q, ldiv)  # βₖ₊₁vₖ₊₁ = MAuₖ  - γₖvₖ₋₁ - αₖvₖ
+    NisI || mulorldiv!(uₖ₊₁, N, p, ldiv)  # γₖ₊₁uₖ₊₁ = NAᵀvₖ - βₖuₖ₋₁ - ᾱₖuₖ
 
     βₖ₊₁ = sqrt(@kdotr(m, vₖ₊₁, q))  # βₖ₊₁ = ‖vₖ₊₁‖_E
     γₖ₊₁ = sqrt(@kdotr(n, uₖ₊₁, p))  # γₖ₊₁ = ‖uₖ₊₁‖_F


### PR DESCRIPTION
We should be able to switch between `mul!̀` and `ldiv!` if we add a boolean argument to all Krylov methods that support preconditioners. This parameter will be the last argument of `kmuldiv!` function.