### PR TITLE
Add a reference to BiCG paper

### DIFF
--- a/src/bilq.jl
+++ b/src/bilq.jl
@@ -42,7 +42,7 @@ and `false` otherwise.
 #### References
 
 * A. Montoison and D. Orban, [*BiLQ: An Iterative Method for Nonsymmetric Linear Systems with a Quasi-Minimum Error Property*](https://doi.org/10.1137/19M1290991), SIAM Journal on Matrix Analysis and Applications, 41(3), pp. 1145--1166, 2020.
-* R. Fletcher, [*Conjugate gradient methods for indefinite systems*](https://doi.org/10.1007/BFb0080116), Numerical Analysis, pp. 73--89, 1976.
+* R. Fletcher, [*Conjugate gradient methods for indefinite systems*](https://doi.org/10.1007/BFb0080116), Numerical Analysis, Springer, pp. 73--89, 1976.
 """
 function bilq end
 

--- a/src/bilq.jl
+++ b/src/bilq.jl
@@ -39,9 +39,10 @@ where `kwargs` are the same keyword arguments as above.
 The callback is called as `callback(solver)` and should return `true` if the main loop should terminate,
 and `false` otherwise.
 
-#### Reference
+#### References
 
 * A. Montoison and D. Orban, [*BiLQ: An Iterative Method for Nonsymmetric Linear Systems with a Quasi-Minimum Error Property*](https://doi.org/10.1137/19M1290991), SIAM Journal on Matrix Analysis and Applications, 41(3), pp. 1145--1166, 2020.
+* R. Fletcher, [*Conjugate gradient methods for indefinite systems*](https://doi.org/10.1007/BFb0080116), Numerical Analysis, pp. 73--89, 1976.
 """
 function bilq end
 


### PR DESCRIPTION
I don't know if I should add the publisher `Springer` for this reference.
`Numerical Analysis` is a book and not a journal paper. 