### PR TITLE
add imput and output arguments in all docstrings

### DIFF
--- a/src/bicgstab.jl
+++ b/src/bicgstab.jl
@@ -24,7 +24,7 @@ export bicgstab, bicgstab!
 `T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
 `FC` is `T` or `Complex{T}`.
 
-Solve the square linear system Ax = b using BICGSTAB.
+Solve the square linear system Ax = b of size n using BICGSTAB.
 BICGSTAB requires two initial vectors `b` and `c`.
 The relation `bᴴc ≠ 0` must be satisfied and by default `c = b`.
 

--- a/src/bicgstab.jl
+++ b/src/bicgstab.jl
@@ -53,12 +53,12 @@ and `false` otherwise.
 
 #### Input arguments
 
-* `A`: a linear operator that models a matrix of dimension n.
+* `A`: a linear operator that models a matrix of dimension n;
 * `b`: a vector of length n.
 
 #### Output arguments
 
-* `x`: a dense vector of length n.
+* `x`: a dense vector of length n;
 * `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
 
 #### References

--- a/src/bicgstab.jl
+++ b/src/bicgstab.jl
@@ -51,6 +51,16 @@ where `kwargs` are the same keyword arguments as above.
 The callback is called as `callback(solver)` and should return `true` if the main loop should terminate,
 and `false` otherwise.
 
+#### Input arguments
+
+* `A`: a linear operator that models a matrix of dimension n.
+* `b`: a vector of length n.
+
+#### Output arguments
+
+* `x`: a dense vector of length n.
+* `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
+
 #### References
 
 * H. A. van der Vorst, [*Bi-CGSTAB: A fast and smoothly converging variant of Bi-CG for the solution of nonsymmetric linear systems*](https://doi.org/10.1137/0913035), SIAM Journal on Scientific and Statistical Computing, 13(2), pp. 631--644, 1992.

--- a/src/bilq.jl
+++ b/src/bilq.jl
@@ -41,12 +41,12 @@ and `false` otherwise.
 
 #### Input arguments
 
-* `A`: a linear operator that models a matrix of dimension n.
+* `A`: a linear operator that models a matrix of dimension n;
 * `b`: a vector of length n.
 
 #### Output arguments
 
-* `x`: a dense vector of length n.
+* `x`: a dense vector of length n;
 * `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
 
 #### References

--- a/src/bilq.jl
+++ b/src/bilq.jl
@@ -39,6 +39,16 @@ where `kwargs` are the same keyword arguments as above.
 The callback is called as `callback(solver)` and should return `true` if the main loop should terminate,
 and `false` otherwise.
 
+#### Input arguments
+
+* `A`: a linear operator that models a matrix of dimension n.
+* `b`: a vector of length n.
+
+#### Output arguments
+
+* `x`: a dense vector of length n.
+* `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
+
 #### References
 
 * A. Montoison and D. Orban, [*BiLQ: An Iterative Method for Nonsymmetric Linear Systems with a Quasi-Minimum Error Property*](https://doi.org/10.1137/19M1290991), SIAM Journal on Matrix Analysis and Applications, 41(3), pp. 1145--1166, 2020.

--- a/src/bilq.jl
+++ b/src/bilq.jl
@@ -21,7 +21,7 @@ export bilq, bilq!
 `T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
 `FC` is `T` or `Complex{T}`.
 
-Solve the square linear system Ax = b using BiLQ.
+Solve the square linear system Ax = b of size n using BiLQ.
 
 BiLQ is based on the Lanczos biorthogonalization process and requires two initial vectors `b` and `c`.
 The relation `bᴴc ≠ 0` must be satisfied and by default `c = b`.

--- a/src/bilqr.jl
+++ b/src/bilqr.jl
@@ -27,8 +27,8 @@ Combine BiLQ and QMR to solve adjoint systems.
     [Aᴴ 0] [x]   [c]
 
 The relation `bᴴc ≠ 0` must be satisfied.
-BiLQ is used for solving primal system `Ax = b`.
-QMR is used for solving dual system `Aᴴy = c`.
+BiLQ is used for solving primal system `Ax = b` of size n.
+QMR is used for solving dual system `Aᴴy = c` of size n.
 
 An option gives the possibility of transferring from the BiLQ point to the
 BiCG point, when it exists. The transfer is based on the residual norm.

--- a/src/bilqr.jl
+++ b/src/bilqr.jl
@@ -44,14 +44,14 @@ and `false` otherwise.
 
 #### Input arguments
 
-* `A`: a linear operator that models a matrix of dimension n.
-* `b`: a vector of length n.
+* `A`: a linear operator that models a matrix of dimension n;
+* `b`: a vector of length n;
 * `c`: a vector of length n.
 
 #### Output arguments
 
-* `x`: a dense vector of length n.
-* `y`: a dense vector of length n.
+* `x`: a dense vector of length n;
+* `y`: a dense vector of length n;
 * `stats`: statistics collected on the run in a [`AdjointStats`](@ref) structure.
 
 #### Reference

--- a/src/bilqr.jl
+++ b/src/bilqr.jl
@@ -42,6 +42,18 @@ where `kwargs` are the same keyword arguments as above.
 The callback is called as `callback(solver)` and should return `true` if the main loop should terminate,
 and `false` otherwise.
 
+#### Input arguments
+
+* `A`: a linear operator that models a matrix of dimension n.
+* `b`: a vector of length n.
+* `c`: a vector of length n.
+
+#### Output arguments
+
+* `x`: a dense vector of length n.
+* `y`: a dense vector of length n.
+* `stats`: statistics collected on the run in a [`AdjointStats`](@ref) structure.
+
 #### Reference
 
 * A. Montoison and D. Orban, [*BiLQ: An Iterative Method for Nonsymmetric Linear Systems with a Quasi-Minimum Error Property*](https://doi.org/10.1137/19M1290991), SIAM Journal on Matrix Analysis and Applications, 41(3), pp. 1145--1166, 2020.

--- a/src/cg.jl
+++ b/src/cg.jl
@@ -26,16 +26,15 @@ export cg, cg!
 `T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
 `FC` is `T` or `Complex{T}`.
 
-The conjugate gradient method to solve the symmetric linear system Ax = b.
+The conjugate gradient method to solve the Hermitian linear system Ax = b of size n.
 
 The method does _not_ abort if A is not definite.
 
 A preconditioner M may be provided in the form of a linear operator and is
-assumed to be symmetric and positive definite.
+assumed to be Hermitian and positive definite.
 M also indicates the weighted norm in which residuals are measured.
 
-If `itmax=0`, the default number of iterations is set to `2 * n`,
-with `n = length(b)`.
+If `itmax=0`, the default number of iterations is set to `2 * n`.
 
 CG can be warm-started from an initial guess `x0` with
 

--- a/src/cg.jl
+++ b/src/cg.jl
@@ -46,6 +46,16 @@ where `kwargs` are the same keyword arguments as above.
 The callback is called as `callback(solver)` and should return `true` if the main loop should terminate,
 and `false` otherwise.
 
+#### Input arguments
+
+* `A`: a linear operator that models a Hermitian positive definite matrix of dimension n.
+* `b`: a vector of length n.
+
+#### Output arguments
+
+* `x`: a dense vector of length n.
+* `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
+
 #### Reference
 
 * M. R. Hestenes and E. Stiefel, [*Methods of conjugate gradients for solving linear systems*](https://doi.org/10.6028/jres.049.044), Journal of Research of the National Bureau of Standards, 49(6), pp. 409--436, 1952.

--- a/src/cg.jl
+++ b/src/cg.jl
@@ -48,12 +48,12 @@ and `false` otherwise.
 
 #### Input arguments
 
-* `A`: a linear operator that models a Hermitian positive definite matrix of dimension n.
+* `A`: a linear operator that models a Hermitian positive definite matrix of dimension n;
 * `b`: a vector of length n.
 
 #### Output arguments
 
-* `x`: a dense vector of length n.
+* `x`: a dense vector of length n;
 * `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
 
 #### Reference

--- a/src/cg_lanczos.jl
+++ b/src/cg_lanczos.jl
@@ -41,6 +41,16 @@ where `kwargs` are the same keyword arguments as above.
 The callback is called as `callback(solver)` and should return `true` if the main loop should terminate,
 and `false` otherwise.
 
+#### Input arguments
+
+* `A`: a linear operator that models a Hermitian matrix of dimension n.
+* `b`: a vector of length n.
+
+#### Output arguments
+
+* `x`: a dense vector of length n.
+* `stats`: statistics collected on the run in a [`LanczosStats`](@ref) structure.
+
 #### References
 
 * A. Frommer and P. Maass, [*Fast CG-Based Methods for Tikhonov-Phillips Regularization*](https://doi.org/10.1137/S1064827596313310), SIAM Journal on Scientific Computing, 20(5), pp. 1831--1850, 1999.

--- a/src/cg_lanczos.jl
+++ b/src/cg_lanczos.jl
@@ -43,12 +43,12 @@ and `false` otherwise.
 
 #### Input arguments
 
-* `A`: a linear operator that models a Hermitian matrix of dimension n.
+* `A`: a linear operator that models a Hermitian matrix of dimension n;
 * `b`: a vector of length n.
 
 #### Output arguments
 
-* `x`: a dense vector of length n.
+* `x`: a dense vector of length n;
 * `stats`: statistics collected on the run in a [`LanczosStats`](@ref) structure.
 
 #### References

--- a/src/cg_lanczos.jl
+++ b/src/cg_lanczos.jl
@@ -23,14 +23,12 @@ export cg_lanczos, cg_lanczos!
 `FC` is `T` or `Complex{T}`.
 
 The Lanczos version of the conjugate gradient method to solve the
-symmetric linear system
-
-    Ax = b
+Hermitian linear system Ax = b of size n.
 
 The method does _not_ abort if A is not definite.
 
 A preconditioner M may be provided in the form of a linear operator and is
-assumed to be hermitian and positive definite.
+assumed to be Hermitian and positive definite.
 
 CG-LANCZOS can be warm-started from an initial guess `x0` with
 

--- a/src/cg_lanczos_shift.jl
+++ b/src/cg_lanczos_shift.jl
@@ -39,13 +39,13 @@ and `false` otherwise.
 
 #### Input arguments
 
-* `A`: a linear operator that models a Hermitian matrix of dimension n.
-* `b`: a vector of length n.
+* `A`: a linear operator that models a Hermitian matrix of dimension n;
+* `b`: a vector of length n;
 * `shifts`: a vector of length nshifts.
 
 #### Output arguments
 
-* `x`: a vector of nshifts dense vectors, each one of length n.
+* `x`: a vector of nshifts dense vectors, each one of length n;
 * `stats`: statistics collected on the run in a [`LanczosShiftStats`](@ref) structure.
 
 #### References

--- a/src/cg_lanczos_shift.jl
+++ b/src/cg_lanczos_shift.jl
@@ -36,6 +36,22 @@ assumed to be hermitian and positive definite.
 
 The callback is called as `callback(solver)` and should return `true` if the main loop should terminate,
 and `false` otherwise.
+
+#### Input arguments
+
+* `A`: a linear operator that models a Hermitian matrix of dimension n.
+* `b`: a vector of length n.
+* `shifts`: a vector of length nshifts.
+
+#### Output arguments
+
+* `x`: a vector of nshifts dense vectors, each one of length n.
+* `stats`: statistics collected on the run in a [`LanczosShiftStats`](@ref) structure.
+
+#### References
+
+* A. Frommer and P. Maass, [*Fast CG-Based Methods for Tikhonov-Phillips Regularization*](https://doi.org/10.1137/S1064827596313310), SIAM Journal on Scientific Computing, 20(5), pp. 1831--1850, 1999.
+* C. C. Paige and M. A. Saunders, [*Solution of Sparse Indefinite Systems of Linear Equations*](https://doi.org/10.1137/0712047), SIAM Journal on Numerical Analysis, 12(4), pp. 617--629, 1975.
 """
 function cg_lanczos_shift end
 

--- a/src/cg_lanczos_shift.jl
+++ b/src/cg_lanczos_shift.jl
@@ -27,12 +27,12 @@ export cg_lanczos_shift, cg_lanczos_shift!
 The Lanczos version of the conjugate gradient method to solve a family
 of shifted systems
 
-    (A + αI) x = b  (α = α₁, ..., αₙ)
+    (A + αI) x = b  (α = α₁, ..., αₚ)
 
-The method does _not_ abort if A + αI is not definite.
+of size n. The method does _not_ abort if A + αI is not definite.
 
 A preconditioner M may be provided in the form of a linear operator and is
-assumed to be hermitian and positive definite.
+assumed to be Hermitian and positive definite.
 
 The callback is called as `callback(solver)` and should return `true` if the main loop should terminate,
 and `false` otherwise.
@@ -41,11 +41,11 @@ and `false` otherwise.
 
 * `A`: a linear operator that models a Hermitian matrix of dimension n;
 * `b`: a vector of length n;
-* `shifts`: a vector of length nshifts.
+* `shifts`: a vector of length p.
 
 #### Output arguments
 
-* `x`: a vector of nshifts dense vectors, each one of length n;
+* `x`: a vector of p dense vectors, each one of length n;
 * `stats`: statistics collected on the run in a [`LanczosShiftStats`](@ref) structure.
 
 #### References

--- a/src/cgls.jl
+++ b/src/cgls.jl
@@ -58,12 +58,12 @@ and `false` otherwise.
 
 #### Input arguments
 
-* `A`: a linear operator that models a matrix of dimension n × m.
+* `A`: a linear operator that models a matrix of dimension n × m;
 * `b`: a vector of length n.
 
 #### Output arguments
 
-* `x`: a dense vector of length m.
+* `x`: a dense vector of length m;
 * `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
 
 #### References

--- a/src/cgls.jl
+++ b/src/cgls.jl
@@ -56,6 +56,16 @@ but simpler to implement.
 The callback is called as `callback(solver)` and should return `true` if the main loop should terminate,
 and `false` otherwise.
 
+#### Input arguments
+
+* `A`: a linear operator that models a matrix of dimension n × m.
+* `b`: a vector of length n.
+
+#### Output arguments
+
+* `x`: a dense vector of length m.
+* `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
+
 #### References
 
 * M. R. Hestenes and E. Stiefel. [*Methods of conjugate gradients for solving linear systems*](https://doi.org/10.6028/jres.049.044), Journal of Research of the National Bureau of Standards, 49(6), pp. 409--436, 1952.

--- a/src/cgls.jl
+++ b/src/cgls.jl
@@ -42,7 +42,7 @@ Solve the regularized linear least-squares problem
 
     minimize ‖b - Ax‖₂² + λ‖x‖₂²
 
-using the Conjugate Gradient (CG) method, where λ ≥ 0 is a regularization
+of size n × m using the Conjugate Gradient (CG) method, where λ ≥ 0 is a regularization
 parameter. This method is equivalent to applying CG to the normal equations
 
     (AᴴA + λI) x = Aᴴb

--- a/src/cgls.jl
+++ b/src/cgls.jl
@@ -42,7 +42,7 @@ Solve the regularized linear least-squares problem
 
     minimize ‖b - Ax‖₂² + λ‖x‖₂²
 
-of size n × m using the Conjugate Gradient (CG) method, where λ ≥ 0 is a regularization
+of size m × n using the Conjugate Gradient (CG) method, where λ ≥ 0 is a regularization
 parameter. This method is equivalent to applying CG to the normal equations
 
     (AᴴA + λI) x = Aᴴb
@@ -58,12 +58,12 @@ and `false` otherwise.
 
 #### Input arguments
 
-* `A`: a linear operator that models a matrix of dimension n × m;
-* `b`: a vector of length n.
+* `A`: a linear operator that models a matrix of dimension m × n;
+* `b`: a vector of length m.
 
 #### Output arguments
 
-* `x`: a dense vector of length m;
+* `x`: a dense vector of length n;
 * `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
 
 #### References

--- a/src/cgne.jl
+++ b/src/cgne.jl
@@ -42,7 +42,7 @@ Solve the consistent linear system
 
     Ax + √λs = b
 
-using the Conjugate Gradient (CG) method, where λ ≥ 0 is a regularization
+of size n × m using the Conjugate Gradient (CG) method, where λ ≥ 0 is a regularization
 parameter. This method is equivalent to applying CG to the normal equations
 of the second kind
 

--- a/src/cgne.jl
+++ b/src/cgne.jl
@@ -65,6 +65,16 @@ A preconditioner N may be provided in the form of a linear operator.
 The callback is called as `callback(solver)` and should return `true` if the main loop should terminate,
 and `false` otherwise.
 
+#### Input arguments
+
+* `A`: a linear operator that models a matrix of dimension n × m.
+* `b`: a vector of length n.
+
+#### Output arguments
+
+* `x`: a dense vector of length m.
+* `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
+
 #### References
 
 * J. E. Craig, [*The N-step iteration procedures*](https://doi.org/10.1002/sapm195534164), Journal of Mathematics and Physics, 34(1), pp. 64--73, 1955.

--- a/src/cgne.jl
+++ b/src/cgne.jl
@@ -67,12 +67,12 @@ and `false` otherwise.
 
 #### Input arguments
 
-* `A`: a linear operator that models a matrix of dimension n × m.
+* `A`: a linear operator that models a matrix of dimension n × m;
 * `b`: a vector of length n.
 
 #### Output arguments
 
-* `x`: a dense vector of length m.
+* `x`: a dense vector of length m;
 * `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
 
 #### References

--- a/src/cgne.jl
+++ b/src/cgne.jl
@@ -42,7 +42,7 @@ Solve the consistent linear system
 
     Ax + √λs = b
 
-of size n × m using the Conjugate Gradient (CG) method, where λ ≥ 0 is a regularization
+of size m × n using the Conjugate Gradient (CG) method, where λ ≥ 0 is a regularization
 parameter. This method is equivalent to applying CG to the normal equations
 of the second kind
 
@@ -67,12 +67,12 @@ and `false` otherwise.
 
 #### Input arguments
 
-* `A`: a linear operator that models a matrix of dimension n × m;
-* `b`: a vector of length n.
+* `A`: a linear operator that models a matrix of dimension m × n;
+* `b`: a vector of length m.
 
 #### Output arguments
 
-* `x`: a dense vector of length m;
+* `x`: a dense vector of length n;
 * `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
 
 #### References

--- a/src/cgs.jl
+++ b/src/cgs.jl
@@ -49,6 +49,16 @@ where `kwargs` are the same keyword arguments as above.
 The callback is called as `callback(solver)` and should return `true` if the main loop should terminate,
 and `false` otherwise.
 
+#### Input arguments
+
+* `A`: a linear operator that models a matrix of dimension n.
+* `b`: a vector of length n.
+
+#### Output arguments
+
+* `x`: a dense vector of length n.
+* `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
+
 #### Reference
 
 * P. Sonneveld, [*CGS, A Fast Lanczos-Type Solver for Nonsymmetric Linear systems*](https://doi.org/10.1137/0910004), SIAM Journal on Scientific and Statistical Computing, 10(1), pp. 36--52, 1989.

--- a/src/cgs.jl
+++ b/src/cgs.jl
@@ -51,12 +51,12 @@ and `false` otherwise.
 
 #### Input arguments
 
-* `A`: a linear operator that models a matrix of dimension n.
+* `A`: a linear operator that models a matrix of dimension n;
 * `b`: a vector of length n.
 
 #### Output arguments
 
-* `x`: a dense vector of length n.
+* `x`: a dense vector of length n;
 * `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
 
 #### Reference

--- a/src/cgs.jl
+++ b/src/cgs.jl
@@ -19,7 +19,7 @@ export cgs, cgs!
 `T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
 `FC` is `T` or `Complex{T}`.
 
-Solve the consistent linear system Ax = b using conjugate gradient squared algorithm.
+Solve the consistent linear system Ax = b of size n using CGS.
 CGS requires two initial vectors `b` and `c`.
 The relation `bᴴc ≠ 0` must be satisfied and by default `c = b`.
 

--- a/src/cr.jl
+++ b/src/cr.jl
@@ -23,16 +23,16 @@ export cr, cr!
 `T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
 `FC` is `T` or `Complex{T}`.
 
-A truncated version of Stiefel’s Conjugate Residual method to solve the symmetric linear system Ax = b or the least-squares problem min ‖b - Ax‖.
-The matrix A must be positive semi-definite.
+A truncated version of Stiefel’s Conjugate Residual method to solve the Hermitian linear system Ax = b
+of size n or the least-squares problem min ‖b - Ax‖ if A is singular.
+The matrix A must be Hermitian semi-definite.
 
-A preconditioner M may be provided in the form of a linear operator and is assumed to be symmetric and positive definite.
+A preconditioner M may be provided in the form of a linear operator and is assumed to be Hermitian and positive definite.
 M also indicates the weighted norm in which residuals are measured.
 
 In a linesearch context, 'linesearch' must be set to 'true'.
 
-If `itmax=0`, the default number of iterations is set to `2 * n`,
-with `n = length(b)`.
+If `itmax=0`, the default number of iterations is set to `2 * n`.
 
 CR can be warm-started from an initial guess `x0` with
 

--- a/src/cr.jl
+++ b/src/cr.jl
@@ -43,6 +43,16 @@ where `kwargs` are the same keyword arguments as above.
 The callback is called as `callback(solver)` and should return `true` if the main loop should terminate,
 and `false` otherwise.
 
+#### Input arguments
+
+* `A`: a linear operator that models a Hermitian positive definite matrix of dimension n.
+* `b`: a vector of length n.
+
+#### Output arguments
+
+* `x`: a dense vector of length n.
+* `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
+
 #### References
 
 * M. R. Hestenes and E. Stiefel, [*Methods of conjugate gradients for solving linear systems*](https://doi.org/10.6028/jres.049.044), Journal of Research of the National Bureau of Standards, 49(6), pp. 409--436, 1952.

--- a/src/cr.jl
+++ b/src/cr.jl
@@ -45,12 +45,12 @@ and `false` otherwise.
 
 #### Input arguments
 
-* `A`: a linear operator that models a Hermitian positive definite matrix of dimension n.
+* `A`: a linear operator that models a Hermitian positive definite matrix of dimension n;
 * `b`: a vector of length n.
 
 #### Output arguments
 
-* `x`: a dense vector of length n.
+* `x`: a dense vector of length n;
 * `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
 
 #### References

--- a/src/craig.jl
+++ b/src/craig.jl
@@ -47,7 +47,7 @@ Find the least-norm solution of the consistent linear system
 
     Ax + λ²y = b
 
-using the Golub-Kahan implementation of Craig's method, where λ ≥ 0 is a
+of size n × m using the Golub-Kahan implementation of Craig's method, where λ ≥ 0 is a
 regularization parameter. This method is equivalent to CGNE but is more
 stable.
 

--- a/src/craig.jl
+++ b/src/craig.jl
@@ -47,7 +47,7 @@ Find the least-norm solution of the consistent linear system
 
     Ax + λ²y = b
 
-of size n × m using the Golub-Kahan implementation of Craig's method, where λ ≥ 0 is a
+of size m × n using the Golub-Kahan implementation of Craig's method, where λ ≥ 0 is a
 regularization parameter. This method is equivalent to CGNE but is more
 stable.
 
@@ -91,13 +91,13 @@ and `false` otherwise.
 
 #### Input arguments
 
-* `A`: a linear operator that models a matrix of dimension n × m;
-* `b`: a vector of length n.
+* `A`: a linear operator that models a matrix of dimension m × n;
+* `b`: a vector of length m.
 
 #### Output arguments
 
-* `x`: a dense vector of length m;
-* `y`: a dense vector of length n;
+* `x`: a dense vector of length n;
+* `y`: a dense vector of length m;
 * `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
 
 #### References

--- a/src/craig.jl
+++ b/src/craig.jl
@@ -89,6 +89,17 @@ In this implementation, both the x and y-parts of the solution are returned.
 The callback is called as `callback(solver)` and should return `true` if the main loop should terminate,
 and `false` otherwise.
 
+#### Input arguments
+
+* `A`: a linear operator that models a matrix of dimension n × m.
+* `b`: a vector of length n.
+
+#### Output arguments
+
+* `x`: a dense vector of length m.
+* `y`: a dense vector of length n.
+* `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
+
 #### References
 
 * C. C. Paige and M. A. Saunders, [*LSQR: An Algorithm for Sparse Linear Equations and Sparse Least Squares*](https://doi.org/10.1145/355984.355989), ACM Transactions on Mathematical Software, 8(1), pp. 43--71, 1982.

--- a/src/craig.jl
+++ b/src/craig.jl
@@ -91,13 +91,13 @@ and `false` otherwise.
 
 #### Input arguments
 
-* `A`: a linear operator that models a matrix of dimension n × m.
+* `A`: a linear operator that models a matrix of dimension n × m;
 * `b`: a vector of length n.
 
 #### Output arguments
 
-* `x`: a dense vector of length m.
-* `y`: a dense vector of length n.
+* `x`: a dense vector of length m;
+* `y`: a dense vector of length n;
 * `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
 
 #### References

--- a/src/craigmr.jl
+++ b/src/craigmr.jl
@@ -40,7 +40,7 @@ Solve the consistent linear system
 
     Ax + λ²y = b
 
-of size n × m using the CRAIGMR method, where λ ≥ 0 is a regularization parameter.
+of size m × n using the CRAIGMR method, where λ ≥ 0 is a regularization parameter.
 This method is equivalent to applying the Conjugate Residuals method
 to the normal equations of the second kind
 
@@ -87,13 +87,13 @@ and `false` otherwise.
 
 #### Input arguments
 
-* `A`: a linear operator that models a matrix of dimension n × m;
-* `b`: a vector of length n.
+* `A`: a linear operator that models a matrix of dimension m × n;
+* `b`: a vector of length m.
 
 #### Output arguments
 
-* `x`: a dense vector of length m;
-* `y`: a dense vector of length n;
+* `x`: a dense vector of length n;
+* `y`: a dense vector of length m;
 * `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
 
 #### References

--- a/src/craigmr.jl
+++ b/src/craigmr.jl
@@ -85,6 +85,17 @@ returned.
 The callback is called as `callback(solver)` and should return `true` if the main loop should terminate,
 and `false` otherwise.
 
+#### Input arguments
+
+* `A`: a linear operator that models a matrix of dimension n × m.
+* `b`: a vector of length n.
+
+#### Output arguments
+
+* `x`: a dense vector of length m.
+* `y`: a dense vector of length n.
+* `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
+
 #### References
 
 * D. Orban and M. Arioli. [*Iterative Solution of Symmetric Quasi-Definite Linear Systems*](https://doi.org/10.1137/1.9781611974737), Volume 3 of Spotlights. SIAM, Philadelphia, PA, 2017.

--- a/src/craigmr.jl
+++ b/src/craigmr.jl
@@ -40,7 +40,7 @@ Solve the consistent linear system
 
     Ax + λ²y = b
 
-using the CRAIGMR method, where λ ≥ 0 is a regularization parameter.
+of size n × m using the CRAIGMR method, where λ ≥ 0 is a regularization parameter.
 This method is equivalent to applying the Conjugate Residuals method
 to the normal equations of the second kind
 

--- a/src/craigmr.jl
+++ b/src/craigmr.jl
@@ -87,13 +87,13 @@ and `false` otherwise.
 
 #### Input arguments
 
-* `A`: a linear operator that models a matrix of dimension n × m.
+* `A`: a linear operator that models a matrix of dimension n × m;
 * `b`: a vector of length n.
 
 #### Output arguments
 
-* `x`: a dense vector of length m.
-* `y`: a dense vector of length n.
+* `x`: a dense vector of length m;
+* `y`: a dense vector of length n;
 * `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
 
 #### References

--- a/src/crls.jl
+++ b/src/crls.jl
@@ -50,12 +50,12 @@ and `false` otherwise.
 
 #### Input arguments
 
-* `A`: a linear operator that models a matrix of dimension n × m.
+* `A`: a linear operator that models a matrix of dimension n × m;
 * `b`: a vector of length n.
 
 #### Output arguments
 
-* `x`: a dense vector of length m.
+* `x`: a dense vector of length m;
 * `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
 
 #### Reference

--- a/src/crls.jl
+++ b/src/crls.jl
@@ -34,8 +34,8 @@ Solve the linear least-squares problem
 
     minimize ‖b - Ax‖₂² + λ‖x‖₂²
 
-using the Conjugate Residuals (CR) method. This method is equivalent to
-applying MINRES to the normal equations
+of size n × m using the Conjugate Residuals (CR) method.
+This method is equivalent to applying MINRES to the normal equations
 
     (AᴴA + λI) x = Aᴴb.
 

--- a/src/crls.jl
+++ b/src/crls.jl
@@ -48,6 +48,16 @@ but simpler to implement.
 The callback is called as `callback(solver)` and should return `true` if the main loop should terminate,
 and `false` otherwise.
 
+#### Input arguments
+
+* `A`: a linear operator that models a matrix of dimension n × m.
+* `b`: a vector of length n.
+
+#### Output arguments
+
+* `x`: a dense vector of length m.
+* `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
+
 #### Reference
 
 * D. C.-L. Fong, *Minimum-Residual Methods for Sparse, Least-Squares using Golubg-Kahan Bidiagonalization*, Ph.D. Thesis, Stanford University, 2011.

--- a/src/crls.jl
+++ b/src/crls.jl
@@ -34,7 +34,7 @@ Solve the linear least-squares problem
 
     minimize ‖b - Ax‖₂² + λ‖x‖₂²
 
-of size n × m using the Conjugate Residuals (CR) method.
+of size m × n using the Conjugate Residuals (CR) method.
 This method is equivalent to applying MINRES to the normal equations
 
     (AᴴA + λI) x = Aᴴb.
@@ -50,12 +50,12 @@ and `false` otherwise.
 
 #### Input arguments
 
-* `A`: a linear operator that models a matrix of dimension n × m;
-* `b`: a vector of length n.
+* `A`: a linear operator that models a matrix of dimension m × n;
+* `b`: a vector of length m.
 
 #### Output arguments
 
-* `x`: a dense vector of length m;
+* `x`: a dense vector of length n;
 * `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
 
 #### Reference

--- a/src/crmr.jl
+++ b/src/crmr.jl
@@ -63,6 +63,16 @@ A preconditioner N may be provided.
 The callback is called as `callback(solver)` and should return `true` if the main loop should terminate,
 and `false` otherwise.
 
+#### Input arguments
+
+* `A`: a linear operator that models a matrix of dimension n × m.
+* `b`: a vector of length n.
+
+#### Output arguments
+
+* `x`: a dense vector of length m.
+* `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
+
 #### References
 
 * D. Orban and M. Arioli, [*Iterative Solution of Symmetric Quasi-Definite Linear Systems*](https://doi.org/10.1137/1.9781611974737), Volume 3 of Spotlights. SIAM, Philadelphia, PA, 2017.

--- a/src/crmr.jl
+++ b/src/crmr.jl
@@ -40,7 +40,7 @@ Solve the consistent linear system
 
     Ax + √λs = b
 
-of size n × m using the Conjugate Residual (CR) method, where λ ≥ 0 is a regularization
+of size m × n using the Conjugate Residual (CR) method, where λ ≥ 0 is a regularization
 parameter. This method is equivalent to applying CR to the normal equations
 of the second kind
 
@@ -65,12 +65,12 @@ and `false` otherwise.
 
 #### Input arguments
 
-* `A`: a linear operator that models a matrix of dimension n × m;
-* `b`: a vector of length n.
+* `A`: a linear operator that models a matrix of dimension m × n;
+* `b`: a vector of length m.
 
 #### Output arguments
 
-* `x`: a dense vector of length m;
+* `x`: a dense vector of length n;
 * `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
 
 #### References

--- a/src/crmr.jl
+++ b/src/crmr.jl
@@ -40,7 +40,7 @@ Solve the consistent linear system
 
     Ax + √λs = b
 
-using the Conjugate Residual (CR) method, where λ ≥ 0 is a regularization
+of size n × m using the Conjugate Residual (CR) method, where λ ≥ 0 is a regularization
 parameter. This method is equivalent to applying CR to the normal equations
 of the second kind
 

--- a/src/crmr.jl
+++ b/src/crmr.jl
@@ -65,12 +65,12 @@ and `false` otherwise.
 
 #### Input arguments
 
-* `A`: a linear operator that models a matrix of dimension n × m.
+* `A`: a linear operator that models a matrix of dimension n × m;
 * `b`: a vector of length n.
 
 #### Output arguments
 
-* `x`: a dense vector of length m.
+* `x`: a dense vector of length m;
 * `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
 
 #### References

--- a/src/diom.jl
+++ b/src/diom.jl
@@ -20,7 +20,7 @@ export diom, diom!
 `T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
 `FC` is `T` or `Complex{T}`.
 
-Solve the consistent linear system Ax = b using DIOM.
+Solve the consistent linear system Ax = b of size n using DIOM.
 
 DIOM only orthogonalizes the new vectors of the Krylov basis against the `memory` most recent vectors.
 If CG is well defined on `Ax = b` and `memory = 2`, DIOM is theoretically equivalent to CG.

--- a/src/diom.jl
+++ b/src/diom.jl
@@ -45,12 +45,12 @@ and `false` otherwise.
 
 #### Input arguments
 
-* `A`: a linear operator that models a matrix of dimension n.
+* `A`: a linear operator that models a matrix of dimension n;
 * `b`: a vector of length n.
 
 #### Output arguments
 
-* `x`: a dense vector of length n.
+* `x`: a dense vector of length n;
 * `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
 
 #### Reference

--- a/src/diom.jl
+++ b/src/diom.jl
@@ -43,6 +43,16 @@ where `kwargs` are the same keyword arguments as above.
 The callback is called as `callback(solver)` and should return `true` if the main loop should terminate,
 and `false` otherwise.
 
+#### Input arguments
+
+* `A`: a linear operator that models a matrix of dimension n.
+* `b`: a vector of length n.
+
+#### Output arguments
+
+* `x`: a dense vector of length n.
+* `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
+
 #### Reference
 
 * Y. Saad, [*Practical use of some krylov subspace methods for solving indefinite and nonsymmetric linear systems*](https://doi.org/10.1137/0905015), SIAM journal on scientific and statistical computing, 5(1), pp. 203--228, 1984.

--- a/src/dqgmres.jl
+++ b/src/dqgmres.jl
@@ -43,6 +43,16 @@ where `kwargs` are the same keyword arguments as above.
 The callback is called as `callback(solver)` and should return `true` if the main loop should terminate,
 and `false` otherwise.
 
+#### Input arguments
+
+* `A`: a linear operator that models a matrix of dimension n.
+* `b`: a vector of length n.
+
+#### Output arguments
+
+* `x`: a dense vector of length n.
+* `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
+
 #### Reference
 
 * Y. Saad and K. Wu, [*DQGMRES: a quasi minimal residual algorithm based on incomplete orthogonalization*](https://doi.org/10.1002/(SICI)1099-1506(199607/08)3:4%3C329::AID-NLA86%3E3.0.CO;2-8), Numerical Linear Algebra with Applications, Vol. 3(4), pp. 329--343, 1996.

--- a/src/dqgmres.jl
+++ b/src/dqgmres.jl
@@ -20,7 +20,7 @@ export dqgmres, dqgmres!
 `T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
 `FC` is `T` or `Complex{T}`.
 
-Solve the consistent linear system Ax = b using DQGMRES.
+Solve the consistent linear system Ax = b of size n using DQGMRES.
 
 DQGMRES algorithm is based on the incomplete Arnoldi orthogonalization process
 and computes a sequence of approximate solutions with the quasi-minimal residual property.

--- a/src/dqgmres.jl
+++ b/src/dqgmres.jl
@@ -45,12 +45,12 @@ and `false` otherwise.
 
 #### Input arguments
 
-* `A`: a linear operator that models a matrix of dimension n.
+* `A`: a linear operator that models a matrix of dimension n;
 * `b`: a vector of length n.
 
 #### Output arguments
 
-* `x`: a dense vector of length n.
+* `x`: a dense vector of length n;
 * `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
 
 #### Reference

--- a/src/fgmres.jl
+++ b/src/fgmres.jl
@@ -46,6 +46,16 @@ where `kwargs` are the same keyword arguments as above.
 The callback is called as `callback(solver)` and should return `true` if the main loop should terminate,
 and `false` otherwise.
 
+#### Input arguments
+
+* `A`: a linear operator that models a matrix of dimension n.
+* `b`: a vector of length n.
+
+#### Output arguments
+
+* `x`: a dense vector of length n.
+* `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
+
 #### Reference
 
 * Y. Saad, [*A Flexible Inner-Outer Preconditioned GMRES Algorithm*](https://doi.org/10.1137/0914028), SIAM Journal on Scientific Computing, Vol. 14(2), pp. 461--469, 1993.

--- a/src/fgmres.jl
+++ b/src/fgmres.jl
@@ -48,12 +48,12 @@ and `false` otherwise.
 
 #### Input arguments
 
-* `A`: a linear operator that models a matrix of dimension n.
+* `A`: a linear operator that models a matrix of dimension n;
 * `b`: a vector of length n.
 
 #### Output arguments
 
-* `x`: a dense vector of length n.
+* `x`: a dense vector of length n;
 * `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
 
 #### Reference

--- a/src/fgmres.jl
+++ b/src/fgmres.jl
@@ -20,7 +20,7 @@ export fgmres, fgmres!
 `T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
 `FC` is `T` or `Complex{T}`.
 
-Solve the linear system Ax = b using FGMRES.
+Solve the linear system Ax = b of size n using FGMRES.
 
 FGMRES computes a sequence of approximate solutions with minimum residual.
 FGMRES is a variant of GMRES that allows changes in the right preconditioner at each iteration.

--- a/src/fom.jl
+++ b/src/fom.jl
@@ -40,6 +40,16 @@ where `kwargs` are the same keyword arguments as above.
 The callback is called as `callback(solver)` and should return `true` if the main loop should terminate,
 and `false` otherwise.
 
+#### Input arguments
+
+* `A`: a linear operator that models a matrix of dimension n.
+* `b`: a vector of length n.
+
+#### Output arguments
+
+* `x`: a dense vector of length n.
+* `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
+
 #### Reference
 
 * Y. Saad, [*Krylov subspace methods for solving unsymmetric linear systems*](https://doi.org/10.1090/S0025-5718-1981-0616364-6), Mathematics of computation, Vol. 37(155), pp. 105--126, 1981.

--- a/src/fom.jl
+++ b/src/fom.jl
@@ -20,7 +20,7 @@ export fom, fom!
 `T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
 `FC` is `T` or `Complex{T}`.
 
-Solve the linear system Ax = b using FOM.
+Solve the linear system Ax = b of size n using FOM.
 
 FOM algorithm is based on the Arnoldi process and a Galerkin condition.
 

--- a/src/fom.jl
+++ b/src/fom.jl
@@ -42,12 +42,12 @@ and `false` otherwise.
 
 #### Input arguments
 
-* `A`: a linear operator that models a matrix of dimension n.
+* `A`: a linear operator that models a matrix of dimension n;
 * `b`: a vector of length n.
 
 #### Output arguments
 
-* `x`: a dense vector of length n.
+* `x`: a dense vector of length n;
 * `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
 
 #### Reference

--- a/src/gmres.jl
+++ b/src/gmres.jl
@@ -40,6 +40,16 @@ where `kwargs` are the same keyword arguments as above.
 The callback is called as `callback(solver)` and should return `true` if the main loop should terminate,
 and `false` otherwise.
 
+#### Input arguments
+
+* `A`: a linear operator that models a matrix of dimension n.
+* `b`: a vector of length n.
+
+#### Output arguments
+
+* `x`: a dense vector of length n.
+* `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
+
 #### Reference
 
 * Y. Saad and M. H. Schultz, [*GMRES: A Generalized Minimal Residual Algorithm for Solving Nonsymmetric Linear Systems*](https://doi.org/10.1137/0907058), SIAM Journal on Scientific and Statistical Computing, Vol. 7(3), pp. 856--869, 1986.

--- a/src/gmres.jl
+++ b/src/gmres.jl
@@ -20,7 +20,7 @@ export gmres, gmres!
 `T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
 `FC` is `T` or `Complex{T}`.
 
-Solve the linear system Ax = b using GMRES.
+Solve the linear system Ax = b of size n using GMRES.
 
 GMRES algorithm is based on the Arnoldi process and computes a sequence of approximate solutions with the minimum residual.
 

--- a/src/gmres.jl
+++ b/src/gmres.jl
@@ -42,12 +42,12 @@ and `false` otherwise.
 
 #### Input arguments
 
-* `A`: a linear operator that models a matrix of dimension n.
+* `A`: a linear operator that models a matrix of dimension n;
 * `b`: a vector of length n.
 
 #### Output arguments
 
-* `x`: a dense vector of length n.
+* `x`: a dense vector of length n;
 * `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
 
 #### Reference

--- a/src/gpmr.jl
+++ b/src/gpmr.jl
@@ -22,10 +22,11 @@ export gpmr, gpmr!
 `T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
 `FC` is `T` or `Complex{T}`.
 
+Given matrices `A` of dimension m × n and `B` of dimension n × m,
 GPMR solves the unsymmetric partitioned linear system
 
-    [ λI   A ] [ x ] = [ b ]
-    [  B  μI ] [ y ]   [ c ],
+    [ λIₘ   A  ] [ x ] = [ b ]
+    [  B   μIₙ ] [ y ]   [ c ],
 
 of size (n+m) × (n+m) where λ and μ are real or complex numbers.
 `A` can have any shape and `B` has the shape of `Aᴴ`.
@@ -69,15 +70,15 @@ and `false` otherwise.
 
 #### Input arguments
 
-* `A`: a linear operator that models a matrix of dimension n × m;
-* `B`: a linear operator that models a matrix of dimension m × n;
-* `b`: a vector of length n;
-* `c`: a vector of length m.
+* `A`: a linear operator that models a matrix of dimension m × n;
+* `B`: a linear operator that models a matrix of dimension n × m;
+* `b`: a vector of length m;
+* `c`: a vector of length n.
 
 #### Output arguments
 
-* `x`: a dense vector of length n;
-* `y`: a dense vector of length m;
+* `x`: a dense vector of length m;
+* `y`: a dense vector of length n;
 * `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
 
 #### Reference

--- a/src/gpmr.jl
+++ b/src/gpmr.jl
@@ -27,7 +27,7 @@ GPMR solves the unsymmetric partitioned linear system
     [ λI   A ] [ x ] = [ b ]
     [  B  μI ] [ y ]   [ c ],
 
-where λ and μ are real or complex numbers.
+of size (n+m) × (n+m) where λ and μ are real or complex numbers.
 `A` can have any shape and `B` has the shape of `Aᴴ`.
 `A`, `B`, `b` and `c` must be all nonzero.
 

--- a/src/gpmr.jl
+++ b/src/gpmr.jl
@@ -67,6 +67,19 @@ where `kwargs` are the same keyword arguments as above.
 The callback is called as `callback(solver)` and should return `true` if the main loop should terminate,
 and `false` otherwise.
 
+#### Input arguments
+
+* `A`: a linear operator that models a matrix of dimension n × m.
+* `B`: a linear operator that models a matrix of dimension m × n.
+* `b`: a vector of length n.
+* `c`: a vector of length m.
+
+#### Output arguments
+
+* `x`: a dense vector of length n.
+* `y`: a dense vector of length m.
+* `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
+
 #### Reference
 
 * A. Montoison and D. Orban, [*GPMR: An Iterative Method for Unsymmetric Partitioned Linear Systems*](https://dx.doi.org/10.13140/RG.2.2.24069.68326), Cahier du GERAD G-2021-62, GERAD, Montréal, 2021.

--- a/src/gpmr.jl
+++ b/src/gpmr.jl
@@ -69,15 +69,15 @@ and `false` otherwise.
 
 #### Input arguments
 
-* `A`: a linear operator that models a matrix of dimension n × m.
-* `B`: a linear operator that models a matrix of dimension m × n.
-* `b`: a vector of length n.
+* `A`: a linear operator that models a matrix of dimension n × m;
+* `B`: a linear operator that models a matrix of dimension m × n;
+* `b`: a vector of length n;
 * `c`: a vector of length m.
 
 #### Output arguments
 
-* `x`: a dense vector of length n.
-* `y`: a dense vector of length m.
+* `x`: a dense vector of length n;
+* `y`: a dense vector of length m;
 * `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
 
 #### Reference

--- a/src/krylov_processes.jl
+++ b/src/krylov_processes.jl
@@ -3,13 +3,13 @@ export hermitian_lanczos, nonhermitian_lanczos, arnoldi, golub_kahan, saunders_s
 """
     V, T = hermitian_lanczos(A, b, k)
 
-#### Input arguments:
+#### Input arguments
 
 * `A`: a linear operator that models a Hermitian matrix of dimension n.
 * `b`: a vector of length n.
 * `k`: the number of iterations of the Hermitian Lanczos process.
 
-#### Output arguments:
+#### Output arguments
 
 * `V`: a dense n × (k+1) matrix.
 * `T`: a sparse (k+1) × k tridiagonal matrix.
@@ -71,14 +71,14 @@ end
 """
     V, T, U, Tᴴ = nonhermitian_lanczos(A, b, c, k)
 
-#### Input arguments:
+#### Input arguments
 
 * `A`: a linear operator that models a square matrix of dimension n.
 * `b`: a vector of length n.
 * `c`: a vector of length n.
 * `k`: the number of iterations of the non-Hermitian Lanczos process.
 
-#### Output arguments:
+#### Output arguments
 
 * `V`: a dense n × (k+1) matrix.
 * `T`: a sparse (k+1) × k tridiagonal matrix.
@@ -163,13 +163,13 @@ end
 """
     V, H = arnoldi(A, b, k)
 
-#### Input arguments:
+#### Input arguments
 
 * `A`: a linear operator that models a square matrix of dimension n.
 * `b`: a vector of length n.
 * `k`: the number of iterations of the Arnoldi process.
 
-#### Output arguments:
+#### Output arguments
 
 * `V`: a dense n × (k+1) matrix.
 * `H`: a sparse (k+1) × k upper Hessenberg matrix.
@@ -222,13 +222,13 @@ end
 """
     V, U, L = golub_kahan(A, b, k)
 
-#### Input arguments:
+#### Input arguments
 
 * `A`: a linear operator that models a matrix of dimension n × m.
 * `b`: a vector of length n.
 * `k`: the number of iterations of the Golub-Kahan process.
 
-#### Output arguments:
+#### Output arguments
 
 * `V`: a dense m × (k+1) matrix.
 * `U`: a dense n × (k+1) matrix.
@@ -295,14 +295,14 @@ end
 """
     V, T, U, Tᴴ = saunders_simon_yip(A, b, c, k)
 
-#### Input arguments:
+#### Input arguments
 
 * `A`: a linear operator that models a matrix of dimension n × m.
 * `b`: a vector of length n.
 * `c`: a vector of length m.
 * `k`: the number of iterations of the Saunders-Simon-Yip process.
 
-#### Output arguments:
+#### Output arguments
 
 * `V`: a dense n × (k+1) matrix.
 * `T`: a sparse (k+1) × k tridiagonal matrix.
@@ -385,7 +385,7 @@ end
 """
     V, H, U, F = montoison_orban(A, B, b, c, k)
 
-#### Input arguments:
+#### Input arguments
 
 * `A`: a linear operator that models a matrix of dimension n × m.
 * `B`: a linear operator that models a matrix of dimension m × n.
@@ -393,7 +393,7 @@ end
 * `c`: a vector of length m.
 * `k`: the number of iterations of the Montoison-Orban process.
 
-#### Output arguments:
+#### Output arguments
 
 * `V`: a dense n × (k+1) matrix.
 * `H`: a sparse (k+1) × k upper Hessenberg matrix.

--- a/src/krylov_processes.jl
+++ b/src/krylov_processes.jl
@@ -224,14 +224,14 @@ end
 
 #### Input arguments
 
-* `A`: a linear operator that models a matrix of dimension n × m;
-* `b`: a vector of length n;
+* `A`: a linear operator that models a matrix of dimension m × n;
+* `b`: a vector of length m;
 * `k`: the number of iterations of the Golub-Kahan process.
 
 #### Output arguments
 
-* `V`: a dense m × (k+1) matrix;
-* `U`: a dense n × (k+1) matrix;
+* `V`: a dense n × (k+1) matrix;
+* `U`: a dense m × (k+1) matrix;
 * `L`: a sparse (k+1) × (k+1) lower bidiagonal matrix.
 
 #### Reference
@@ -297,16 +297,16 @@ end
 
 #### Input arguments
 
-* `A`: a linear operator that models a matrix of dimension n × m;
-* `b`: a vector of length n;
-* `c`: a vector of length m;
+* `A`: a linear operator that models a matrix of dimension m × n;
+* `b`: a vector of length m;
+* `c`: a vector of length n;
 * `k`: the number of iterations of the Saunders-Simon-Yip process.
 
 #### Output arguments
 
-* `V`: a dense n × (k+1) matrix;
+* `V`: a dense m × (k+1) matrix;
 * `T`: a sparse (k+1) × k tridiagonal matrix;
-* `U`: a dense m × (k+1) matrix;
+* `U`: a dense n × (k+1) matrix;
 * `Tᴴ`: a sparse (k+1) × k tridiagonal matrix.
 
 #### Reference
@@ -387,17 +387,17 @@ end
 
 #### Input arguments
 
-* `A`: a linear operator that models a matrix of dimension n × m;
-* `B`: a linear operator that models a matrix of dimension m × n;
-* `b`: a vector of length n;
-* `c`: a vector of length m;
+* `A`: a linear operator that models a matrix of dimension m × n;
+* `B`: a linear operator that models a matrix of dimension n × m;
+* `b`: a vector of length m;
+* `c`: a vector of length n;
 * `k`: the number of iterations of the Montoison-Orban process.
 
 #### Output arguments
 
-* `V`: a dense n × (k+1) matrix;
+* `V`: a dense m × (k+1) matrix;
 * `H`: a sparse (k+1) × k upper Hessenberg matrix;
-* `U`: a dense m × (k+1) matrix;
+* `U`: a dense n × (k+1) matrix;
 * `F`: a sparse (k+1) × k upper Hessenberg matrix.
 
 #### Reference

--- a/src/krylov_processes.jl
+++ b/src/krylov_processes.jl
@@ -5,13 +5,13 @@ export hermitian_lanczos, nonhermitian_lanczos, arnoldi, golub_kahan, saunders_s
 
 #### Input arguments
 
-* `A`: a linear operator that models a Hermitian matrix of dimension n.
-* `b`: a vector of length n.
+* `A`: a linear operator that models a Hermitian matrix of dimension n;
+* `b`: a vector of length n;
 * `k`: the number of iterations of the Hermitian Lanczos process.
 
 #### Output arguments
 
-* `V`: a dense n × (k+1) matrix.
+* `V`: a dense n × (k+1) matrix;
 * `T`: a sparse (k+1) × k tridiagonal matrix.
 
 #### Reference
@@ -73,16 +73,16 @@ end
 
 #### Input arguments
 
-* `A`: a linear operator that models a square matrix of dimension n.
-* `b`: a vector of length n.
-* `c`: a vector of length n.
+* `A`: a linear operator that models a square matrix of dimension n;
+* `b`: a vector of length n;
+* `c`: a vector of length n;
 * `k`: the number of iterations of the non-Hermitian Lanczos process.
 
 #### Output arguments
 
-* `V`: a dense n × (k+1) matrix.
-* `T`: a sparse (k+1) × k tridiagonal matrix.
-* `U`: a dense n × (k+1) matrix.
+* `V`: a dense n × (k+1) matrix;
+* `T`: a sparse (k+1) × k tridiagonal matrix;
+* `U`: a dense n × (k+1) matrix;
 * `Tᴴ`: a sparse (k+1) × k tridiagonal matrix.
 
 #### Reference
@@ -165,13 +165,13 @@ end
 
 #### Input arguments
 
-* `A`: a linear operator that models a square matrix of dimension n.
-* `b`: a vector of length n.
+* `A`: a linear operator that models a square matrix of dimension n;
+* `b`: a vector of length n;
 * `k`: the number of iterations of the Arnoldi process.
 
 #### Output arguments
 
-* `V`: a dense n × (k+1) matrix.
+* `V`: a dense n × (k+1) matrix;
 * `H`: a sparse (k+1) × k upper Hessenberg matrix.
 
 #### Reference
@@ -224,14 +224,14 @@ end
 
 #### Input arguments
 
-* `A`: a linear operator that models a matrix of dimension n × m.
-* `b`: a vector of length n.
+* `A`: a linear operator that models a matrix of dimension n × m;
+* `b`: a vector of length n;
 * `k`: the number of iterations of the Golub-Kahan process.
 
 #### Output arguments
 
-* `V`: a dense m × (k+1) matrix.
-* `U`: a dense n × (k+1) matrix.
+* `V`: a dense m × (k+1) matrix;
+* `U`: a dense n × (k+1) matrix;
 * `L`: a sparse (k+1) × (k+1) lower bidiagonal matrix.
 
 #### Reference
@@ -297,16 +297,16 @@ end
 
 #### Input arguments
 
-* `A`: a linear operator that models a matrix of dimension n × m.
-* `b`: a vector of length n.
-* `c`: a vector of length m.
+* `A`: a linear operator that models a matrix of dimension n × m;
+* `b`: a vector of length n;
+* `c`: a vector of length m;
 * `k`: the number of iterations of the Saunders-Simon-Yip process.
 
 #### Output arguments
 
-* `V`: a dense n × (k+1) matrix.
-* `T`: a sparse (k+1) × k tridiagonal matrix.
-* `U`: a dense m × (k+1) matrix.
+* `V`: a dense n × (k+1) matrix;
+* `T`: a sparse (k+1) × k tridiagonal matrix;
+* `U`: a dense m × (k+1) matrix;
 * `Tᴴ`: a sparse (k+1) × k tridiagonal matrix.
 
 #### Reference
@@ -387,17 +387,17 @@ end
 
 #### Input arguments
 
-* `A`: a linear operator that models a matrix of dimension n × m.
-* `B`: a linear operator that models a matrix of dimension m × n.
-* `b`: a vector of length n.
-* `c`: a vector of length m.
+* `A`: a linear operator that models a matrix of dimension n × m;
+* `B`: a linear operator that models a matrix of dimension m × n;
+* `b`: a vector of length n;
+* `c`: a vector of length m;
 * `k`: the number of iterations of the Montoison-Orban process.
 
 #### Output arguments
 
-* `V`: a dense n × (k+1) matrix.
-* `H`: a sparse (k+1) × k upper Hessenberg matrix.
-* `U`: a dense m × (k+1) matrix.
+* `V`: a dense n × (k+1) matrix;
+* `H`: a sparse (k+1) × k upper Hessenberg matrix;
+* `U`: a dense m × (k+1) matrix;
 * `F`: a sparse (k+1) × k upper Hessenberg matrix.
 
 #### Reference

--- a/src/lnlq.jl
+++ b/src/lnlq.jl
@@ -84,13 +84,13 @@ and `false` otherwise.
 
 #### Input arguments
 
-* `A`: a linear operator that models a matrix of dimension n × m.
+* `A`: a linear operator that models a matrix of dimension n × m;
 * `b`: a vector of length n.
 
 #### Output arguments
 
-* `x`: a dense vector of length m.
-* `y`: a dense vector of length n.
+* `x`: a dense vector of length m;
+* `y`: a dense vector of length n;
 * `stats`: statistics collected on the run in a [`LNLQStats`](@ref) structure.
 
 #### Reference

--- a/src/lnlq.jl
+++ b/src/lnlq.jl
@@ -38,7 +38,7 @@ Find the least-norm solution of the consistent linear system
 
     Ax + λ²y = b
 
-of size n × m using the LNLQ method, where λ ≥ 0 is a regularization parameter.
+of size m × n using the LNLQ method, where λ ≥ 0 is a regularization parameter.
 
 For a system in the form Ax = b, LNLQ method is equivalent to applying
 SYMMLQ to AAᴴy = b and recovering x = Aᴴy but is more stable.
@@ -84,13 +84,13 @@ and `false` otherwise.
 
 #### Input arguments
 
-* `A`: a linear operator that models a matrix of dimension n × m;
-* `b`: a vector of length n.
+* `A`: a linear operator that models a matrix of dimension m × n;
+* `b`: a vector of length m.
 
 #### Output arguments
 
-* `x`: a dense vector of length m;
-* `y`: a dense vector of length n;
+* `x`: a dense vector of length n;
+* `y`: a dense vector of length m;
 * `stats`: statistics collected on the run in a [`LNLQStats`](@ref) structure.
 
 #### Reference

--- a/src/lnlq.jl
+++ b/src/lnlq.jl
@@ -82,6 +82,17 @@ For instance σ:=(1-1e-7)σₘᵢₙ .
 The callback is called as `callback(solver)` and should return `true` if the main loop should terminate,
 and `false` otherwise.
 
+#### Input arguments
+
+* `A`: a linear operator that models a matrix of dimension n × m.
+* `b`: a vector of length n.
+
+#### Output arguments
+
+* `x`: a dense vector of length m.
+* `y`: a dense vector of length n.
+* `stats`: statistics collected on the run in a [`LNLQStats`](@ref) structure.
+
 #### Reference
 
 * R. Estrin, D. Orban, M.A. Saunders, [*LNLQ: An Iterative Method for Least-Norm Problems with an Error Minimization Property*](https://doi.org/10.1137/18M1194948), SIAM Journal on Matrix Analysis and Applications, 40(3), pp. 1102--1124, 2019.

--- a/src/lnlq.jl
+++ b/src/lnlq.jl
@@ -38,7 +38,7 @@ Find the least-norm solution of the consistent linear system
 
     Ax + λ²y = b
 
-using the LNLQ method, where λ ≥ 0 is a regularization parameter.
+of size n × m using the LNLQ method, where λ ≥ 0 is a regularization parameter.
 
 For a system in the form Ax = b, LNLQ method is equivalent to applying
 SYMMLQ to AAᴴy = b and recovering x = Aᴴy but is more stable.

--- a/src/lslq.jl
+++ b/src/lslq.jl
@@ -38,7 +38,7 @@ Solve the regularized linear least-squares problem
 
     minimize ‖b - Ax‖₂² + λ²‖x‖₂²
 
-using the LSLQ method, where λ ≥ 0 is a regularization parameter.
+of size n × m using the LSLQ method, where λ ≥ 0 is a regularization parameter.
 LSLQ is formally equivalent to applying SYMMLQ to the normal equations
 
     (AᴴA + λ²I) x = Aᴴb

--- a/src/lslq.jl
+++ b/src/lslq.jl
@@ -83,29 +83,29 @@ In this case, `N` can still be specified and indicates the weighted norm in whic
 
 #### Input arguments
 
-* `A`: a linear operator that models a matrix of dimension n × m.
+* `A`: a linear operator that models a matrix of dimension n × m;
 * `b`: a vector of length n.
 
 #### Keyword arguments
 
-* `M`: a symmetric and positive definite dual preconditioner
-* `N`: a symmetric and positive definite primal preconditioner
-* `sqd` indicates that we are solving a symmetric and quasi-definite system with `λ=1`
-* `λ` is a regularization parameter (see the problem statement above)
-* `σ` is an underestimate of the smallest nonzero singular value of `A`---setting `σ` too large will result in an error in the course of the iterations
-* `atol` is a stopping tolerance based on the residual
-* `btol` is a stopping tolerance used to detect zero-residual problems
-* `etol` is a stopping tolerance based on the lower bound on the error
-* `window` is the number of iterations used to accumulate a lower bound on the error
-* `utol` is a stopping tolerance based on the upper bound on the error
-* `transfer_to_lsqr` return the CG solution estimate (i.e., the LSQR point) instead of the LQ estimate
-* `itmax` is the maximum number of iterations (0 means no imposed limit)
-* `conlim` is the limit on the estimated condition number of `A` beyond which the solution will be abandoned
+* `M`: a symmetric and positive definite dual preconditioner;
+* `N`: a symmetric and positive definite primal preconditioner;
+* `sqd` indicates that we are solving a symmetric and quasi-definite system with `λ=1`;
+* `λ` is a regularization parameter (see the problem statement above);
+* `σ` is an underestimate of the smallest nonzero singular value of `A`---setting `σ` too large will result in an error in the course of the iterations;
+* `atol` is a stopping tolerance based on the residual;
+* `btol` is a stopping tolerance used to detect zero-residual problems;
+* `etol` is a stopping tolerance based on the lower bound on the error;
+* `window` is the number of iterations used to accumulate a lower bound on the error;
+* `utol` is a stopping tolerance based on the upper bound on the error;
+* `transfer_to_lsqr` return the CG solution estimate (i.e., the LSQR point) instead of the LQ estimate;
+* `itmax` is the maximum number of iterations (0 means no imposed limit);
+* `conlim` is the limit on the estimated condition number of `A` beyond which the solution will be abandoned;
 * `verbose` determines verbosity.
 
 #### Output arguments
 
-* `x`: a dense vector of length m.
+* `x`: a dense vector of length m;
 * `stats`: statistics collected on the run in a [`LSLQStats`](@ref) structure.
 
 * `stats.err_lbnds` is a vector of lower bounds on the LQ error---the vector is empty if `window` is set to zero

--- a/src/lslq.jl
+++ b/src/lslq.jl
@@ -53,12 +53,6 @@ but is more stable.
 * it is possible to transition cheaply from the LSLQ iterate to the LSQR iterate if there is an advantage (there always is in terms of error)
 * if `A` is rank deficient, identify the minimum least-squares solution
 
-#### Optional arguments
-
-* `M`: a symmetric and positive definite dual preconditioner
-* `N`: a symmetric and positive definite primal preconditioner
-* `sqd` indicates that we are solving a symmetric and quasi-definite system with `λ=1`
-
 If `λ > 0`, we solve the symmetric and quasi-definite system
 
     [ E      A ] [ r ]   [ b ]
@@ -87,6 +81,16 @@ The system above represents the optimality conditions of
 In this case, `N` can still be specified and indicates the weighted norm in which `x` and `Aᴴr` should be measured.
 `r` can be recovered by computing `E⁻¹(b - Ax)`.
 
+#### Input arguments
+
+* `A`: a linear operator that models a matrix of dimension n × m.
+* `b`: a vector of length n.
+
+#### Keyword arguments
+
+* `M`: a symmetric and positive definite dual preconditioner
+* `N`: a symmetric and positive definite primal preconditioner
+* `sqd` indicates that we are solving a symmetric and quasi-definite system with `λ=1`
 * `λ` is a regularization parameter (see the problem statement above)
 * `σ` is an underestimate of the smallest nonzero singular value of `A`---setting `σ` too large will result in an error in the course of the iterations
 * `atol` is a stopping tolerance based on the residual
@@ -99,12 +103,10 @@ In this case, `N` can still be specified and indicates the weighted norm in whic
 * `conlim` is the limit on the estimated condition number of `A` beyond which the solution will be abandoned
 * `verbose` determines verbosity.
 
-#### Return values
+#### Output arguments
 
-`lslq` returns the tuple `(x, stats)` where
-
-* `x` is the LQ solution estimate
-* `stats` collects other statistics on the run in a LSLQStats
+* `x`: a dense vector of length m.
+* `stats`: statistics collected on the run in a [`LSLQStats`](@ref) structure.
 
 * `stats.err_lbnds` is a vector of lower bounds on the LQ error---the vector is empty if `window` is set to zero
 * `stats.err_ubnds_lq` is a vector of upper bounds on the LQ error---the vector is empty if `σ == 0` is left at zero

--- a/src/lslq.jl
+++ b/src/lslq.jl
@@ -38,7 +38,7 @@ Solve the regularized linear least-squares problem
 
     minimize ‖b - Ax‖₂² + λ²‖x‖₂²
 
-of size n × m using the LSLQ method, where λ ≥ 0 is a regularization parameter.
+of size m × n using the LSLQ method, where λ ≥ 0 is a regularization parameter.
 LSLQ is formally equivalent to applying SYMMLQ to the normal equations
 
     (AᴴA + λ²I) x = Aᴴb
@@ -83,8 +83,8 @@ In this case, `N` can still be specified and indicates the weighted norm in whic
 
 #### Input arguments
 
-* `A`: a linear operator that models a matrix of dimension n × m;
-* `b`: a vector of length n.
+* `A`: a linear operator that models a matrix of dimension m × n;
+* `b`: a vector of length m.
 
 #### Keyword arguments
 
@@ -105,7 +105,7 @@ In this case, `N` can still be specified and indicates the weighted norm in whic
 
 #### Output arguments
 
-* `x`: a dense vector of length m;
+* `x`: a dense vector of length n;
 * `stats`: statistics collected on the run in a [`LSLQStats`](@ref) structure.
 
 * `stats.err_lbnds` is a vector of lower bounds on the LQ error---the vector is empty if `window` is set to zero

--- a/src/lsmr.jl
+++ b/src/lsmr.jl
@@ -43,7 +43,7 @@ Solve the regularized linear least-squares problem
 
     minimize ‖b - Ax‖₂² + λ²‖x‖₂²
 
-using the LSMR method, where λ ≥ 0 is a regularization parameter.
+of size n × m using the LSMR method, where λ ≥ 0 is a regularization parameter.
 LSMR is formally equivalent to applying MINRES to the normal equations
 
     (AᴴA + λ²I) x = Aᴴb

--- a/src/lsmr.jl
+++ b/src/lsmr.jl
@@ -43,7 +43,7 @@ Solve the regularized linear least-squares problem
 
     minimize ‖b - Ax‖₂² + λ²‖x‖₂²
 
-of size n × m using the LSMR method, where λ ≥ 0 is a regularization parameter.
+of size m × n using the LSMR method, where λ ≥ 0 is a regularization parameter.
 LSMR is formally equivalent to applying MINRES to the normal equations
 
     (AᴴA + λ²I) x = Aᴴb
@@ -90,12 +90,12 @@ and `false` otherwise.
 
 #### Input arguments
 
-* `A`: a linear operator that models a matrix of dimension n × m;
-* `b`: a vector of length n.
+* `A`: a linear operator that models a matrix of dimension m × n;
+* `b`: a vector of length m.
 
 #### Output arguments
 
-* `x`: a dense vector of length m;
+* `x`: a dense vector of length n;
 * `stats`: statistics collected on the run in a [`LsmrStats`](@ref) structure.
 
 #### Reference

--- a/src/lsmr.jl
+++ b/src/lsmr.jl
@@ -90,12 +90,12 @@ and `false` otherwise.
 
 #### Input arguments
 
-* `A`: a linear operator that models a matrix of dimension n × m.
+* `A`: a linear operator that models a matrix of dimension n × m;
 * `b`: a vector of length n.
 
 #### Output arguments
 
-* `x`: a dense vector of length m.
+* `x`: a dense vector of length m;
 * `stats`: statistics collected on the run in a [`LsmrStats`](@ref) structure.
 
 #### Reference

--- a/src/lsmr.jl
+++ b/src/lsmr.jl
@@ -88,6 +88,16 @@ In this case, `N` can still be specified and indicates the weighted norm in whic
 The callback is called as `callback(solver)` and should return `true` if the main loop should terminate,
 and `false` otherwise.
 
+#### Input arguments
+
+* `A`: a linear operator that models a matrix of dimension n × m.
+* `b`: a vector of length n.
+
+#### Output arguments
+
+* `x`: a dense vector of length m.
+* `stats`: statistics collected on the run in a [`LsmrStats`](@ref) structure.
+
 #### Reference
 
 * D. C.-L. Fong and M. A. Saunders, [*LSMR: An Iterative Algorithm for Sparse Least Squares Problems*](https://doi.org/10.1137/10079687X), SIAM Journal on Scientific Computing, 33(5), pp. 2950--2971, 2011.

--- a/src/lsqr.jl
+++ b/src/lsqr.jl
@@ -85,12 +85,12 @@ and `false` otherwise.
 
 #### Input arguments
 
-* `A`: a linear operator that models a matrix of dimension n × m.
+* `A`: a linear operator that models a matrix of dimension n × m;
 * `b`: a vector of length n.
 
 #### Output arguments
 
-* `x`: a dense vector of length m.
+* `x`: a dense vector of length m;
 * `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
 
 #### Reference

--- a/src/lsqr.jl
+++ b/src/lsqr.jl
@@ -83,6 +83,16 @@ In this case, `N` can still be specified and indicates the weighted norm in whic
 The callback is called as `callback(solver)` and should return `true` if the main loop should terminate,
 and `false` otherwise.
 
+#### Input arguments
+
+* `A`: a linear operator that models a matrix of dimension n × m.
+* `b`: a vector of length n.
+
+#### Output arguments
+
+* `x`: a dense vector of length m.
+* `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
+
 #### Reference
 
 * C. C. Paige and M. A. Saunders, [*LSQR: An Algorithm for Sparse Linear Equations and Sparse Least Squares*](https://doi.org/10.1145/355984.355989), ACM Transactions on Mathematical Software, 8(1), pp. 43--71, 1982.

--- a/src/lsqr.jl
+++ b/src/lsqr.jl
@@ -42,7 +42,7 @@ Solve the regularized linear least-squares problem
 
     minimize ‖b - Ax‖₂² + λ²‖x‖₂²
 
-of size n × m using the LSQR method, where λ ≥ 0 is a regularization parameter.
+of size m × n using the LSQR method, where λ ≥ 0 is a regularization parameter.
 LSQR is formally equivalent to applying CG to the normal equations
 
     (AᴴA + λ²I) x = Aᴴb
@@ -85,12 +85,12 @@ and `false` otherwise.
 
 #### Input arguments
 
-* `A`: a linear operator that models a matrix of dimension n × m;
-* `b`: a vector of length n.
+* `A`: a linear operator that models a matrix of dimension m × n;
+* `b`: a vector of length m.
 
 #### Output arguments
 
-* `x`: a dense vector of length m;
+* `x`: a dense vector of length n;
 * `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
 
 #### Reference

--- a/src/lsqr.jl
+++ b/src/lsqr.jl
@@ -42,7 +42,7 @@ Solve the regularized linear least-squares problem
 
     minimize ‖b - Ax‖₂² + λ²‖x‖₂²
 
-using the LSQR method, where λ ≥ 0 is a regularization parameter.
+of size n × m using the LSQR method, where λ ≥ 0 is a regularization parameter.
 LSQR is formally equivalent to applying CG to the normal equations
 
     (AᴴA + λ²I) x = Aᴴb

--- a/src/minres.jl
+++ b/src/minres.jl
@@ -66,12 +66,12 @@ and `false` otherwise.
 
 #### Input arguments
 
-* `A`: a linear operator that models a Hermitian matrix of dimension n.
+* `A`: a linear operator that models a Hermitian matrix of dimension n;
 * `b`: a vector of length n.
 
 #### Output arguments
 
-* `x`: a dense vector of length n.
+* `x`: a dense vector of length n;
 * `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
 
 #### Reference

--- a/src/minres.jl
+++ b/src/minres.jl
@@ -3,7 +3,7 @@
 #
 #  minimize ‖Ax - b‖₂
 #
-# where A is square and symmetric.
+# where A is Hermitian.
 #
 # MINRES is formally equivalent to applying the conjugate residuals method
 # to Ax = b when A is positive definite, but is more general and also applies
@@ -43,8 +43,8 @@ or the shifted linear system
 
     (A + λI) x = b
 
-using the MINRES method, where λ ≥ 0 is a shift parameter,
-where A is square and symmetric.
+of size n using the MINRES method, where λ ≥ 0 is a shift parameter,
+where A is Hermitian.
 
 MINRES is formally equivalent to applying CR to Ax=b when A is positive
 definite, but is typically more stable and also applies to the case where
@@ -53,7 +53,7 @@ A is indefinite.
 MINRES produces monotonic residuals ‖r‖₂ and optimality residuals ‖Aᴴr‖₂.
 
 A preconditioner M may be provided in the form of a linear operator and is
-assumed to be symmetric and positive definite.
+assumed to be Hermitian and positive definite.
 
 MINRES can be warm-started from an initial guess `x0` with
 

--- a/src/minres.jl
+++ b/src/minres.jl
@@ -64,6 +64,16 @@ where `kwargs` are the same keyword arguments as above.
 The callback is called as `callback(solver)` and should return `true` if the main loop should terminate,
 and `false` otherwise.
 
+#### Input arguments
+
+* `A`: a linear operator that models a Hermitian matrix of dimension n.
+* `b`: a vector of length n.
+
+#### Output arguments
+
+* `x`: a dense vector of length n.
+* `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
+
 #### Reference
 
 * C. C. Paige and M. A. Saunders, [*Solution of Sparse Indefinite Systems of Linear Equations*](https://doi.org/10.1137/0712047), SIAM Journal on Numerical Analysis, 12(4), pp. 617--629, 1975.

--- a/src/minres_qlp.jl
+++ b/src/minres_qlp.jl
@@ -27,11 +27,11 @@ export minres_qlp, minres_qlp!
 `FC` is `T` or `Complex{T}`.
 
 MINRES-QLP is the only method based on the Lanczos process that returns the minimum-norm
-solution on singular inconsistent systems (A + λI)x = b, where λ is a shift parameter.
+solution on singular inconsistent systems (A + λI)x = b of size n, where λ is a shift parameter.
 It is significantly more complex but can be more reliable than MINRES when A is ill-conditioned.
 
 A preconditioner M may be provided in the form of a linear operator and is
-assumed to be symmetric and positive definite.
+assumed to be Hermitian and positive definite.
 M also indicates the weighted norm in which residuals are measured.
 
 MINRES-QLP can be warm-started from an initial guess `x0` with

--- a/src/minres_qlp.jl
+++ b/src/minres_qlp.jl
@@ -45,12 +45,12 @@ and `false` otherwise.
 
 #### Input arguments
 
-* `A`: a linear operator that models a Hermitian matrix of dimension n.
+* `A`: a linear operator that models a Hermitian matrix of dimension n;
 * `b`: a vector of length n.
 
 #### Output arguments
 
-* `x`: a dense vector of length n.
+* `x`: a dense vector of length n;
 * `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
 
 #### References

--- a/src/minres_qlp.jl
+++ b/src/minres_qlp.jl
@@ -43,6 +43,16 @@ where `kwargs` are the same keyword arguments as above.
 The callback is called as `callback(solver)` and should return `true` if the main loop should terminate,
 and `false` otherwise.
 
+#### Input arguments
+
+* `A`: a linear operator that models a Hermitian matrix of dimension n.
+* `b`: a vector of length n.
+
+#### Output arguments
+
+* `x`: a dense vector of length n.
+* `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
+
 #### References
 
 * S.-C. T. Choi, *Iterative methods for singular linear equations and least-squares problems*, Ph.D. thesis, ICME, Stanford University, 2006.

--- a/src/qmr.jl
+++ b/src/qmr.jl
@@ -46,12 +46,12 @@ and `false` otherwise.
 
 #### Input arguments
 
-* `A`: a linear operator that models a matrix of dimension n.
+* `A`: a linear operator that models a matrix of dimension n;
 * `b`: a vector of length n.
 
 #### Output arguments
 
-* `x`: a dense vector of length n.
+* `x`: a dense vector of length n;
 * `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
 
 #### References

--- a/src/qmr.jl
+++ b/src/qmr.jl
@@ -29,7 +29,7 @@ export qmr, qmr!
 `T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
 `FC` is `T` or `Complex{T}`.
 
-Solve the square linear system Ax = b using QMR.
+Solve the square linear system Ax = b of size n using QMR.
 
 QMR is based on the Lanczos biorthogonalization process and requires two initial vectors `b` and `c`.
 The relation `bᴴc ≠ 0` must be satisfied and by default `c = b`.

--- a/src/qmr.jl
+++ b/src/qmr.jl
@@ -44,6 +44,16 @@ where `kwargs` are the same keyword arguments as above.
 The callback is called as `callback(solver)` and should return `true` if the main loop should terminate,
 and `false` otherwise.
 
+#### Input arguments
+
+* `A`: a linear operator that models a matrix of dimension n.
+* `b`: a vector of length n.
+
+#### Output arguments
+
+* `x`: a dense vector of length n.
+* `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
+
 #### References
 
 * R. W. Freund and N. M. Nachtigal, [*QMR : a quasi-minimal residual method for non-Hermitian linear systems*](https://doi.org/10.1007/BF01385726), Numerische mathematik, Vol. 60(1), pp. 315--339, 1991.

--- a/src/symmlq.jl
+++ b/src/symmlq.jl
@@ -46,12 +46,12 @@ and `false` otherwise.
 
 #### Input arguments
 
-* `A`: a linear operator that models a Hermitian matrix of dimension n.
+* `A`: a linear operator that models a Hermitian matrix of dimension n;
 * `b`: a vector of length n.
 
 #### Output arguments
 
-* `x`: a dense vector of length n.
+* `x`: a dense vector of length n;
 * `stats`: statistics collected on the run in a [`SymmlqStats`](@ref) structure.
 
 #### Reference

--- a/src/symmlq.jl
+++ b/src/symmlq.jl
@@ -1,5 +1,5 @@
 # An implementation of SYMMLQ for the solution of the
-# linear system Ax = b, where A is square and symmetric.
+# linear system Ax = b, where A is Hermitian.
 #
 # This implementation follows the original implementation by
 # Michael Saunders described in
@@ -27,13 +27,13 @@ Solve the shifted linear system
 
     (A + λI) x = b
 
-using the SYMMLQ method, where λ is a shift parameter,
-and A is square and symmetric.
+of size n using the SYMMLQ method, where λ is a shift parameter,
+and A is Hermitian.
 
 SYMMLQ produces monotonic errors ‖x* - x‖₂.
 
 A preconditioner M may be provided in the form of a linear operator and is
-assumed to be symmetric and positive definite.
+assumed to be Hermitian and positive definite.
 
 SYMMLQ can be warm-started from an initial guess `x0` with
 

--- a/src/symmlq.jl
+++ b/src/symmlq.jl
@@ -44,6 +44,16 @@ where `kwargs` are the same keyword arguments as above.
 The callback is called as `callback(solver)` and should return `true` if the main loop should terminate,
 and `false` otherwise.
 
+#### Input arguments
+
+* `A`: a linear operator that models a Hermitian matrix of dimension n.
+* `b`: a vector of length n.
+
+#### Output arguments
+
+* `x`: a dense vector of length n.
+* `stats`: statistics collected on the run in a [`SymmlqStats`](@ref) structure.
+
 #### Reference
 
 * C. C. Paige and M. A. Saunders, [*Solution of Sparse Indefinite Systems of Linear Equations*](https://doi.org/10.1137/0712047), SIAM Journal on Numerical Analysis, 12(4), pp. 617--629, 1975.

--- a/src/tricg.jl
+++ b/src/tricg.jl
@@ -62,6 +62,18 @@ where `kwargs` are the same keyword arguments as above.
 The callback is called as `callback(solver)` and should return `true` if the main loop should terminate,
 and `false` otherwise.
 
+#### Input arguments
+
+* `A`: a linear operator that models a matrix of dimension n × m.
+* `b`: a vector of length n.
+* `c`: a vector of length m.
+
+#### Output arguments
+
+* `x`: a dense vector of length n.
+* `y`: a dense vector of length m.
+* `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
+
 #### Reference
 
 * A. Montoison and D. Orban, [*TriCG and TriMR: Two Iterative Methods for Symmetric Quasi-Definite Systems*](https://doi.org/10.1137/20M1363030), SIAM Journal on Scientific Computing, 43(4), pp. 2502--2525, 2021.

--- a/src/tricg.jl
+++ b/src/tricg.jl
@@ -64,14 +64,14 @@ and `false` otherwise.
 
 #### Input arguments
 
-* `A`: a linear operator that models a matrix of dimension n × m.
-* `b`: a vector of length n.
+* `A`: a linear operator that models a matrix of dimension n × m;
+* `b`: a vector of length n;
 * `c`: a vector of length m.
 
 #### Output arguments
 
-* `x`: a dense vector of length n.
-* `y`: a dense vector of length m.
+* `x`: a dense vector of length n;
+* `y`: a dense vector of length m;
 * `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
 
 #### Reference

--- a/src/tricg.jl
+++ b/src/tricg.jl
@@ -27,7 +27,7 @@ TriCG solves the symmetric linear system
     [ τE    A ] [ x ] = [ b ]
     [  Aᴴ  νF ] [ y ]   [ c ],
 
-where τ and ν are real numbers, E = M⁻¹ ≻ 0 and F = N⁻¹ ≻ 0.
+of size (n+m) × (n+m) where τ and ν are real numbers, E = M⁻¹ ≻ 0 and F = N⁻¹ ≻ 0.
 `b` and `c` must both be nonzero.
 TriCG could breakdown if `τ = 0` or `ν = 0`.
 It's recommended to use TriMR in these cases.

--- a/src/tricg.jl
+++ b/src/tricg.jl
@@ -22,7 +22,7 @@ export tricg, tricg!
 `T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
 `FC` is `T` or `Complex{T}`.
 
-TriCG solves the symmetric linear system
+Given a matrix `A` of dimension m × n, TriCG solves the symmetric linear system
 
     [ τE    A ] [ x ] = [ b ]
     [  Aᴴ  νF ] [ y ]   [ c ],
@@ -64,14 +64,14 @@ and `false` otherwise.
 
 #### Input arguments
 
-* `A`: a linear operator that models a matrix of dimension n × m;
-* `b`: a vector of length n;
-* `c`: a vector of length m.
+* `A`: a linear operator that models a matrix of dimension m × n;
+* `b`: a vector of length m;
+* `c`: a vector of length n.
 
 #### Output arguments
 
-* `x`: a dense vector of length n;
-* `y`: a dense vector of length m;
+* `x`: a dense vector of length m;
+* `y`: a dense vector of length n;
 * `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
 
 #### Reference

--- a/src/trilqr.jl
+++ b/src/trilqr.jl
@@ -41,6 +41,18 @@ where `kwargs` are the same keyword arguments as above.
 The callback is called as `callback(solver)` and should return `true` if the main loop should terminate,
 and `false` otherwise.
 
+#### Input arguments
+
+* `A`: a linear operator that models a matrix of dimension n × m.
+* `b`: a vector of length n.
+* `c`: a vector of length m.
+
+#### Output arguments
+
+* `x`: a dense vector of length m.
+* `y`: a dense vector of length n.
+* `stats`: statistics collected on the run in a [`AdjointStats`](@ref) structure.
+
 #### Reference
 
 * A. Montoison and D. Orban, [*BiLQ: An Iterative Method for Nonsymmetric Linear Systems with a Quasi-Minimum Error Property*](https://doi.org/10.1137/19M1290991), SIAM Journal on Matrix Analysis and Applications, 41(3), pp. 1145--1166, 2020.

--- a/src/trilqr.jl
+++ b/src/trilqr.jl
@@ -26,8 +26,8 @@ Combine USYMLQ and USYMQR to solve adjoint systems.
     [0  A] [y] = [b]
     [Aᴴ 0] [x]   [c]
 
-USYMLQ is used for solving primal system `Ax = b`.
-USYMQR is used for solving dual system `Aᴴy = c`.
+USYMLQ is used for solving primal system `Ax = b` of size n.
+USYMQR is used for solving dual system `Aᴴy = c` of size m.
 
 An option gives the possibility of transferring from the USYMLQ point to the
 USYMCG point, when it exists. The transfer is based on the residual norm.

--- a/src/trilqr.jl
+++ b/src/trilqr.jl
@@ -43,14 +43,14 @@ and `false` otherwise.
 
 #### Input arguments
 
-* `A`: a linear operator that models a matrix of dimension n × m.
-* `b`: a vector of length n.
+* `A`: a linear operator that models a matrix of dimension n × m;
+* `b`: a vector of length n;
 * `c`: a vector of length m.
 
 #### Output arguments
 
-* `x`: a dense vector of length m.
-* `y`: a dense vector of length n.
+* `x`: a dense vector of length m;
+* `y`: a dense vector of length n;
 * `stats`: statistics collected on the run in a [`AdjointStats`](@ref) structure.
 
 #### Reference

--- a/src/trilqr.jl
+++ b/src/trilqr.jl
@@ -26,8 +26,8 @@ Combine USYMLQ and USYMQR to solve adjoint systems.
     [0  A] [y] = [b]
     [Aᴴ 0] [x]   [c]
 
-USYMLQ is used for solving primal system `Ax = b` of size n.
-USYMQR is used for solving dual system `Aᴴy = c` of size m.
+USYMLQ is used for solving primal system `Ax = b` of size m × n.
+USYMQR is used for solving dual system `Aᴴy = c` of size n × m.
 
 An option gives the possibility of transferring from the USYMLQ point to the
 USYMCG point, when it exists. The transfer is based on the residual norm.
@@ -43,14 +43,14 @@ and `false` otherwise.
 
 #### Input arguments
 
-* `A`: a linear operator that models a matrix of dimension n × m;
-* `b`: a vector of length n;
-* `c`: a vector of length m.
+* `A`: a linear operator that models a matrix of dimension m × n;
+* `b`: a vector of length m;
+* `c`: a vector of length n.
 
 #### Output arguments
 
-* `x`: a dense vector of length m;
-* `y`: a dense vector of length n;
+* `x`: a dense vector of length n;
+* `y`: a dense vector of length m;
 * `stats`: statistics collected on the run in a [`AdjointStats`](@ref) structure.
 
 #### Reference

--- a/src/trimr.jl
+++ b/src/trimr.jl
@@ -62,6 +62,18 @@ where `kwargs` are the same keyword arguments as above.
 The callback is called as `callback(solver)` and should return `true` if the main loop should terminate,
 and `false` otherwise.
 
+#### Input arguments
+
+* `A`: a linear operator that models a matrix of dimension n × m.
+* `b`: a vector of length n.
+* `c`: a vector of length m.
+
+#### Output arguments
+
+* `x`: a dense vector of length n.
+* `y`: a dense vector of length m.
+* `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
+
 #### Reference
 
 * A. Montoison and D. Orban, [*TriCG and TriMR: Two Iterative Methods for Symmetric Quasi-Definite Systems*](https://doi.org/10.1137/20M1363030), SIAM Journal on Scientific Computing, 43(4), pp. 2502--2525, 2021.

--- a/src/trimr.jl
+++ b/src/trimr.jl
@@ -27,7 +27,7 @@ TriMR solves the symmetric linear system
     [ τE    A ] [ x ] = [ b ]
     [  Aᴴ  νF ] [ y ]   [ c ],
 
-where τ and ν are real numbers, E = M⁻¹ ≻ 0, F = N⁻¹ ≻ 0.
+of size (n+m) × (n+m) where τ and ν are real numbers, E = M⁻¹ ≻ 0, F = N⁻¹ ≻ 0.
 `b` and `c` must both be nonzero.
 TriMR handles saddle-point systems (`τ = 0` or `ν = 0`) and adjoint systems (`τ = 0` and `ν = 0`) without any risk of breakdown.
 

--- a/src/trimr.jl
+++ b/src/trimr.jl
@@ -64,14 +64,14 @@ and `false` otherwise.
 
 #### Input arguments
 
-* `A`: a linear operator that models a matrix of dimension n × m.
-* `b`: a vector of length n.
+* `A`: a linear operator that models a matrix of dimension n × m;
+* `b`: a vector of length n;
 * `c`: a vector of length m.
 
 #### Output arguments
 
-* `x`: a dense vector of length n.
-* `y`: a dense vector of length m.
+* `x`: a dense vector of length n;
+* `y`: a dense vector of length m;
 * `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
 
 #### Reference

--- a/src/trimr.jl
+++ b/src/trimr.jl
@@ -22,7 +22,7 @@ export trimr, trimr!
 `T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
 `FC` is `T` or `Complex{T}`.
 
-TriMR solves the symmetric linear system
+Given a matrix `A` of dimension m × n, TriMR solves the symmetric linear system
 
     [ τE    A ] [ x ] = [ b ]
     [  Aᴴ  νF ] [ y ]   [ c ],
@@ -64,14 +64,14 @@ and `false` otherwise.
 
 #### Input arguments
 
-* `A`: a linear operator that models a matrix of dimension n × m;
-* `b`: a vector of length n;
-* `c`: a vector of length m.
+* `A`: a linear operator that models a matrix of dimension m × n;
+* `b`: a vector of length m;
+* `c`: a vector of length n.
 
 #### Output arguments
 
-* `x`: a dense vector of length n;
-* `y`: a dense vector of length m;
+* `x`: a dense vector of length m;
+* `y`: a dense vector of length n;
 * `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
 
 #### Reference

--- a/src/usymlq.jl
+++ b/src/usymlq.jl
@@ -50,6 +50,17 @@ where `kwargs` are the same keyword arguments as above.
 The callback is called as `callback(solver)` and should return `true` if the main loop should terminate,
 and `false` otherwise.
 
+#### Input arguments
+
+* `A`: a linear operator that models a matrix of dimension n × m.
+* `b`: a vector of length n.
+* `c`: a vector of length m.
+
+#### Output arguments
+
+* `x`: a dense vector of length m.
+* `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
+
 #### References
 
 * M. A. Saunders, H. D. Simon, and E. L. Yip, [*Two Conjugate-Gradient-Type Methods for Unsymmetric Linear Equations*](https://doi.org/10.1137/0725052), SIAM Journal on Numerical Analysis, 25(4), pp. 927--940, 1988.

--- a/src/usymlq.jl
+++ b/src/usymlq.jl
@@ -28,7 +28,7 @@ export usymlq, usymlq!
 `T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
 `FC` is `T` or `Complex{T}`.
 
-Solve the linear system Ax = b of size n × m using the USYMLQ method.
+Solve the linear system Ax = b of size m × n using the USYMLQ method.
 
 USYMLQ is based on the orthogonal tridiagonalization process and requires two initial nonzero vectors `b` and `c`.
 The vector `c` is only used to initialize the process and a default value can be `b` or `Aᴴb` depending on the shape of `A`.
@@ -52,13 +52,13 @@ and `false` otherwise.
 
 #### Input arguments
 
-* `A`: a linear operator that models a matrix of dimension n × m;
-* `b`: a vector of length n;
-* `c`: a vector of length m.
+* `A`: a linear operator that models a matrix of dimension m × n;
+* `b`: a vector of length m;
+* `c`: a vector of length n.
 
 #### Output arguments
 
-* `x`: a dense vector of length m;
+* `x`: a dense vector of length n;
 * `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
 
 #### References

--- a/src/usymlq.jl
+++ b/src/usymlq.jl
@@ -52,13 +52,13 @@ and `false` otherwise.
 
 #### Input arguments
 
-* `A`: a linear operator that models a matrix of dimension n × m.
-* `b`: a vector of length n.
+* `A`: a linear operator that models a matrix of dimension n × m;
+* `b`: a vector of length n;
 * `c`: a vector of length m.
 
 #### Output arguments
 
-* `x`: a dense vector of length m.
+* `x`: a dense vector of length m;
 * `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
 
 #### References

--- a/src/usymlq.jl
+++ b/src/usymlq.jl
@@ -28,7 +28,7 @@ export usymlq, usymlq!
 `T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
 `FC` is `T` or `Complex{T}`.
 
-Solve the linear system Ax = b using the USYMLQ method.
+Solve the linear system Ax = b of size n × m using the USYMLQ method.
 
 USYMLQ is based on the orthogonal tridiagonalization process and requires two initial nonzero vectors `b` and `c`.
 The vector `c` is only used to initialize the process and a default value can be `b` or `Aᴴb` depending on the shape of `A`.

--- a/src/usymqr.jl
+++ b/src/usymqr.jl
@@ -49,13 +49,13 @@ and `false` otherwise.
 
 #### Input arguments
 
-* `A`: a linear operator that models a matrix of dimension n × m.
-* `b`: a vector of length n.
+* `A`: a linear operator that models a matrix of dimension n × m;
+* `b`: a vector of length n;
 * `c`: a vector of length m.
 
 #### Output arguments
 
-* `x`: a dense vector of length m.
+* `x`: a dense vector of length m;
 * `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
 
 #### References

--- a/src/usymqr.jl
+++ b/src/usymqr.jl
@@ -47,6 +47,17 @@ where `kwargs` are the same keyword arguments as above.
 The callback is called as `callback(solver)` and should return `true` if the main loop should terminate,
 and `false` otherwise.
 
+#### Input arguments
+
+* `A`: a linear operator that models a matrix of dimension n × m.
+* `b`: a vector of length n.
+* `c`: a vector of length m.
+
+#### Output arguments
+
+* `x`: a dense vector of length m.
+* `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
+
 #### References
 
 * M. A. Saunders, H. D. Simon, and E. L. Yip, [*Two Conjugate-Gradient-Type Methods for Unsymmetric Linear Equations*](https://doi.org/10.1137/0725052), SIAM Journal on Numerical Analysis, 25(4), pp. 927--940, 1988.

--- a/src/usymqr.jl
+++ b/src/usymqr.jl
@@ -28,7 +28,7 @@ export usymqr, usymqr!
 `T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
 `FC` is `T` or `Complex{T}`.
 
-Solve the linear system Ax = b of size n × m using USYMQR.
+Solve the linear system Ax = b of size m × n using USYMQR.
 
 USYMQR is based on the orthogonal tridiagonalization process and requires two initial nonzero vectors `b` and `c`.
 The vector `c` is only used to initialize the process and a default value can be `b` or `Aᴴb` depending on the shape of `A`.
@@ -49,13 +49,13 @@ and `false` otherwise.
 
 #### Input arguments
 
-* `A`: a linear operator that models a matrix of dimension n × m;
-* `b`: a vector of length n;
-* `c`: a vector of length m.
+* `A`: a linear operator that models a matrix of dimension m × n;
+* `b`: a vector of length m;
+* `c`: a vector of length n.
 
 #### Output arguments
 
-* `x`: a dense vector of length m;
+* `x`: a dense vector of length n;
 * `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
 
 #### References

--- a/src/usymqr.jl
+++ b/src/usymqr.jl
@@ -28,7 +28,7 @@ export usymqr, usymqr!
 `T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
 `FC` is `T` or `Complex{T}`.
 
-Solve the linear system Ax = b using USYMQR.
+Solve the linear system Ax = b of size n × m using USYMQR.
 
 USYMQR is based on the orthogonal tridiagonalization process and requires two initial nonzero vectors `b` and `c`.
 The vector `c` is only used to initialize the process and a default value can be `b` or `Aᴴb` depending on the shape of `A`.


### PR DESCRIPTION
I will add a `#### Optional argument(s)` section when #564 will be closed.
The final goal is to also add `#### Keyword arguments` and `#### Stopping conditions` in all docstrings such that we can do a release 1.0.