### PR TITLE
Better display of Krylov solvers

### DIFF
--- a/src/krylov_solvers.jl
+++ b/src/krylov_solvers.jl
@@ -1887,7 +1887,7 @@ end
 
 function ksizeof(attribute)
   if isa(attribute, Vector{<:AbstractVector}) && !isempty(attribute)
-    # A vector of vector is a vector of pointers in Julia.
+    # A vector of vectors is a vector of pointers in Julia.
     # All vectors inside a vector have the same size in Krylov.jl
     size_attribute = sizeof(attribute) + length(attribute) * ksizeof(attribute[1])
   else

--- a/src/krylov_solvers.jl
+++ b/src/krylov_solvers.jl
@@ -1886,9 +1886,10 @@ for (KS, fun, nsol, nA, nAt, warm_start) in [
 end
 
 function ksizeof(attribute)
-  if isa(attribute, AbstractVector) && !isempty(attribute)
+  if isa(attribute, Vector{<:AbstractVector}) && !isempty(attribute)
+    # A vector of vector is a vector of pointers in Julia.
     # All vectors inside a vector have the same size in Krylov.jl
-    size_attribute = length(attribute) * ksizeof(attribute[1])
+    size_attribute = sizeof(attribute) + length(attribute) * ksizeof(attribute[1])
   else
     size_attribute = sizeof(attribute)
   end
@@ -1938,9 +1939,9 @@ function show(io :: IO, solver :: KrylovSolver{T,FC,S}; show_stats :: Bool=true)
     field_i = getfield(solver, name_i)
     size_i = ksizeof(field_i)
     if (name_i in [:w̅, :w̄, :d̅]) && (VERSION < v"1.8.0-DEV")
-      Printf.format(io, format2, string(name_i), type_i, format_bytes(size_i))
+      (size_i ≠ 0) && Printf.format(io, format2, string(name_i), type_i, format_bytes(size_i))
     else
-      Printf.format(io, format, string(name_i), type_i, format_bytes(size_i))
+      (size_i ≠ 0) && Printf.format(io, format, string(name_i), type_i, format_bytes(size_i))
     end
   end
   @printf(io, "└%s┴%s┴%s┘\n","─"^l1,"─"^l2,"─"^l3)

--- a/src/krylov_stats.jl
+++ b/src/krylov_stats.jl
@@ -1,3 +1,6 @@
+export KrylovStats, SimpleStats, LsmrStats, LanczosStats, LanczosShiftStats,
+SymmlqStats, AdjointStats, LNLQStats, LSLQStats
+
 "Abstract type for statistics returned by a solver"
 abstract type KrylovStats{T} end
 

--- a/src/minres.jl
+++ b/src/minres.jl
@@ -306,7 +306,7 @@ function minres!(solver :: MinresSolver{T,FC,S}, A, b :: AbstractVector{FC};
 
     if iter == 1 && β / β₁ ≤ 10 * ϵM
       # Aᴴb = 0 so x = 0 is a minimum least-squares solution
-      stats.niter = 0
+      stats.niter = 1
       stats.solved, stats.inconsistent = true, true
       stats.status = "x is a minimum least-squares solution"
       solver.warm_start = false

--- a/test/test_solvers.jl
+++ b/test/test_solvers.jl
@@ -11,1175 +11,139 @@ function test_solvers(FC)
   nshifts = 5
   T = real(FC)
   S = Vector{FC}
+  solvers = Dict{Symbol, KrylovSolver}()
 
   @eval begin
-    cg_solver = $(KRYLOV_SOLVERS[:cg])($n, $n, $S)
-    symmlq_solver = $(KRYLOV_SOLVERS[:symmlq])($n, $n, $S)
-    minres_solver = $(KRYLOV_SOLVERS[:minres])($n, $n, $S)
-    cg_lanczos_solver = $(KRYLOV_SOLVERS[:cg_lanczos])($n, $n, $S)
-    diom_solver = $(KRYLOV_SOLVERS[:diom])($n, $n, $mem, $S)
-    fom_solver = $(KRYLOV_SOLVERS[:fom])($n, $n, $mem, $S)
-    dqgmres_solver = $(KRYLOV_SOLVERS[:dqgmres])($n, $n, $mem, $S)
-    gmres_solver = $(KRYLOV_SOLVERS[:gmres])($n, $n, $mem, $S)
-    fgmres_solver = $(KRYLOV_SOLVERS[:fgmres])($n, $n, $mem, $S)
-    cr_solver = $(KRYLOV_SOLVERS[:cr])($n, $n, $S)
-    crmr_solver = $(KRYLOV_SOLVERS[:crmr])($m, $n, $S)
-    cgs_solver = $(KRYLOV_SOLVERS[:cgs])($n, $n, $S)
-    bicgstab_solver = $(KRYLOV_SOLVERS[:bicgstab])($n, $n, $S)
-    craigmr_solver = $(KRYLOV_SOLVERS[:craigmr])($m, $n, $S)
-    cgne_solver = $(KRYLOV_SOLVERS[:cgne])($m, $n, $S)
-    lnlq_solver = $(KRYLOV_SOLVERS[:lnlq])($m, $n, $S)
-    craig_solver = $(KRYLOV_SOLVERS[:craig])($m, $n, $S)
-    lslq_solver = $(KRYLOV_SOLVERS[:lslq])($n, $m, $S)
-    cgls_solver = $(KRYLOV_SOLVERS[:cgls])($n, $m, $S)
-    lsqr_solver = $(KRYLOV_SOLVERS[:lsqr])($n, $m, $S)
-    crls_solver = $(KRYLOV_SOLVERS[:crls])($n, $m, $S)
-    lsmr_solver = $(KRYLOV_SOLVERS[:lsmr])($n, $m, $S)
-    usymqr_solver = $(KRYLOV_SOLVERS[:usymqr])($n, $m, $S)
-    trilqr_solver = $(KRYLOV_SOLVERS[:trilqr])($n, $n, $S)
-    bilq_solver = $(KRYLOV_SOLVERS[:bilq])($n, $n, $S)
-    bilqr_solver = $(KRYLOV_SOLVERS[:bilqr])($n, $n, $S)
-    minres_qlp_solver = $(KRYLOV_SOLVERS[:minres_qlp])($n, $n, $S)
-    qmr_solver = $(KRYLOV_SOLVERS[:qmr])($n, $n, $S)
-    usymlq_solver = $(KRYLOV_SOLVERS[:usymlq])($m, $n, $S)
-    tricg_solver = $(KRYLOV_SOLVERS[:tricg])($m, $n, $S)
-    trimr_solver = $(KRYLOV_SOLVERS[:trimr])($m, $n, $S)
-    gpmr_solver = $(KRYLOV_SOLVERS[:gpmr])($n, $m, $mem, $S)
-    cg_lanczos_shift_solver = $(KRYLOV_SOLVERS[:cg_lanczos_shift])($n, $n, $nshifts, $S)
+    $solvers[:cg] = $(KRYLOV_SOLVERS[:cg])($n, $n, $S)
+    $solvers[:symmlq] = $(KRYLOV_SOLVERS[:symmlq])($n, $n, $S)
+    $solvers[:minres] = $(KRYLOV_SOLVERS[:minres])($n, $n, $S)
+    $solvers[:cg_lanczos] = $(KRYLOV_SOLVERS[:cg_lanczos])($n, $n, $S)
+    $solvers[:cg_lanczos_shift] = $(KRYLOV_SOLVERS[:cg_lanczos_shift])($n, $n, $nshifts, $S)
+    $solvers[:diom] = $(KRYLOV_SOLVERS[:diom])($n, $n, $mem, $S)
+    $solvers[:fom] = $(KRYLOV_SOLVERS[:fom])($n, $n, $mem, $S)
+    $solvers[:dqgmres] = $(KRYLOV_SOLVERS[:dqgmres])($n, $n, $mem, $S)
+    $solvers[:gmres] = $(KRYLOV_SOLVERS[:gmres])($n, $n, $mem, $S)
+    $solvers[:fgmres] = $(KRYLOV_SOLVERS[:fgmres])($n, $n, $mem, $S)
+    $solvers[:cr] = $(KRYLOV_SOLVERS[:cr])($n, $n, $S)
+    $solvers[:crmr] = $(KRYLOV_SOLVERS[:crmr])($m, $n, $S)
+    $solvers[:cgs] = $(KRYLOV_SOLVERS[:cgs])($n, $n, $S)
+    $solvers[:bicgstab] = $(KRYLOV_SOLVERS[:bicgstab])($n, $n, $S)
+    $solvers[:craigmr] = $(KRYLOV_SOLVERS[:craigmr])($m, $n, $S)
+    $solvers[:cgne] = $(KRYLOV_SOLVERS[:cgne])($m, $n, $S)
+    $solvers[:lnlq] = $(KRYLOV_SOLVERS[:lnlq])($m, $n, $S)
+    $solvers[:craig] = $(KRYLOV_SOLVERS[:craig])($m, $n, $S)
+    $solvers[:lslq] = $(KRYLOV_SOLVERS[:lslq])($n, $m, $S)
+    $solvers[:cgls] = $(KRYLOV_SOLVERS[:cgls])($n, $m, $S)
+    $solvers[:lsqr] = $(KRYLOV_SOLVERS[:lsqr])($n, $m, $S)
+    $solvers[:crls] = $(KRYLOV_SOLVERS[:crls])($n, $m, $S)
+    $solvers[:lsmr] = $(KRYLOV_SOLVERS[:lsmr])($n, $m, $S)
+    $solvers[:usymqr] = $(KRYLOV_SOLVERS[:usymqr])($n, $m, $S)
+    $solvers[:trilqr] = $(KRYLOV_SOLVERS[:trilqr])($n, $n, $S)
+    $solvers[:bilq] = $(KRYLOV_SOLVERS[:bilq])($n, $n, $S)
+    $solvers[:bilqr] = $(KRYLOV_SOLVERS[:bilqr])($n, $n, $S)
+    $solvers[:minres_qlp] = $(KRYLOV_SOLVERS[:minres_qlp])($n, $n, $S)
+    $solvers[:qmr] = $(KRYLOV_SOLVERS[:qmr])($n, $n, $S)
+    $solvers[:usymlq] = $(KRYLOV_SOLVERS[:usymlq])($m, $n, $S)
+    $solvers[:tricg] = $(KRYLOV_SOLVERS[:tricg])($m, $n, $S)
+    $solvers[:trimr] = $(KRYLOV_SOLVERS[:trimr])($m, $n, $S)
+    $solvers[:gpmr] = $(KRYLOV_SOLVERS[:gpmr])($n, $m, $mem, $S)
+    $solvers[:cg_lanczos_shift] = $(KRYLOV_SOLVERS[:cg_lanczos_shift])($n, $n, $nshifts, $S)
   end
 
-  for i = 1 : 3
-    A  = i * A
-    Au = i * Au
-    Ao = i * Ao
-    b  = 5 * b
-    c  = 3 * c
+  for (method, solver) in solvers
+    @testset "$(method)" begin
+      for i = 1 : 3
+        A  = i * A
+        Au = i * Au
+        Ao = i * Ao
+        b  = 5 * b
+        c  = 3 * c
 
-    solver = solve!(cg_solver, A, b)
-    niter = niterations(solver)
-    @test niter > 0
-    @test Aprod(solver) == niter
-    @test Atprod(solver) == 0
-    @test statistics(solver) === solver.stats
-    @test solution(solver, 1) === solver.x
-    @test nsolution(solver) == 1
-    @test issolved(solver)
+        if method ∈ (:cg, :cr, :symmlq, :minres, :minres_qlp, :cg_lanczos, :diom, :fom,
+                     :dqgmres, :gmres, :fgmres, :cgs, :bicgstab, :bilq, :qmr, :cg_lanczos_shift)
+          method == :cg_lanczos_shift ? solve!(solver, A, b, shifts) : solve!(solver, A, b)
+          niter = niterations(solver)
+          @test Aprod(solver) == (method ∈ (:cgs, :bicgstab) ? 2 * niter : niter)
+          @test Atprod(solver) == (method ∈ (:bilq, :qmr) ? niter : 0)
+          @test solution(solver) === solver.x
+          @test nsolution(solver) == 1
+        end
 
-    solver = solve!(symmlq_solver, A, b)
-    niter = niterations(solver)
-    @test niter > 0
-    @test Aprod(solver) == niter
-    @test Atprod(solver) == 0
-    @test statistics(solver) === solver.stats
-    @test solution(solver, 1) === solver.x
-    @test nsolution(solver) == 1
-    @test issolved(solver)
+        if method ∈ (:cgne, :crmr, :lnlq, :craig, :craigmr)
+          solve!(solver, Au, c)
+          niter = niterations(solver)
+          @test Aprod(solver) == niter
+          @test Atprod(solver) == niter
+          @test solution(solver, 1) === solver.x
+          @test nsolution(solver) == (method ∈ (:cgne, :crmr) ? 1 : 2)
+          (nsolution == 2) && (@test solution(solver, 2) == solver.y)
+        end
 
-    solver = solve!(minres_solver, A, b)
-    niter = niterations(solver)
-    @test niter > 0
-    @test Aprod(solver) == niter
-    @test Atprod(solver) == 0
-    @test statistics(solver) === solver.stats
-    @test solution(solver, 1) === solver.x
-    @test nsolution(solver) == 1
-    @test issolved(solver)
+        if method ∈ (:cgls, :crls, :lslq, :lsqr, :lsmr)
+          solve!(solver, Ao, b)
+          niter = niterations(solver)
+          @test Aprod(solver) == niter
+          @test Atprod(solver) == niter
+          @test solution(solver) === solver.x
+          @test nsolution(solver) == 1
+        end
 
-    solver = solve!(cg_lanczos_solver, A, b)
-    niter = niterations(solver)
-    @test niter > 0
-    @test Aprod(solver) == niter
-    @test Atprod(solver) == 0
-    @test statistics(solver) === solver.stats
-    @test solution(solver, 1) === solver.x
-    @test nsolution(solver) == 1
-    @test issolved(solver)
+        if method ∈ (:bilqr, :trilqr)
+          solve!(solver, A, b, b)
+          niter = niterations(solver)
+          @test Aprod(solver) == niter
+          @test Atprod(solver) == niter
+          @test solution(solver, 1) === solver.x
+          @test solution(solver, 2) === solver.y
+          @test nsolution(solver) == 2
+          @test issolved_primal(solver)
+          @test issolved_dual(solver)
+        end
 
-    solver = solve!(cg_lanczos_shift_solver, A, b, shifts)
-    niter = niterations(solver)
-    @test niter > 0
-    @test Aprod(solver) == niter
-    @test Atprod(solver) == 0
-    @test statistics(solver) === solver.stats
-    @test solution(solver, 1) === solver.x
-    @test nsolution(solver) == 1
-    @test issolved(solver)
+        if method ∈ (:tricg, :trimr, :gpmr)
+          method == :gpmr ? solve!(solver, Ao, Au, b, c) : solve!(solver, Au, c, b)
+          niter = niterations(solver)
+          @test Aprod(solver) == niter
+          method != :gpmr && (@test Atprod(solver) == niter)
+          method == :gpmr && (@test Bprod(solver) == niter)
+          @test solution(solver, 1) === solver.x
+          @test solution(solver, 2) === solver.y
+          @test nsolution(solver) == 2
+        end
 
-    solver = solve!(diom_solver, A, b)
-    niter = niterations(solver)
-    @test niter > 0
-    @test Aprod(solver) == niter
-    @test Atprod(solver) == 0
-    @test statistics(solver) === solver.stats
-    @test solution(solver, 1) === solver.x
-    @test nsolution(solver) == 1
-    @test issolved(solver)
+        if method ∈ (:usymlq, :usymqr)
+          method == :usymlq ? solve!(solver, Au, c, b) : solve!(solver, Ao, b, c)
+          niter = niterations(solver)
+          @test Aprod(solver) == niter
+          @test Atprod(solver) == niter
+          @test solution(solver) === solver.x
+          @test nsolution(solver) == 1
+        end
 
-    solver = solve!(fom_solver, A, b)
-    niter = niterations(solver)
-    @test niter > 0
-    @test Aprod(solver) == niter
-    @test Atprod(solver) == 0
-    @test statistics(solver) === solver.stats
-    @test solution(solver, 1) === solver.x
-    @test nsolution(solver) == 1
-    @test issolved(solver)
+        @test niter > 0
+        @test statistics(solver) === solver.stats
+        @test issolved(solver)
+      end
 
-    solver = solve!(dqgmres_solver, A, b)
-    niter = niterations(solver)
-    @test niter > 0
-    @test Aprod(solver) == niter
-    @test Atprod(solver) == 0
-    @test statistics(solver) === solver.stats
-    @test solution(solver, 1) === solver.x
-    @test nsolution(solver) == 1
-    @test issolved(solver)
+      io = IOBuffer()
+      show(io, solver, show_stats=false)
+      showed = String(take!(io))
 
-    solver = solve!(gmres_solver, A, b)
-    niter = niterations(solver)
-    @test niter > 0
-    @test Aprod(solver) == niter
-    @test Atprod(solver) == 0
-    @test statistics(solver) === solver.stats
-    @test solution(solver, 1) === solver.x
-    @test nsolution(solver) == 1
-    @test issolved(solver)
+      # Test that the lines have the same length
+      str = split(showed, "\n", keepempty=false)
+      len_row = length(str[1])
+      @test mapreduce(x -> length(x) - mapreduce(y -> occursin(y, x), |, ["w̅","w̄","d̅"]) == len_row, &, str)
 
-    solver = solve!(fgmres_solver, A, b)
-    niter = niterations(solver)
-    @test niter > 0
-    @test Aprod(solver) == niter
-    @test Atprod(solver) == 0
-    @test statistics(solver) === solver.stats
-    @test solution(solver, 1) === solver.x
-    @test nsolution(solver) == 1
-    @test issolved(solver)
-
-    solver = solve!(cr_solver, A, b)
-    niter = niterations(solver)
-    @test niter > 0
-    @test Aprod(solver) == niter
-    @test Atprod(solver) == 0
-    @test statistics(solver) === solver.stats
-    @test solution(solver, 1) === solver.x
-    @test nsolution(solver) == 1
-    @test issolved(solver)
-
-    solver = solve!(crmr_solver, Au, c)
-    niter = niterations(solver)
-    @test niter > 0
-    @test Aprod(solver) == niter
-    @test Atprod(solver) == niter
-    @test statistics(solver) === solver.stats
-    @test solution(solver, 1) === solver.x
-    @test nsolution(solver) == 1
-    @test issolved(solver)
-
-    solver = solve!(cgs_solver, A, b)
-    niter = niterations(solver)
-    @test niter > 0
-    @test Aprod(solver) == 2 * niter
-    @test Atprod(solver) == 0
-    @test statistics(solver) === solver.stats
-    @test solution(solver, 1) === solver.x
-    @test nsolution(solver) == 1
-    @test issolved(solver)
-
-    solver = solve!(bicgstab_solver, A, b)
-    niter = niterations(solver)
-    @test niter > 0
-    @test Aprod(solver) == 2 * niter
-    @test Atprod(solver) == 0
-    @test statistics(solver) === solver.stats
-    @test solution(solver, 1) === solver.x
-    @test nsolution(solver) == 1
-    @test issolved(solver)
-
-    solver = solve!(craigmr_solver, Au, c)
-    niter = niterations(solver)
-    @test niter > 0
-    @test Aprod(solver) == niter
-    @test Atprod(solver) == niter
-    @test statistics(solver) === solver.stats
-    @test solution(solver, 1) === solver.x
-    @test nsolution(solver) == 2
-    @test issolved(solver)
-
-    solver = solve!(cgne_solver, Au, c)
-    niter = niterations(solver)
-    @test niter > 0
-    @test Aprod(solver) == niter
-    @test Atprod(solver) == niter
-    @test statistics(solver) === solver.stats
-    @test solution(solver, 1) === solver.x
-    @test nsolution(solver) == 1
-    @test issolved(solver)
-
-    solver = solve!(lnlq_solver, Au, c)
-    niter = niterations(solver)
-    @test niter > 0
-    @test Aprod(solver) == niter
-    @test Atprod(solver) == niter
-    @test statistics(solver) === solver.stats
-    @test solution(solver, 1) === solver.x
-    @test solution(solver, 2) === solver.y
-    @test nsolution(solver) == 2
-    @test issolved(solver)
-
-    solver = solve!(craig_solver, Au, c)
-    niter = niterations(solver)
-    @test niter > 0
-    @test Aprod(solver) == niter
-    @test Atprod(solver) == niter
-    @test statistics(solver) === solver.stats
-    @test solution(solver, 1) === solver.x
-    @test solution(solver, 2) === solver.y
-    @test nsolution(solver) == 2
-    @test issolved(solver)
-
-    solver = solve!(lslq_solver, Ao, b)
-    niter = niterations(solver)
-    @test niter > 0
-    @test Aprod(solver) == niter
-    @test Atprod(solver) == niter
-    @test statistics(solver) === solver.stats
-    @test solution(solver, 1) === solver.x
-    @test nsolution(solver) == 1
-    @test issolved(solver)
-
-    solver = solve!(cgls_solver, Ao, b)
-    niter = niterations(solver)
-    @test niter > 0
-    @test Aprod(solver) == niter
-    @test Atprod(solver) == niter
-    @test statistics(solver) === solver.stats
-    @test solution(solver, 1) === solver.x
-    @test nsolution(solver) == 1
-    @test issolved(solver)
-
-    solver = solve!(lsqr_solver, Ao, b)
-    niter = niterations(solver)
-    @test niter > 0
-    @test Aprod(solver) == niter
-    @test Atprod(solver) == niter
-    @test statistics(solver) === solver.stats
-    @test solution(solver, 1) === solver.x
-    @test nsolution(solver) == 1
-    @test issolved(solver)
-
-    solver = solve!(crls_solver, Ao, b)
-    niter = niterations(solver)
-    @test niter > 0
-    @test Aprod(solver) == niter
-    @test Atprod(solver) == niter
-    @test statistics(solver) === solver.stats
-    @test solution(solver, 1) === solver.x
-    @test nsolution(solver) == 1
-    @test issolved(solver)
-
-    solver = solve!(lsmr_solver, Ao, b)
-    niter = niterations(solver)
-    @test niter > 0
-    @test Aprod(solver) == niter
-    @test Atprod(solver) == niter
-    @test statistics(solver) === solver.stats
-    @test solution(solver, 1) === solver.x
-    @test nsolution(solver) == 1
-    @test issolved(solver)
-
-    solver = solve!(usymqr_solver, Ao, b, c)
-    niter = niterations(solver)
-    @test niter > 0
-    @test Aprod(solver) == niter
-    @test Atprod(solver) == niter
-    @test statistics(solver) === solver.stats
-    @test solution(solver, 1) === solver.x
-    @test nsolution(solver) == 1
-    @test issolved(solver)
-
-    solver = solve!(trilqr_solver, A, b, b)
-    niter = niterations(solver)
-    @test niter > 0
-    @test Aprod(solver) == niter
-    @test Atprod(solver) == niter
-    @test statistics(solver) === solver.stats
-    @test solution(solver, 1) === solver.x
-    @test solution(solver, 2) === solver.y
-    @test nsolution(solver) == 2
-    @test issolved_primal(solver)
-    @test issolved_dual(solver)
-    @test issolved(solver)
-
-    solver = solve!(bilq_solver, A, b)
-    niter = niterations(solver)
-    @test niter > 0
-    @test Aprod(solver) == niter
-    @test Atprod(solver) == niter
-    @test statistics(solver) === solver.stats
-    @test solution(solver, 1) === solver.x
-    @test nsolution(solver) == 1
-    @test issolved(solver)
-
-    solver = solve!(bilqr_solver, A, b, b)
-    niter = niterations(solver)
-    @test niter > 0
-    @test Aprod(solver) == niter
-    @test Atprod(solver) == niter
-    @test statistics(solver) === solver.stats
-    @test solution(solver, 1) === solver.x
-    @test solution(solver, 2) === solver.y
-    @test nsolution(solver) == 2
-    @test issolved_primal(solver)
-    @test issolved_dual(solver)
-    @test issolved(solver)
-
-    solver = solve!(minres_qlp_solver, A, b)
-    niter = niterations(solver)
-    @test niter > 0
-    @test Aprod(solver) == niter
-    @test Atprod(solver) == 0
-    @test statistics(solver) === solver.stats
-    @test solution(solver, 1) === solver.x
-    @test nsolution(solver) == 1
-    @test issolved(solver)
-
-    solver = solve!(qmr_solver, A, b)
-    niter = niterations(solver)
-    @test niter > 0
-    @test Aprod(solver) == niter
-    @test Atprod(solver) == niter
-    @test statistics(solver) === solver.stats
-    @test solution(solver, 1) === solver.x
-    @test nsolution(solver) == 1
-    @test issolved(solver)
-
-    solver = solve!(usymlq_solver, Au, c, b)
-    niter = niterations(solver)
-    @test niter > 0
-    @test Aprod(solver) == niter
-    @test Atprod(solver) == niter
-    @test statistics(solver) === solver.stats
-    @test solution(solver, 1) === solver.x
-    @test nsolution(solver) == 1
-    @test issolved(solver)
-
-    solver = solve!(tricg_solver, Au, c, b)
-    niter = niterations(solver)
-    @test niter > 0
-    @test Aprod(solver) == niter
-    @test Atprod(solver) == niter
-    @test statistics(solver) === solver.stats
-    @test solution(solver, 1) === solver.x
-    @test solution(solver, 2) === solver.y
-    @test nsolution(solver) == 2
-    @test issolved(solver)
-
-    solver = solve!(trimr_solver, Au, c, b)
-    niter = niterations(solver)
-    @test niter > 0
-    @test Aprod(solver) == niter
-    @test Atprod(solver) == niter
-    @test statistics(solver) === solver.stats
-    @test solution(solver, 1) === solver.x
-    @test solution(solver, 2) === solver.y
-    @test nsolution(solver) == 2
-    @test issolved(solver)
-
-    solver = solve!(gpmr_solver, Ao, Au, b, c)
-    niter = niterations(solver)
-    @test niter > 0
-    @test Aprod(solver) == niter
-    @test Atprod(solver) == 0
-    @test Bprod(solver) == niter
-    @test statistics(solver) === solver.stats
-    @test solution(solver, 1) === solver.x
-    @test solution(solver, 2) === solver.y
-    @test nsolution(solver) == 2
-    @test issolved(solver)
+      # Test that the columns have the same length
+      str2 = split(showed, ['│','┌','┬','┐','├','┼','┤','└','┴','┴','┘','\n'], keepempty=false)
+      len_col1 = length(str2[1])
+      len_col2 = length(str2[2])
+      len_col3 = length(str2[3])
+      @test mapreduce(x -> length(x) - mapreduce(y -> occursin(y, x), |, ["w̅","w̄","d̅"]) == len_col1, &, str2[1:3:end-2])
+      @test mapreduce(x -> length(x) - mapreduce(y -> occursin(y, x), |, ["w̅","w̄","d̅"]) == len_col2, &, str2[2:3:end-1])
+      @test mapreduce(x -> length(x) - mapreduce(y -> occursin(y, x), |, ["w̅","w̄","d̅"]) == len_col3, &, str2[3:3:end])
+    end
   end
-
-  io = IOBuffer()
-  show(io, cg_solver, show_stats=false)
-  showed = String(take!(io))
-  expected = """
-  ┌──────────┬───────────────┬─────────────────┐
-  │  CgSolver│Precision: $FC │Architecture: CPU│
-  ├──────────┼───────────────┼─────────────────┤
-  │ Attribute│           Type│             Size│
-  ├──────────┼───────────────┼─────────────────┤
-  │        Δx│    Vector{$FC}│                0│
-  │         x│    Vector{$FC}│               64│
-  │         r│    Vector{$FC}│               64│
-  │         p│    Vector{$FC}│               64│
-  │        Ap│    Vector{$FC}│               64│
-  │         z│    Vector{$FC}│                0│
-  │warm_start│           Bool│                0│
-  └──────────┴───────────────┴─────────────────┘
-  """
-  @test reduce(replace, [" " => "", "\n" => "", "─" => ""], init=showed) == reduce(replace, [" " => "", "\n" => "", "─" => ""], init=expected)
-
-  io = IOBuffer()
-  show(io, symmlq_solver, show_stats=false)
-  showed = String(take!(io))
-  expected = """
-  ┌────────────┬───────────────┬─────────────────┐
-  │SymmlqSolver│Precision: $FC │Architecture: CPU│
-  ├────────────┼───────────────┼─────────────────┤
-  │   Attribute│           Type│             Size│
-  ├────────────┼───────────────┼─────────────────┤
-  │          Δx│    Vector{$FC}│                0│
-  │           x│    Vector{$FC}│               64│
-  │       Mvold│    Vector{$FC}│               64│
-  │          Mv│    Vector{$FC}│               64│
-  │     Mv_next│    Vector{$FC}│               64│
-  │           w̅│    Vector{$FC}│               64│
-  │           v│    Vector{$FC}│                0│
-  │       clist│     Vector{$T}│                5│
-  │       zlist│     Vector{$T}│                5│
-  │       sprod│     Vector{$T}│                5│
-  │  warm_start│           Bool│                0│
-  └────────────┴───────────────┴─────────────────┘
-  """
-  @test reduce(replace, [" " => "", "\n" => "", "─" => ""], init=showed) == reduce(replace, [" " => "", "\n" => "", "─" => ""], init=expected)
-
-  io = IOBuffer()
-  show(io, minres_solver, show_stats=false)
-  showed = String(take!(io))
-  expected = """
-  ┌────────────┬───────────────┬─────────────────┐
-  │MinresSolver│Precision: $FC │Architecture: CPU│
-  ├────────────┼───────────────┼─────────────────┤
-  │   Attribute│           Type│             Size│
-  ├────────────┼───────────────┼─────────────────┤
-  │          Δx│    Vector{$FC}│                0│
-  │           x│    Vector{$FC}│               64│
-  │          r1│    Vector{$FC}│               64│
-  │          r2│    Vector{$FC}│               64│
-  │          w1│    Vector{$FC}│               64│
-  │          w2│    Vector{$FC}│               64│
-  │           y│    Vector{$FC}│               64│
-  │           v│    Vector{$FC}│                0│
-  │     err_vec│     Vector{$T}│                5│
-  │  warm_start│           Bool│                0│
-  └────────────┴───────────────┴─────────────────┘
-  """
-  @test reduce(replace, [" " => "", "\n" => "", "─" => ""], init=showed) == reduce(replace, [" " => "", "\n" => "", "─" => ""], init=expected)
-
-  io = IOBuffer()
-  show(io, cg_lanczos_solver, show_stats=false)
-  showed = String(take!(io))
-  expected = """
-  ┌───────────────┬───────────────┬─────────────────┐
-  │CgLanczosSolver│Precision: $FC │Architecture: CPU│
-  ├───────────────┼───────────────┼─────────────────┤
-  │      Attribute│           Type│             Size│
-  ├───────────────┼───────────────┼─────────────────┤
-  │             Δx│    Vector{$FC}│                0│
-  │              x│    Vector{$FC}│               64│
-  │             Mv│    Vector{$FC}│               64│
-  │        Mv_prev│    Vector{$FC}│               64│
-  │              p│    Vector{$FC}│               64│
-  │        Mv_next│    Vector{$FC}│               64│
-  │              v│    Vector{$FC}│                0│
-  │     warm_start│           Bool│                0│
-  └───────────────┴───────────────┴─────────────────┘
-  """
-  @test reduce(replace, [" " => "", "\n" => "", "─" => ""], init=showed) == reduce(replace, [" " => "", "\n" => "", "─" => ""], init=expected)
-
-  io = IOBuffer()
-  show(io, cg_lanczos_shift_solver, show_stats=false)
-  showed = String(take!(io))
-  expected = """
-  ┌────────────────────┬───────────────────┬─────────────────┐
-  │CgLanczosShiftSolver│    Precision: $FC │Architecture: CPU│
-  ├────────────────────┼───────────────────┼─────────────────┤
-  │           Attribute│               Type│             Size│
-  ├────────────────────┼───────────────────┼─────────────────┤
-  │                  Mv│        Vector{$FC}│               64│
-  │             Mv_prev│        Vector{$FC}│               64│
-  │             Mv_next│        Vector{$FC}│               64│
-  │                   v│        Vector{$FC}│                0│
-  │                   x│Vector{Vector{$FC}}│           5 x 64│
-  │                   p│Vector{Vector{$FC}}│           5 x 64│
-  │                   σ│         Vector{$T}│                5│
-  │                δhat│         Vector{$T}│                5│
-  │                   ω│         Vector{$T}│                5│
-  │                   γ│         Vector{$T}│                5│
-  │              rNorms│         Vector{$T}│                5│
-  │           converged│          BitVector│                5│
-  │              not_cv│          BitVector│                5│
-  └────────────────────┴───────────────────┴─────────────────┘
-  """
-  @test reduce(replace, [" " => "", "\n" => "", "─" => ""], init=showed) == reduce(replace, [" " => "", "\n" => "", "─" => ""], init=expected)
-
-  io = IOBuffer()
-  show(io, diom_solver, show_stats=false)
-  showed = String(take!(io))
-  expected = """
-  ┌──────────┬───────────────────┬─────────────────┐
-  │DiomSolver│    Precision: $FC │Architecture: CPU│
-  ├──────────┼───────────────────┼─────────────────┤
-  │ Attribute│               Type│             Size│
-  ├──────────┼───────────────────┼─────────────────┤
-  │        Δx│        Vector{$FC}│                0│
-  │         x│        Vector{$FC}│               64│
-  │         t│        Vector{$FC}│               64│
-  │         z│        Vector{$FC}│                0│
-  │         w│        Vector{$FC}│                0│
-  │         P│Vector{Vector{$FC}}│           9 x 64│
-  │         V│Vector{Vector{$FC}}│          10 x 64│
-  │         L│        Vector{$FC}│                9│
-  │         H│        Vector{$FC}│               10│
-  │warm_start│               Bool│                0│
-  └──────────┴───────────────────┴─────────────────┘
-  """
-  @test reduce(replace, [" " => "", "\n" => "", "─" => ""], init=showed) == reduce(replace, [" " => "", "\n" => "", "─" => ""], init=expected)
-
-  io = IOBuffer()
-  show(io, fom_solver, show_stats=false)
-  showed = String(take!(io))
-  expected = """
-  ┌──────────┬───────────────────┬─────────────────┐
-  │ FomSolver│    Precision: $FC │Architecture: CPU│
-  ├──────────┼───────────────────┼─────────────────┤
-  │ Attribute│               Type│             Size│
-  ├──────────┼───────────────────┼─────────────────┤
-  │        Δx│        Vector{$FC}│                0│
-  │         x│        Vector{$FC}│               64│
-  │         w│        Vector{$FC}│               64│
-  │         p│        Vector{$FC}│                0│
-  │         q│        Vector{$FC}│                0│
-  │         V│Vector{Vector{$FC}}│          10 x 64│
-  │         l│        Vector{$FC}│               10│
-  │         z│        Vector{$FC}│               10│
-  │         U│        Vector{$FC}│               55│
-  │warm_start│               Bool│                0│
-  └──────────┴───────────────────┴─────────────────┘
-  """
-  @test reduce(replace, [" " => "", "\n" => "", "─" => ""], init=showed) == reduce(replace, [" " => "", "\n" => "", "─" => ""], init=expected)
-
-  io = IOBuffer()
-  show(io, dqgmres_solver, show_stats=false)
-  showed = String(take!(io))
-  expected = """
-  ┌─────────────┬───────────────────┬─────────────────┐
-  │DqgmresSolver│    Precision: $FC │Architecture: CPU│
-  ├─────────────┼───────────────────┼─────────────────┤
-  │    Attribute│               Type│             Size│
-  ├─────────────┼───────────────────┼─────────────────┤
-  │           Δx│        Vector{$FC}│                0│
-  │            x│        Vector{$FC}│               64│
-  │            t│        Vector{$FC}│               64│
-  │            z│        Vector{$FC}│                0│
-  │            w│        Vector{$FC}│                0│
-  │            P│Vector{Vector{$FC}}│          10 x 64│
-  │            V│Vector{Vector{$FC}}│          10 x 64│
-  │            c│         Vector{$T}│               10│
-  │            s│        Vector{$FC}│               10│
-  │            H│        Vector{$FC}│               11│
-  │   warm_start│               Bool│                0│
-  └─────────────┴───────────────────┴─────────────────┘
-  """
-  @test reduce(replace, [" " => "", "\n" => "", "─" => ""], init=showed) == reduce(replace, [" " => "", "\n" => "", "─" => ""], init=expected)
-
-  io = IOBuffer()
-  show(io, gmres_solver, show_stats=false)
-  showed = String(take!(io))
-  expected = """
-  ┌───────────┬───────────────────┬─────────────────┐
-  │GmresSolver│    Precision: $FC │Architecture: CPU│
-  ├───────────┼───────────────────┼─────────────────┤
-  │  Attribute│               Type│             Size│
-  ├───────────┼───────────────────┼─────────────────┤
-  │         Δx│        Vector{$FC}│                0│
-  │          x│        Vector{$FC}│               64│
-  │          w│        Vector{$FC}│               64│
-  │          p│        Vector{$FC}│                0│
-  │          q│        Vector{$FC}│                0│
-  │          V│Vector{Vector{$FC}}│          10 x 64│
-  │          c│         Vector{$T}│               10│
-  │          s│        Vector{$FC}│               10│
-  │          z│        Vector{$FC}│               10│
-  │          R│        Vector{$FC}│               55│
-  │ warm_start│               Bool│                0│
-  │ inner_iter│              Int64│                0│
-  └───────────┴───────────────────┴─────────────────┘
-  """
-  @test reduce(replace, [" " => "", "\n" => "", "─" => ""], init=showed) == reduce(replace, [" " => "", "\n" => "", "─" => ""], init=expected)
-
-  io = IOBuffer()
-  show(io, fgmres_solver, show_stats=false)
-  showed = String(take!(io))
-  expected = """
-  ┌────────────┬───────────────────┬─────────────────┐
-  │FgmresSolver│    Precision: $FC │Architecture: CPU│
-  ├────────────┼───────────────────┼─────────────────┤
-  │   Attribute│               Type│             Size│
-  ├────────────┼───────────────────┼─────────────────┤
-  │          Δx│        Vector{$FC}│                0│
-  │           x│        Vector{$FC}│               64│
-  │           w│        Vector{$FC}│               64│
-  │           q│        Vector{$FC}│                0│
-  │           V│Vector{Vector{$FC}}│          10 x 64│
-  │           Z│Vector{Vector{$FC}}│          10 x 64│
-  │           c│         Vector{$T}│               10│
-  │           s│        Vector{$FC}│               10│
-  │           z│        Vector{$FC}│               10│
-  │           R│        Vector{$FC}│               55│
-  │  warm_start│               Bool│                0│
-  │  inner_iter│              Int64│                0│
-  └────────────┴───────────────────┴─────────────────┘
-  """
-  @test reduce(replace, [" " => "", "\n" => "", "─" => ""], init=showed) == reduce(replace, [" " => "", "\n" => "", "─" => ""], init=expected)
-
-  io = IOBuffer()
-  show(io, cr_solver, show_stats=false)
-  showed = String(take!(io))
-  expected = """
-  ┌──────────┬───────────────┬─────────────────┐
-  │  CrSolver│Precision: $FC │Architecture: CPU│
-  ├──────────┼───────────────┼─────────────────┤
-  │ Attribute│           Type│             Size│
-  ├──────────┼───────────────┼─────────────────┤
-  │        Δx│    Vector{$FC}│                0│
-  │         x│    Vector{$FC}│               64│
-  │         r│    Vector{$FC}│               64│
-  │         p│    Vector{$FC}│               64│
-  │         q│    Vector{$FC}│               64│
-  │        Ar│    Vector{$FC}│               64│
-  │        Mq│    Vector{$FC}│                0│
-  │warm_start│           Bool│                0│
-  └──────────┴───────────────┴─────────────────┘
-  """
-  @test reduce(replace, [" " => "", "\n" => "", "─" => ""], init=showed) == reduce(replace, [" " => "", "\n" => "", "─" => ""], init=expected)
-
-  io = IOBuffer()
-  show(io, crmr_solver, show_stats=false)
-  showed = String(take!(io))
-  expected = """
-  ┌──────────┬───────────────┬─────────────────┐
-  │CrmrSolver│Precision: $FC │Architecture: CPU│
-  ├──────────┼───────────────┼─────────────────┤
-  │ Attribute│           Type│             Size│
-  ├──────────┼───────────────┼─────────────────┤
-  │         x│    Vector{$FC}│               64│
-  │         p│    Vector{$FC}│               64│
-  │       Aᴴr│    Vector{$FC}│               64│
-  │         r│    Vector{$FC}│               32│
-  │         q│    Vector{$FC}│               32│
-  │        Nq│    Vector{$FC}│                0│
-  │         s│    Vector{$FC}│                0│
-  └──────────┴───────────────┴─────────────────┘
-  """
-  @test reduce(replace, [" " => "", "\n" => "", "─" => ""], init=showed) == reduce(replace, [" " => "", "\n" => "", "─" => ""], init=expected)
-
-  io = IOBuffer()
-  show(io, cgs_solver, show_stats=false)
-  showed = String(take!(io))
-  expected = """
-  ┌──────────┬───────────────┬─────────────────┐
-  │ CgsSolver│Precision: $FC │Architecture: CPU│
-  ├──────────┼───────────────┼─────────────────┤
-  │Attribute │           Type│             Size│
-  ├──────────┼───────────────┼─────────────────┤
-  │        Δx│    Vector{$FC}│                0│
-  │         x│    Vector{$FC}│               64│
-  │         r│    Vector{$FC}│               64│
-  │         u│    Vector{$FC}│               64│
-  │         p│    Vector{$FC}│               64│
-  │         q│    Vector{$FC}│               64│
-  │        ts│    Vector{$FC}│               64│
-  │        yz│    Vector{$FC}│                0│
-  │        vw│    Vector{$FC}│                0│
-  │warm_start│           Bool│                0│
-  └──────────┴───────────────┴─────────────────┘
-  """
-  @test reduce(replace, [" " => "", "\n" => "", "─" => ""], init=showed) == reduce(replace, [" " => "", "\n" => "", "─" => ""], init=expected)
-
-  io = IOBuffer()
-  show(io, bicgstab_solver, show_stats=false)
-  showed = String(take!(io))
-  expected = """
-  ┌──────────────┬───────────────┬─────────────────┐
-  │BicgstabSolver│Precision: $FC │Architecture: CPU│
-  ├──────────────┼───────────────┼─────────────────┤
-  │     Attribute│           Type│             Size│
-  ├──────────────┼───────────────┼─────────────────┤
-  │            Δx│    Vector{$FC}│                0│
-  │             x│    Vector{$FC}│               64│
-  │             r│    Vector{$FC}│               64│
-  │             p│    Vector{$FC}│               64│
-  │             v│    Vector{$FC}│               64│
-  │             s│    Vector{$FC}│               64│
-  │            qd│    Vector{$FC}│               64│
-  │            yz│    Vector{$FC}│                0│
-  │             t│    Vector{$FC}│                0│
-  │    warm_start│           Bool│                0│
-  └──────────────┴───────────────┴─────────────────┘
-  """
-  @test reduce(replace, [" " => "", "\n" => "", "─" => ""], init=showed) == reduce(replace, [" " => "", "\n" => "", "─" => ""], init=expected)
-
-  io = IOBuffer()
-  show(io, craigmr_solver, show_stats=false)
-  showed = String(take!(io))
-  expected = """
-  ┌─────────────┬───────────────┬─────────────────┐
-  │CraigmrSolver│Precision: $FC │Architecture: CPU│
-  ├─────────────┼───────────────┼─────────────────┤
-  │    Attribute│           Type│             Size│
-  ├─────────────┼───────────────┼─────────────────┤
-  │            x│    Vector{$FC}│               64│
-  │           Nv│    Vector{$FC}│               64│
-  │          Aᴴu│    Vector{$FC}│               64│
-  │            d│    Vector{$FC}│               64│
-  │            y│    Vector{$FC}│               32│
-  │           Mu│    Vector{$FC}│               32│
-  │            w│    Vector{$FC}│               32│
-  │         wbar│    Vector{$FC}│               32│
-  │           Av│    Vector{$FC}│               32│
-  │            u│    Vector{$FC}│                0│
-  │            v│    Vector{$FC}│                0│
-  │            q│    Vector{$FC}│                0│
-  └─────────────┴───────────────┴─────────────────┘
-  """
-  @test reduce(replace, [" " => "", "\n" => "", "─" => ""], init=showed) == reduce(replace, [" " => "", "\n" => "", "─" => ""], init=expected)
-
-  io = IOBuffer()
-  show(io, cgne_solver, show_stats=false)
-  showed = String(take!(io))
-  expected = """
-  ┌──────────┬───────────────┬─────────────────┐
-  │CgneSolver│Precision: $FC │Architecture: CPU│
-  ├──────────┼───────────────┼─────────────────┤
-  │ Attribute│           Type│             Size│
-  ├──────────┼───────────────┼─────────────────┤
-  │         x│    Vector{$FC}│               64│
-  │         p│    Vector{$FC}│               64│
-  │       Aᴴz│    Vector{$FC}│               64│
-  │         r│    Vector{$FC}│               32│
-  │         q│    Vector{$FC}│               32│
-  │         s│    Vector{$FC}│                0│
-  │         z│    Vector{$FC}│                0│
-  └──────────┴───────────────┴─────────────────┘
-  """
-  @test reduce(replace, [" " => "", "\n" => "", "─" => ""], init=showed) == reduce(replace, [" " => "", "\n" => "", "─" => ""], init=expected)
-
-  io = IOBuffer()
-  show(io, lnlq_solver, show_stats=false)
-  showed = String(take!(io))
-  expected = """
-  ┌──────────┬───────────────┬─────────────────┐
-  │LnlqSolver│Precision: $FC │Architecture: CPU│
-  ├──────────┼───────────────┼─────────────────┤
-  │ Attribute│           Type│             Size│
-  ├──────────┼───────────────┼─────────────────┤
-  │         x│    Vector{$FC}│               64│
-  │        Nv│    Vector{$FC}│               64│
-  │       Aᴴu│    Vector{$FC}│               64│
-  │         y│    Vector{$FC}│               32│
-  │         w̄│    Vector{$FC}│               32│
-  │        Mu│    Vector{$FC}│               32│
-  │        Av│    Vector{$FC}│               32│
-  │         u│    Vector{$FC}│                0│
-  │         v│    Vector{$FC}│                0│
-  │         q│    Vector{$FC}│                0│
-  └──────────┴───────────────┴─────────────────┘
-  """
-  @test reduce(replace, [" " => "", "\n" => "", "─" => ""], init=showed) == reduce(replace, [" " => "", "\n" => "", "─" => ""], init=expected)
-
-  io = IOBuffer()
-  show(io, craig_solver, show_stats=false)
-  showed = String(take!(io))
-  expected = """
-  ┌───────────┬───────────────┬─────────────────┐
-  │CraigSolver│Precision: $FC │Architecture: CPU│
-  ├───────────┼───────────────┼─────────────────┤
-  │  Attribute│           Type│             Size│
-  ├───────────┼───────────────┼─────────────────┤
-  │          x│    Vector{$FC}│               64│
-  │         Nv│    Vector{$FC}│               64│
-  │        Aᴴu│    Vector{$FC}│               64│
-  │          y│    Vector{$FC}│               32│
-  │          w│    Vector{$FC}│               32│
-  │         Mu│    Vector{$FC}│               32│
-  │         Av│    Vector{$FC}│               32│
-  │          u│    Vector{$FC}│                0│
-  │          v│    Vector{$FC}│                0│
-  │         w2│    Vector{$FC}│                0│
-  └───────────┴───────────────┴─────────────────┘
-  """
-  @test reduce(replace, [" " => "", "\n" => "", "─" => ""], init=showed) == reduce(replace, [" " => "", "\n" => "", "─" => ""], init=expected)
-
-  io = IOBuffer()
-  show(io, lslq_solver, show_stats=false)
-  showed = String(take!(io))
-  expected = """
-  ┌──────────┬───────────────┬─────────────────┐
-  │LslqSolver│Precision: $FC │Architecture: CPU│
-  ├──────────┼───────────────┼─────────────────┤
-  │ Attribute│           Type│             Size│
-  ├──────────┼───────────────┼─────────────────┤
-  │         x│    Vector{$FC}│               32│
-  │        Nv│    Vector{$FC}│               32│
-  │       Aᴴu│    Vector{$FC}│               32│
-  │         w̄│    Vector{$FC}│               32│
-  │        Mu│    Vector{$FC}│               64│
-  │        Av│    Vector{$FC}│               64│
-  │         u│    Vector{$FC}│                0│
-  │         v│    Vector{$FC}│                0│
-  │   err_vec│     Vector{$T}│                5│
-  └──────────┴───────────────┴─────────────────┘
-  """
-  @test reduce(replace, [" " => "", "\n" => "", "─" => ""], init=showed) == reduce(replace, [" " => "", "\n" => "", "─" => ""], init=expected)
-
-  io = IOBuffer()
-  show(io, cgls_solver, show_stats=false)
-  showed = String(take!(io))
-  expected = """
-  ┌──────────┬───────────────┬─────────────────┐
-  │CglsSolver│Precision: $FC │Architecture: CPU│
-  ├──────────┼───────────────┼─────────────────┤
-  │ Attribute│           Type│             Size│
-  ├──────────┼───────────────┼─────────────────┤
-  │         x│    Vector{$FC}│               32│
-  │         p│    Vector{$FC}│               32│
-  │         s│    Vector{$FC}│               32│
-  │         r│    Vector{$FC}│               64│
-  │         q│    Vector{$FC}│               64│
-  │        Mr│    Vector{$FC}│                0│
-  └──────────┴───────────────┴─────────────────┘
-  """
-  @test reduce(replace, [" " => "", "\n" => "", "─" => ""], init=showed) == reduce(replace, [" " => "", "\n" => "", "─" => ""], init=expected)
-
-  io = IOBuffer()
-  show(io, lsqr_solver, show_stats=false)
-  showed = String(take!(io))
-  expected = """
-  ┌──────────┬───────────────┬─────────────────┐
-  │LsqrSolver│Precision: $FC │Architecture: CPU│
-  ├──────────┼───────────────┼─────────────────┤
-  │ Attribute│           Type│             Size│
-  ├──────────┼───────────────┼─────────────────┤
-  │         x│    Vector{$FC}│               32│
-  │        Nv│    Vector{$FC}│               32│
-  │       Aᴴu│    Vector{$FC}│               32│
-  │         w│    Vector{$FC}│               32│
-  │        Mu│    Vector{$FC}│               64│
-  │        Av│    Vector{$FC}│               64│
-  │         u│    Vector{$FC}│                0│
-  │         v│    Vector{$FC}│                0│
-  │   err_vec│     Vector{$T}│                5│
-  └──────────┴───────────────┴─────────────────┘
-  """
-  @test reduce(replace, [" " => "", "\n" => "", "─" => ""], init=showed) == reduce(replace, [" " => "", "\n" => "", "─" => ""], init=expected)
-
-  io = IOBuffer()
-  show(io, crls_solver, show_stats=false)
-  showed = String(take!(io))
-  expected = """
-  ┌──────────┬───────────────┬─────────────────┐
-  │CrlsSolver│Precision: $FC │Architecture: CPU│
-  ├──────────┼───────────────┼─────────────────┤
-  │ Attribute│           Type│             Size│
-  ├──────────┼───────────────┼─────────────────┤
-  │         x│    Vector{$FC}│               32│
-  │         p│    Vector{$FC}│               32│
-  │        Ar│    Vector{$FC}│               32│
-  │         q│    Vector{$FC}│               32│
-  │         r│    Vector{$FC}│               64│
-  │        Ap│    Vector{$FC}│               64│
-  │         s│    Vector{$FC}│               64│
-  │        Ms│    Vector{$FC}│                0│
-  └──────────┴───────────────┴─────────────────┘
-  """
-  @test reduce(replace, [" " => "", "\n" => "", "─" => ""], init=showed) == reduce(replace, [" " => "", "\n" => "", "─" => ""], init=expected)
-
-  io = IOBuffer()
-  show(io, lsmr_solver, show_stats=false)
-  showed = String(take!(io))
-  expected = """
-  ┌──────────┬───────────────┬─────────────────┐
-  │LsmrSolver│Precision: $FC │Architecture: CPU│
-  ├──────────┼───────────────┼─────────────────┤
-  │ Attribute│           Type│             Size│
-  ├──────────┼───────────────┼─────────────────┤
-  │         x│    Vector{$FC}│               32│
-  │        Nv│    Vector{$FC}│               32│
-  │       Aᴴu│    Vector{$FC}│               32│
-  │         h│    Vector{$FC}│               32│
-  │      hbar│    Vector{$FC}│               32│
-  │        Mu│    Vector{$FC}│               64│
-  │        Av│    Vector{$FC}│               64│
-  │         u│    Vector{$FC}│                0│
-  │         v│    Vector{$FC}│                0│
-  │   err_vec│     Vector{$T}│                5│
-  └──────────┴───────────────┴─────────────────┘
-  """
-  @test reduce(replace, [" " => "", "\n" => "", "─" => ""], init=showed) == reduce(replace, [" " => "", "\n" => "", "─" => ""], init=expected)
-
-  io = IOBuffer()
-  show(io, usymqr_solver, show_stats=false)
-  showed = String(take!(io))
-  expected = """
-  ┌────────────┬───────────────┬─────────────────┐
-  │UsymqrSolver│Precision: $FC │Architecture: CPU│
-  ├────────────┼───────────────┼─────────────────┤
-  │   Attribute│           Type│             Size│
-  ├────────────┼───────────────┼─────────────────┤
-  │        vₖ₋₁│    Vector{$FC}│               64│
-  │          vₖ│    Vector{$FC}│               64│
-  │           q│    Vector{$FC}│               64│
-  │          Δx│    Vector{$FC}│                0│
-  │           x│    Vector{$FC}│               32│
-  │        wₖ₋₂│    Vector{$FC}│               32│
-  │        wₖ₋₁│    Vector{$FC}│               32│
-  │        uₖ₋₁│    Vector{$FC}│               32│
-  │          uₖ│    Vector{$FC}│               32│
-  │           p│    Vector{$FC}│               32│
-  │  warm_start│           Bool│                0│
-  └────────────┴───────────────┴─────────────────┘
-  """
-  @test reduce(replace, [" " => "", "\n" => "", "─" => ""], init=showed) == reduce(replace, [" " => "", "\n" => "", "─" => ""], init=expected)
-
-  io = IOBuffer()
-  show(io, trilqr_solver, show_stats=false)
-  showed = String(take!(io))
-  expected = """
-  ┌────────────┬───────────────┬─────────────────┐
-  │TrilqrSolver│Precision: $FC │Architecture: CPU│
-  ├────────────┼───────────────┼─────────────────┤
-  │   Attribute│           Type│             Size│
-  ├────────────┼───────────────┼─────────────────┤
-  │        uₖ₋₁│    Vector{$FC}│               64│
-  │          uₖ│    Vector{$FC}│               64│
-  │           p│    Vector{$FC}│               64│
-  │           d̅│    Vector{$FC}│               64│
-  │          Δx│    Vector{$FC}│                0│
-  │           x│    Vector{$FC}│               64│
-  │        vₖ₋₁│    Vector{$FC}│               64│
-  │          vₖ│    Vector{$FC}│               64│
-  │           q│    Vector{$FC}│               64│
-  │          Δy│    Vector{$FC}│                0│
-  │           y│    Vector{$FC}│               64│
-  │        wₖ₋₃│    Vector{$FC}│               64│
-  │        wₖ₋₂│    Vector{$FC}│               64│
-  │  warm_start│           Bool│                0│
-  └────────────┴───────────────┴─────────────────┘
-  """
-  @test reduce(replace, [" " => "", "\n" => "", "─" => ""], init=showed) == reduce(replace, [" " => "", "\n" => "", "─" => ""], init=expected)
-
-  io = IOBuffer()
-  show(io, bilq_solver, show_stats=false)
-  showed = String(take!(io))
-  expected = """
-  ┌──────────┬───────────────┬─────────────────┐
-  │BilqSolver│Precision: $FC │Architecture: CPU│
-  ├──────────┼───────────────┼─────────────────┤
-  │ Attribute│           Type│             Size│
-  ├──────────┼───────────────┼─────────────────┤
-  │      uₖ₋₁│    Vector{$FC}│               64│
-  │        uₖ│    Vector{$FC}│               64│
-  │         q│    Vector{$FC}│               64│
-  │      vₖ₋₁│    Vector{$FC}│               64│
-  │        vₖ│    Vector{$FC}│               64│
-  │         p│    Vector{$FC}│               64│
-  │        Δx│    Vector{$FC}│                0│
-  │         x│    Vector{$FC}│               64│
-  │         d̅│    Vector{$FC}│               64│
-  │warm_start│           Bool│                0│
-  └──────────┴───────────────┴─────────────────┘
-  """
-  @test reduce(replace, [" " => "", "\n" => "", "─" => ""], init=showed) == reduce(replace, [" " => "", "\n" => "", "─" => ""], init=expected)
-
-  io = IOBuffer()
-  show(io, bilqr_solver, show_stats=false)
-  showed = String(take!(io))
-  expected = """
-  ┌───────────┬───────────────┬─────────────────┐
-  │BilqrSolver│Precision: $FC │Architecture: CPU│
-  ├───────────┼───────────────┼─────────────────┤
-  │  Attribute│           Type│             Size│
-  ├───────────┼───────────────┼─────────────────┤
-  │       uₖ₋₁│    Vector{$FC}│               64│
-  │         uₖ│    Vector{$FC}│               64│
-  │          q│    Vector{$FC}│               64│
-  │       vₖ₋₁│    Vector{$FC}│               64│
-  │         vₖ│    Vector{$FC}│               64│
-  │          p│    Vector{$FC}│               64│
-  │         Δx│    Vector{$FC}│                0│
-  │          x│    Vector{$FC}│               64│
-  │         Δy│    Vector{$FC}│                0│
-  │          y│    Vector{$FC}│               64│
-  │          d̅│    Vector{$FC}│               64│
-  │       wₖ₋₃│    Vector{$FC}│               64│
-  │       wₖ₋₂│    Vector{$FC}│               64│
-  │ warm_start│           Bool│                0│
-  └───────────┴───────────────┴─────────────────┘
-  """
-  @test reduce(replace, [" " => "", "\n" => "", "─" => ""], init=showed) == reduce(replace, [" " => "", "\n" => "", "─" => ""], init=expected)
-
-  io = IOBuffer()
-  show(io, minres_qlp_solver, show_stats=false)
-  showed = String(take!(io))
-  expected = """
-  ┌───────────────┬───────────────┬─────────────────┐
-  │MinresQlpSolver│Precision: $FC │Architecture: CPU│
-  ├───────────────┼───────────────┼─────────────────┤
-  │      Attribute│           Type│             Size│
-  ├───────────────┼───────────────┼─────────────────┤
-  │             Δx│    Vector{$FC}│                0│
-  │           wₖ₋₁│    Vector{$FC}│               64│
-  │             wₖ│    Vector{$FC}│               64│
-  │        M⁻¹vₖ₋₁│    Vector{$FC}│               64│
-  │          M⁻¹vₖ│    Vector{$FC}│               64│
-  │              x│    Vector{$FC}│               64│
-  │              p│    Vector{$FC}│               64│
-  │             vₖ│    Vector{$FC}│                0│
-  │     warm_start│           Bool│                0│
-  └───────────────┴───────────────┴─────────────────┘
-  """
-  @test reduce(replace, [" " => "", "\n" => "", "─" => ""], init=showed) == reduce(replace, [" " => "", "\n" => "", "─" => ""], init=expected)
-
-  io = IOBuffer()
-  show(io, qmr_solver, show_stats=false)
-  showed = String(take!(io))
-  expected = """
-  ┌──────────┬───────────────┬─────────────────┐
-  │ QmrSolver│Precision: $FC │Architecture: CPU│
-  ├──────────┼───────────────┼─────────────────┤
-  │ Attribute│           Type│             Size│
-  ├──────────┼───────────────┼─────────────────┤
-  │      uₖ₋₁│    Vector{$FC}│               64│
-  │        uₖ│    Vector{$FC}│               64│
-  │         q│    Vector{$FC}│               64│
-  │      vₖ₋₁│    Vector{$FC}│               64│
-  │        vₖ│    Vector{$FC}│               64│
-  │         p│    Vector{$FC}│               64│
-  │        Δx│    Vector{$FC}│                0│
-  │         x│    Vector{$FC}│               64│
-  │      wₖ₋₂│    Vector{$FC}│               64│
-  │      wₖ₋₁│    Vector{$FC}│               64│
-  │warm_start│           Bool│                0│
-  └──────────┴───────────────┴─────────────────┘
-  """
-  @test reduce(replace, [" " => "", "\n" => "", "─" => ""], init=showed) == reduce(replace, [" " => "", "\n" => "", "─" => ""], init=expected)
-
-  io = IOBuffer()
-  show(io, usymlq_solver, show_stats=false)
-  showed = String(take!(io))
-  expected = """
-  ┌────────────┬───────────────┬─────────────────┐
-  │UsymlqSolver│Precision: $FC │Architecture: CPU│
-  ├────────────┼───────────────┼─────────────────┤
-  │   Attribute│           Type│             Size│
-  ├────────────┼───────────────┼─────────────────┤
-  │        uₖ₋₁│    Vector{$FC}│               64│
-  │          uₖ│    Vector{$FC}│               64│
-  │           p│    Vector{$FC}│               64│
-  │          Δx│    Vector{$FC}│                0│
-  │           x│    Vector{$FC}│               64│
-  │           d̅│    Vector{$FC}│               64│
-  │        vₖ₋₁│    Vector{$FC}│               32│
-  │          vₖ│    Vector{$FC}│               32│
-  │           q│    Vector{$FC}│               32│
-  │  warm_start│           Bool│                0│
-  └────────────┴───────────────┴─────────────────┘
-  """
-  @test reduce(replace, [" " => "", "\n" => "", "─" => ""], init=showed) == reduce(replace, [" " => "", "\n" => "", "─" => ""], init=expected)
-
-  io = IOBuffer()
-  show(io, tricg_solver, show_stats=false)
-  showed = String(take!(io))
-  expected = """
-  ┌───────────┬───────────────┬─────────────────┐
-  │TricgSolver│Precision: $FC │Architecture: CPU│
-  ├───────────┼───────────────┼─────────────────┤
-  │  Attribute│           Type│             Size│
-  ├───────────┼───────────────┼─────────────────┤
-  │          y│    Vector{$FC}│               64│
-  │    N⁻¹uₖ₋₁│    Vector{$FC}│               64│
-  │      N⁻¹uₖ│    Vector{$FC}│               64│
-  │          p│    Vector{$FC}│               64│
-  │     gy₂ₖ₋₁│    Vector{$FC}│               64│
-  │       gy₂ₖ│    Vector{$FC}│               64│
-  │          x│    Vector{$FC}│               32│
-  │    M⁻¹vₖ₋₁│    Vector{$FC}│               32│
-  │      M⁻¹vₖ│    Vector{$FC}│               32│
-  │          q│    Vector{$FC}│               32│
-  │     gx₂ₖ₋₁│    Vector{$FC}│               32│
-  │       gx₂ₖ│    Vector{$FC}│               32│
-  │         Δx│    Vector{$FC}│                0│
-  │         Δy│    Vector{$FC}│                0│
-  │         uₖ│    Vector{$FC}│                0│
-  │         vₖ│    Vector{$FC}│                0│
-  │ warm_start│           Bool│                0│
-  └───────────┴───────────────┴─────────────────┘
-  """
-  @test reduce(replace, [" " => "", "\n" => "", "─" => ""], init=showed) == reduce(replace, [" " => "", "\n" => "", "─" => ""], init=expected)
-
-  io = IOBuffer()
-  show(io, trimr_solver, show_stats=false)
-  showed = String(take!(io))
-  expected = """
-  ┌───────────┬───────────────┬─────────────────┐
-  │TrimrSolver│Precision: $FC │Architecture: CPU│
-  ├───────────┼───────────────┼─────────────────┤
-  │  Attribute│           Type│             Size│
-  ├───────────┼───────────────┼─────────────────┤
-  │          y│    Vector{$FC}│               64│
-  │    N⁻¹uₖ₋₁│    Vector{$FC}│               64│
-  │      N⁻¹uₖ│    Vector{$FC}│               64│
-  │          p│    Vector{$FC}│               64│
-  │     gy₂ₖ₋₃│    Vector{$FC}│               64│
-  │     gy₂ₖ₋₂│    Vector{$FC}│               64│
-  │     gy₂ₖ₋₁│    Vector{$FC}│               64│
-  │       gy₂ₖ│    Vector{$FC}│               64│
-  │          x│    Vector{$FC}│               32│
-  │    M⁻¹vₖ₋₁│    Vector{$FC}│               32│
-  │      M⁻¹vₖ│    Vector{$FC}│               32│
-  │          q│    Vector{$FC}│               32│
-  │     gx₂ₖ₋₃│    Vector{$FC}│               32│
-  │     gx₂ₖ₋₂│    Vector{$FC}│               32│
-  │     gx₂ₖ₋₁│    Vector{$FC}│               32│
-  │       gx₂ₖ│    Vector{$FC}│               32│
-  │         Δx│    Vector{$FC}│                0│
-  │         Δy│    Vector{$FC}│                0│
-  │         uₖ│    Vector{$FC}│                0│
-  │         vₖ│    Vector{$FC}│                0│
-  │ warm_start│           Bool│                0│
-  └───────────┴───────────────┴─────────────────┘
-  """
-  @test reduce(replace, [" " => "", "\n" => "", "─" => ""], init=showed) == reduce(replace, [" " => "", "\n" => "", "─" => ""], init=expected)
-
-  io = IOBuffer()
-  show(io, gpmr_solver, show_stats=false)
-  showed = String(take!(io))
-  expected = """
-  ┌──────────┬───────────────────┬─────────────────┐
-  │GpmrSolver│    Precision: $FC │Architecture: CPU│
-  ├──────────┼───────────────────┼─────────────────┤
-  │ Attribute│               Type│             Size│
-  ├──────────┼───────────────────┼─────────────────┤
-  │        wA│        Vector{$FC}│                0│
-  │        wB│        Vector{$FC}│                0│
-  │        dA│        Vector{$FC}│               64│
-  │        dB│        Vector{$FC}│               32│
-  │        Δx│        Vector{$FC}│                0│
-  │        Δy│        Vector{$FC}│                0│
-  │         x│        Vector{$FC}│               64│
-  │         y│        Vector{$FC}│               32│
-  │         q│        Vector{$FC}│                0│
-  │         p│        Vector{$FC}│                0│
-  │         V│Vector{Vector{$FC}}│          10 x 64│
-  │         U│Vector{Vector{$FC}}│          10 x 32│
-  │        gs│        Vector{$FC}│               40│
-  │        gc│         Vector{$T}│               40│
-  │        zt│        Vector{$FC}│               20│
-  │         R│        Vector{$FC}│              210│
-  │warm_start│               Bool│                0│
-  └──────────┴───────────────────┴─────────────────┘
-  """
-  @test reduce(replace, [" " => "", "\n" => "", "─" => ""], init=showed) == reduce(replace, [" " => "", "\n" => "", "─" => ""], init=expected)
 end
 
 @testset "solvers" begin

--- a/test/test_solvers.jl
+++ b/test/test_solvers.jl
@@ -142,6 +142,9 @@ function test_solvers(FC)
       @test mapreduce(x -> length(x) - mapreduce(y -> occursin(y, x), |, ["w̅","w̄","d̅"]) == len_col1, &, str2[1:3:end-2])
       @test mapreduce(x -> length(x) - mapreduce(y -> occursin(y, x), |, ["w̅","w̄","d̅"]) == len_col2, &, str2[2:3:end-1])
       @test mapreduce(x -> length(x) - mapreduce(y -> occursin(y, x), |, ["w̅","w̄","d̅"]) == len_col3, &, str2[3:3:end])
+
+      # Code coverage
+      show(io, solver, show_stats=true)
     end
   end
 end


### PR DESCRIPTION
@dpo @tmigot 
I modified the `show` function for the Krylov solvers.
It displays `nrows`, `ncols` AND the `storage` used by the solver!!!
Maybe we should say `unallocated` for the size of empty vectors instead of `0` byte.
What do you think? 

```julia
using SuiteSparseMatrixCollection, MatrixMarket, Krylov

ssmc = ssmc_db()

matrix_name = "pre2"
matrix = ssmc_matrices(ssmc, "", matrix_name)
paths = fetch_ssmc(matrix, format="MM")
M = MatrixMarket.mmread(joinpath(paths[1], matrix_name * ".mtx"))

bilq_solver = BilqSolver(size(M)..., Vector{Float64})
bicgstab_solver = BicgstabSolver(size(M)..., Vector{Float64})

matrix_name = "nlpkkt200"
matrix = ssmc_matrices(ssmc, "", matrix_name)
paths = fetch_ssmc(matrix, format="MM")
M = MatrixMarket.mmread(joinpath(paths[1], matrix_name * ".mtx"))

cg_solver = CgSolver(size(M)..., CuVector{Float64})
minresqlp_solver = MinresQlpSolver(size(M)..., CuVector{Float64})
```
![Capture d’écran du 2022-10-07 02-07-58](https://user-images.githubusercontent.com/35051714/194479844-d1ea65ae-239c-4add-a340-86d29ba5ee81.png)
![Capture d’écran du 2022-10-07 02-08-14](https://user-images.githubusercontent.com/35051714/194479917-216b3661-f20a-461f-976b-fa960ea9f77f.png)
![Capture d’écran du 2022-10-07 02-12-08](https://user-images.githubusercontent.com/35051714/194479930-a0f7e5de-561f-4b54-84d3-e23e058e2520.png)
![Capture d’écran du 2022-10-07 02-12-24](https://user-images.githubusercontent.com/35051714/194479941-b5b11439-006b-4ffd-8ea0-0f94a095a0cb.png)
