### PR TITLE
[KrylovSolvers] Improve GPU support

### DIFF
--- a/src/bicgstab.jl
+++ b/src/bicgstab.jl
@@ -112,8 +112,8 @@ function bicgstab!(solver :: BicgstabSolver{T,FC,S}, A, b :: AbstractVector{FC};
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
-  ktypeof(c) <: S || error("ktypeof(c) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) is not a subtype of $S")
+  ktypeof(c) <: S || error("ktypeof(c) is not a subtype of $S")
 
   # Set up workspace.
   allocate_if(!MisI, solver, :t , S, n)

--- a/src/bicgstab.jl
+++ b/src/bicgstab.jl
@@ -112,8 +112,8 @@ function bicgstab!(solver :: BicgstabSolver{T,FC,S}, A, b :: AbstractVector{FC};
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) == S || error("ktypeof(b) ≠ $S")
-  ktypeof(c) == S || error("ktypeof(c) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
+  ktypeof(c) <: S || error("ktypeof(c) ≠ $S")
 
   # Set up workspace.
   allocate_if(!MisI, solver, :t , S, n)

--- a/src/bilq.jl
+++ b/src/bilq.jl
@@ -96,8 +96,8 @@ function bilq!(solver :: BilqSolver{T,FC,S}, A, b :: AbstractVector{FC}; c :: Ab
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) == S || error("ktypeof(b) ≠ $S")
-  ktypeof(c) == S || error("ktypeof(c) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
+  ktypeof(c) <: S || error("ktypeof(c) ≠ $S")
 
   # Compute the adjoint of A
   Aᴴ = A'

--- a/src/bilq.jl
+++ b/src/bilq.jl
@@ -96,8 +96,8 @@ function bilq!(solver :: BilqSolver{T,FC,S}, A, b :: AbstractVector{FC}; c :: Ab
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
-  ktypeof(c) <: S || error("ktypeof(c) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) is not a subtype of $S")
+  ktypeof(c) <: S || error("ktypeof(c) is not a subtype of $S")
 
   # Compute the adjoint of A
   Aᴴ = A'

--- a/src/bilqr.jl
+++ b/src/bilqr.jl
@@ -102,8 +102,8 @@ function bilqr!(solver :: BilqrSolver{T,FC,S}, A, b :: AbstractVector{FC}, c :: 
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) == S || error("ktypeof(b) ≠ $S")
-  ktypeof(c) == S || error("ktypeof(c) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
+  ktypeof(c) <: S || error("ktypeof(c) ≠ $S")
 
   # Compute the adjoint of A
   Aᴴ = A'

--- a/src/bilqr.jl
+++ b/src/bilqr.jl
@@ -102,8 +102,8 @@ function bilqr!(solver :: BilqrSolver{T,FC,S}, A, b :: AbstractVector{FC}, c :: 
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
-  ktypeof(c) <: S || error("ktypeof(c) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) is not a subtype of $S")
+  ktypeof(c) <: S || error("ktypeof(c) is not a subtype of $S")
 
   # Compute the adjoint of A
   Aᴴ = A'

--- a/src/cg.jl
+++ b/src/cg.jl
@@ -107,7 +107,7 @@ function cg!(solver :: CgSolver{T,FC,S}, A, b :: AbstractVector{FC};
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) == S || error("ktypeof(b) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
 
   # Set up workspace.
   allocate_if(!MisI, solver, :z, S, n)

--- a/src/cg.jl
+++ b/src/cg.jl
@@ -107,7 +107,7 @@ function cg!(solver :: CgSolver{T,FC,S}, A, b :: AbstractVector{FC};
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) is not a subtype of $S")
 
   # Set up workspace.
   allocate_if(!MisI, solver, :z, S, n)

--- a/src/cg_lanczos.jl
+++ b/src/cg_lanczos.jl
@@ -99,7 +99,7 @@ function cg_lanczos!(solver :: CgLanczosSolver{T,FC,S}, A, b :: AbstractVector{F
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $T")
-  ktypeof(b) == S || error("ktypeof(b) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
 
   # Set up workspace.
   allocate_if(!MisI, solver, :v, S, n)

--- a/src/cg_lanczos.jl
+++ b/src/cg_lanczos.jl
@@ -99,7 +99,7 @@ function cg_lanczos!(solver :: CgLanczosSolver{T,FC,S}, A, b :: AbstractVector{F
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $T")
-  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) is not a subtype of $S")
 
   # Set up workspace.
   allocate_if(!MisI, solver, :v, S, n)

--- a/src/cg_lanczos_shift.jl
+++ b/src/cg_lanczos_shift.jl
@@ -89,7 +89,7 @@ function cg_lanczos_shift!(solver :: CgLanczosShiftSolver{T,FC,S}, A, b :: Abstr
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) is not a subtype of $S")
 
   # Set up workspace.
   allocate_if(!MisI, solver, :v, S, n)

--- a/src/cg_lanczos_shift.jl
+++ b/src/cg_lanczos_shift.jl
@@ -89,7 +89,7 @@ function cg_lanczos_shift!(solver :: CgLanczosShiftSolver{T,FC,S}, A, b :: Abstr
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) == S || error("ktypeof(b) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
 
   # Set up workspace.
   allocate_if(!MisI, solver, :v, S, n)

--- a/src/cgls.jl
+++ b/src/cgls.jl
@@ -102,7 +102,7 @@ function cgls!(solver :: CglsSolver{T,FC,S}, A, b :: AbstractVector{FC};
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) == S || error("ktypeof(b) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
 
   # Compute the adjoint of A
   Aᴴ = A'

--- a/src/cgls.jl
+++ b/src/cgls.jl
@@ -102,7 +102,7 @@ function cgls!(solver :: CglsSolver{T,FC,S}, A, b :: AbstractVector{FC};
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) is not a subtype of $S")
 
   # Compute the adjoint of A
   Aᴴ = A'

--- a/src/cgne.jl
+++ b/src/cgne.jl
@@ -111,7 +111,7 @@ function cgne!(solver :: CgneSolver{T,FC,S}, A, b :: AbstractVector{FC};
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) is not a subtype of $S")
 
   # Compute the adjoint of A
   Aᴴ = A'

--- a/src/cgne.jl
+++ b/src/cgne.jl
@@ -111,7 +111,7 @@ function cgne!(solver :: CgneSolver{T,FC,S}, A, b :: AbstractVector{FC};
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) == S || error("ktypeof(b) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
 
   # Compute the adjoint of A
   Aᴴ = A'

--- a/src/cgs.jl
+++ b/src/cgs.jl
@@ -109,8 +109,8 @@ function cgs!(solver :: CgsSolver{T,FC,S}, A, b :: AbstractVector{FC}; c :: Abst
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
-  ktypeof(c) <: S || error("ktypeof(c) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) is not a subtype of $S")
+  ktypeof(c) <: S || error("ktypeof(c) is not a subtype of $S")
 
   # Set up workspace.
   allocate_if(!MisI, solver, :vw, S, n)

--- a/src/cgs.jl
+++ b/src/cgs.jl
@@ -109,8 +109,8 @@ function cgs!(solver :: CgsSolver{T,FC,S}, A, b :: AbstractVector{FC}; c :: Abst
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) == S || error("ktypeof(b) ≠ $S")
-  ktypeof(c) == S || error("ktypeof(c) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
+  ktypeof(c) <: S || error("ktypeof(c) ≠ $S")
 
   # Set up workspace.
   allocate_if(!MisI, solver, :vw, S, n)

--- a/src/cr.jl
+++ b/src/cr.jl
@@ -106,7 +106,7 @@ function cr!(solver :: CrSolver{T,FC,S}, A, b :: AbstractVector{FC};
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) is not a subtype of $S")
 
   # Set up workspace
   allocate_if(!MisI, solver, :Mq, S, n)

--- a/src/cr.jl
+++ b/src/cr.jl
@@ -106,7 +106,7 @@ function cr!(solver :: CrSolver{T,FC,S}, A, b :: AbstractVector{FC};
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) == S || error("ktypeof(b) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
 
   # Set up workspace
   allocate_if(!MisI, solver, :Mq, S, n)

--- a/src/craig.jl
+++ b/src/craig.jl
@@ -142,7 +142,7 @@ function craig!(solver :: CraigSolver{T,FC,S}, A, b :: AbstractVector{FC};
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) is not a subtype of $S")
 
   # Compute the adjoint of A
   Aᴴ = A'

--- a/src/craig.jl
+++ b/src/craig.jl
@@ -142,7 +142,7 @@ function craig!(solver :: CraigSolver{T,FC,S}, A, b :: AbstractVector{FC};
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) == S || error("ktypeof(b) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
 
   # Compute the adjoint of A
   Aᴴ = A'

--- a/src/craigmr.jl
+++ b/src/craigmr.jl
@@ -137,7 +137,7 @@ function craigmr!(solver :: CraigmrSolver{T,FC,S}, A, b :: AbstractVector{FC};
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) is not a subtype of $S")
 
   # Compute the adjoint of A
   Aᴴ = A'

--- a/src/craigmr.jl
+++ b/src/craigmr.jl
@@ -137,7 +137,7 @@ function craigmr!(solver :: CraigmrSolver{T,FC,S}, A, b :: AbstractVector{FC};
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) == S || error("ktypeof(b) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
 
   # Compute the adjoint of A
   Aᴴ = A'

--- a/src/crls.jl
+++ b/src/crls.jl
@@ -93,7 +93,7 @@ function crls!(solver :: CrlsSolver{T,FC,S}, A, b :: AbstractVector{FC};
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) == S || error("ktypeof(b) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
 
   # Compute the adjoint of A
   Aᴴ = A'

--- a/src/crls.jl
+++ b/src/crls.jl
@@ -93,7 +93,7 @@ function crls!(solver :: CrlsSolver{T,FC,S}, A, b :: AbstractVector{FC};
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) is not a subtype of $S")
 
   # Compute the adjoint of A
   Aᴴ = A'

--- a/src/crmr.jl
+++ b/src/crmr.jl
@@ -109,7 +109,7 @@ function crmr!(solver :: CrmrSolver{T,FC,S}, A, b :: AbstractVector{FC};
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) is not a subtype of $S")
 
   # Compute the adjoint of A
   Aᴴ = A'

--- a/src/crmr.jl
+++ b/src/crmr.jl
@@ -109,7 +109,7 @@ function crmr!(solver :: CrmrSolver{T,FC,S}, A, b :: AbstractVector{FC};
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) == S || error("ktypeof(b) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
 
   # Compute the adjoint of A
   Aᴴ = A'

--- a/src/diom.jl
+++ b/src/diom.jl
@@ -107,7 +107,7 @@ function diom!(solver :: DiomSolver{T,FC,S}, A, b :: AbstractVector{FC};
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) is not a subtype of $S")
 
   # Set up workspace.
   allocate_if(!MisI, solver, :w, S, n)

--- a/src/diom.jl
+++ b/src/diom.jl
@@ -107,7 +107,7 @@ function diom!(solver :: DiomSolver{T,FC,S}, A, b :: AbstractVector{FC};
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) == S || error("ktypeof(b) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
 
   # Set up workspace.
   allocate_if(!MisI, solver, :w, S, n)

--- a/src/dqgmres.jl
+++ b/src/dqgmres.jl
@@ -107,7 +107,7 @@ function dqgmres!(solver :: DqgmresSolver{T,FC,S}, A, b :: AbstractVector{FC};
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) == S || error("ktypeof(b) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
 
   # Set up workspace.
   allocate_if(!MisI, solver, :w, S, n)

--- a/src/dqgmres.jl
+++ b/src/dqgmres.jl
@@ -107,7 +107,7 @@ function dqgmres!(solver :: DqgmresSolver{T,FC,S}, A, b :: AbstractVector{FC};
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) is not a subtype of $S")
 
   # Set up workspace.
   allocate_if(!MisI, solver, :w, S, n)

--- a/src/fgmres.jl
+++ b/src/fgmres.jl
@@ -109,7 +109,7 @@ function fgmres!(solver :: FgmresSolver{T,FC,S}, A, b :: AbstractVector{FC};
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) is not a subtype of $S")
 
   # Set up workspace.
   allocate_if(!MisI  , solver, :q , S, n)

--- a/src/fgmres.jl
+++ b/src/fgmres.jl
@@ -109,7 +109,7 @@ function fgmres!(solver :: FgmresSolver{T,FC,S}, A, b :: AbstractVector{FC};
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) == S || error("ktypeof(b) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
 
   # Set up workspace.
   allocate_if(!MisI  , solver, :q , S, n)

--- a/src/fom.jl
+++ b/src/fom.jl
@@ -104,7 +104,7 @@ function fom!(solver :: FomSolver{T,FC,S}, A, b :: AbstractVector{FC};
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) == S || error("ktypeof(b) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
 
   # Set up workspace.
   allocate_if(!MisI  , solver, :q , S, n)

--- a/src/fom.jl
+++ b/src/fom.jl
@@ -104,7 +104,7 @@ function fom!(solver :: FomSolver{T,FC,S}, A, b :: AbstractVector{FC};
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) is not a subtype of $S")
 
   # Set up workspace.
   allocate_if(!MisI  , solver, :q , S, n)

--- a/src/gmres.jl
+++ b/src/gmres.jl
@@ -104,7 +104,7 @@ function gmres!(solver :: GmresSolver{T,FC,S}, A, b :: AbstractVector{FC};
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) is not a subtype of $S")
 
   # Set up workspace.
   allocate_if(!MisI  , solver, :q , S, n)

--- a/src/gmres.jl
+++ b/src/gmres.jl
@@ -104,7 +104,7 @@ function gmres!(solver :: GmresSolver{T,FC,S}, A, b :: AbstractVector{FC};
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) == S || error("ktypeof(b) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
 
   # Set up workspace.
   allocate_if(!MisI  , solver, :q , S, n)

--- a/src/gpmr.jl
+++ b/src/gpmr.jl
@@ -143,8 +143,8 @@ function gpmr!(solver :: GpmrSolver{T,FC,S}, A, B, b :: AbstractVector{FC}, c ::
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
   eltype(B) == FC || error("eltype(B) ≠ $FC")
-  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
-  ktypeof(c) <: S || error("ktypeof(c) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) is not a subtype of $S")
+  ktypeof(c) <: S || error("ktypeof(c) is not a subtype of $S")
 
   # Determine λ and μ associated to generalized saddle point systems.
   gsp && (λ = one(FC) ; μ = zero(FC))

--- a/src/gpmr.jl
+++ b/src/gpmr.jl
@@ -143,8 +143,8 @@ function gpmr!(solver :: GpmrSolver{T,FC,S}, A, B, b :: AbstractVector{FC}, c ::
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
   eltype(B) == FC || error("eltype(B) ≠ $FC")
-  ktypeof(b) == S || error("ktypeof(b) ≠ $S")
-  ktypeof(c) == S || error("ktypeof(c) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
+  ktypeof(c) <: S || error("ktypeof(c) ≠ $S")
 
   # Determine λ and μ associated to generalized saddle point systems.
   gsp && (λ = one(FC) ; μ = zero(FC))

--- a/src/lnlq.jl
+++ b/src/lnlq.jl
@@ -134,7 +134,7 @@ function lnlq!(solver :: LnlqSolver{T,FC,S}, A, b :: AbstractVector{FC};
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) is not a subtype of $S")
 
   # Compute the adjoint of A
   Aᴴ = A'

--- a/src/lnlq.jl
+++ b/src/lnlq.jl
@@ -134,7 +134,7 @@ function lnlq!(solver :: LnlqSolver{T,FC,S}, A, b :: AbstractVector{FC};
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) == S || error("ktypeof(b) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
 
   # Compute the adjoint of A
   Aᴴ = A'

--- a/src/lslq.jl
+++ b/src/lslq.jl
@@ -176,7 +176,7 @@ function lslq!(solver :: LslqSolver{T,FC,S}, A, b :: AbstractVector{FC};
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) == S || error("ktypeof(b) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
 
   # Compute the adjoint of A
   Aᴴ = A'

--- a/src/lslq.jl
+++ b/src/lslq.jl
@@ -176,7 +176,7 @@ function lslq!(solver :: LslqSolver{T,FC,S}, A, b :: AbstractVector{FC};
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) is not a subtype of $S")
 
   # Compute the adjoint of A
   Aᴴ = A'

--- a/src/lsmr.jl
+++ b/src/lsmr.jl
@@ -141,7 +141,7 @@ function lsmr!(solver :: LsmrSolver{T,FC,S}, A, b :: AbstractVector{FC};
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) is not a subtype of $S")
 
   # Compute the adjoint of A
   Aᴴ = A'

--- a/src/lsmr.jl
+++ b/src/lsmr.jl
@@ -141,7 +141,7 @@ function lsmr!(solver :: LsmrSolver{T,FC,S}, A, b :: AbstractVector{FC};
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) == S || error("ktypeof(b) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
 
   # Compute the adjoint of A
   Aᴴ = A'

--- a/src/lsqr.jl
+++ b/src/lsqr.jl
@@ -136,7 +136,7 @@ function lsqr!(solver :: LsqrSolver{T,FC,S}, A, b :: AbstractVector{FC};
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) is not a subtype of $S")
 
   # Compute the adjoint of A
   Aᴴ = A'

--- a/src/lsqr.jl
+++ b/src/lsqr.jl
@@ -136,7 +136,7 @@ function lsqr!(solver :: LsqrSolver{T,FC,S}, A, b :: AbstractVector{FC};
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) == S || error("ktypeof(b) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
 
   # Compute the adjoint of A
   Aᴴ = A'

--- a/src/minres.jl
+++ b/src/minres.jl
@@ -124,7 +124,7 @@ function minres!(solver :: MinresSolver{T,FC,S}, A, b :: AbstractVector{FC};
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) is not a subtype of $S")
 
   # Set up workspace.
   allocate_if(!MisI, solver, :v, S, n)

--- a/src/minres.jl
+++ b/src/minres.jl
@@ -124,7 +124,7 @@ function minres!(solver :: MinresSolver{T,FC,S}, A, b :: AbstractVector{FC};
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) == S || error("ktypeof(b) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
 
   # Set up workspace.
   allocate_if(!MisI, solver, :v, S, n)

--- a/src/minres_qlp.jl
+++ b/src/minres_qlp.jl
@@ -105,7 +105,7 @@ function minres_qlp!(solver :: MinresQlpSolver{T,FC,S}, A, b :: AbstractVector{F
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) is not a subtype of $S")
 
   # Set up workspace.
   allocate_if(!MisI, solver, :vₖ, S, n)

--- a/src/minres_qlp.jl
+++ b/src/minres_qlp.jl
@@ -105,7 +105,7 @@ function minres_qlp!(solver :: MinresQlpSolver{T,FC,S}, A, b :: AbstractVector{F
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) == S || error("ktypeof(b) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
 
   # Set up workspace.
   allocate_if(!MisI, solver, :vₖ, S, n)

--- a/src/qmr.jl
+++ b/src/qmr.jl
@@ -102,8 +102,8 @@ function qmr!(solver :: QmrSolver{T,FC,S}, A, b :: AbstractVector{FC}; c :: Abst
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
-  ktypeof(c) <: S || error("ktypeof(c) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) is not a subtype of $S")
+  ktypeof(c) <: S || error("ktypeof(c) is not a subtype of $S")
 
   # Compute the adjoint of A
   Aᴴ = A'

--- a/src/qmr.jl
+++ b/src/qmr.jl
@@ -102,8 +102,8 @@ function qmr!(solver :: QmrSolver{T,FC,S}, A, b :: AbstractVector{FC}; c :: Abst
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) == S || error("ktypeof(b) ≠ $S")
-  ktypeof(c) == S || error("ktypeof(c) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
+  ktypeof(c) <: S || error("ktypeof(c) ≠ $S")
 
   # Compute the adjoint of A
   Aᴴ = A'

--- a/src/symmlq.jl
+++ b/src/symmlq.jl
@@ -105,7 +105,7 @@ function symmlq!(solver :: SymmlqSolver{T,FC,S}, A, b :: AbstractVector{FC};
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) == S || error("ktypeof(b) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
 
   # Set up workspace.
   allocate_if(!MisI, solver, :v, S, n)

--- a/src/symmlq.jl
+++ b/src/symmlq.jl
@@ -105,7 +105,7 @@ function symmlq!(solver :: SymmlqSolver{T,FC,S}, A, b :: AbstractVector{FC};
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) is not a subtype of $S")
 
   # Set up workspace.
   allocate_if(!MisI, solver, :v, S, n)

--- a/src/tricg.jl
+++ b/src/tricg.jl
@@ -132,8 +132,8 @@ function tricg!(solver :: TricgSolver{T,FC,S}, A, b :: AbstractVector{FC}, c :: 
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
-  ktypeof(c) <: S || error("ktypeof(c) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) is not a subtype of $S")
+  ktypeof(c) <: S || error("ktypeof(c) is not a subtype of $S")
 
   # Determine τ and ν associated to SQD, SPD or SND systems.
   flip && (τ = -one(T) ; ν =  one(T))

--- a/src/tricg.jl
+++ b/src/tricg.jl
@@ -132,8 +132,8 @@ function tricg!(solver :: TricgSolver{T,FC,S}, A, b :: AbstractVector{FC}, c :: 
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) == S || error("ktypeof(b) ≠ $S")
-  ktypeof(c) == S || error("ktypeof(c) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
+  ktypeof(c) <: S || error("ktypeof(c) ≠ $S")
 
   # Determine τ and ν associated to SQD, SPD or SND systems.
   flip && (τ = -one(T) ; ν =  one(T))

--- a/src/trilqr.jl
+++ b/src/trilqr.jl
@@ -101,8 +101,8 @@ function trilqr!(solver :: TrilqrSolver{T,FC,S}, A, b :: AbstractVector{FC}, c :
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
-  ktypeof(c) <: S || error("ktypeof(c) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) is not a subtype of $S")
+  ktypeof(c) <: S || error("ktypeof(c) is not a subtype of $S")
 
   # Compute the adjoint of A
   Aᴴ = A'

--- a/src/trilqr.jl
+++ b/src/trilqr.jl
@@ -101,8 +101,8 @@ function trilqr!(solver :: TrilqrSolver{T,FC,S}, A, b :: AbstractVector{FC}, c :
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) == S || error("ktypeof(b) ≠ $S")
-  ktypeof(c) == S || error("ktypeof(c) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
+  ktypeof(c) <: S || error("ktypeof(c) ≠ $S")
 
   # Compute the adjoint of A
   Aᴴ = A'

--- a/src/trimr.jl
+++ b/src/trimr.jl
@@ -135,8 +135,8 @@ function trimr!(solver :: TrimrSolver{T,FC,S}, A, b :: AbstractVector{FC}, c :: 
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) == S || error("ktypeof(b) ≠ $S")
-  ktypeof(c) == S || error("ktypeof(c) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
+  ktypeof(c) <: S || error("ktypeof(c) ≠ $S")
 
   # Determine τ and ν associated to SQD, SPD or SND systems.
   flip && (τ = -one(T) ; ν =  one(T))

--- a/src/trimr.jl
+++ b/src/trimr.jl
@@ -135,8 +135,8 @@ function trimr!(solver :: TrimrSolver{T,FC,S}, A, b :: AbstractVector{FC}, c :: 
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
-  ktypeof(c) <: S || error("ktypeof(c) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) is not a subtype of $S")
+  ktypeof(c) <: S || error("ktypeof(c) is not a subtype of $S")
 
   # Determine τ and ν associated to SQD, SPD or SND systems.
   flip && (τ = -one(T) ; ν =  one(T))

--- a/src/usymlq.jl
+++ b/src/usymlq.jl
@@ -110,8 +110,8 @@ function usymlq!(solver :: UsymlqSolver{T,FC,S}, A, b :: AbstractVector{FC}, c :
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) == S || error("ktypeof(b) ≠ $S")
-  ktypeof(c) == S || error("ktypeof(c) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
+  ktypeof(c) <: S || error("ktypeof(c) ≠ $S")
 
   # Compute the adjoint of A
   Aᴴ = A'

--- a/src/usymlq.jl
+++ b/src/usymlq.jl
@@ -110,8 +110,8 @@ function usymlq!(solver :: UsymlqSolver{T,FC,S}, A, b :: AbstractVector{FC}, c :
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
-  ktypeof(c) <: S || error("ktypeof(c) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) is not a subtype of $S")
+  ktypeof(c) <: S || error("ktypeof(c) is not a subtype of $S")
 
   # Compute the adjoint of A
   Aᴴ = A'

--- a/src/usymqr.jl
+++ b/src/usymqr.jl
@@ -107,8 +107,8 @@ function usymqr!(solver :: UsymqrSolver{T,FC,S}, A, b :: AbstractVector{FC}, c :
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
-  ktypeof(c) <: S || error("ktypeof(c) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) is not a subtype of $S")
+  ktypeof(c) <: S || error("ktypeof(c) is not a subtype of $S")
 
   # Compute the adjoint of A
   Aᴴ = A'

--- a/src/usymqr.jl
+++ b/src/usymqr.jl
@@ -107,8 +107,8 @@ function usymqr!(solver :: UsymqrSolver{T,FC,S}, A, b :: AbstractVector{FC}, c :
 
   # Check type consistency
   eltype(A) == FC || error("eltype(A) ≠ $FC")
-  ktypeof(b) == S || error("ktypeof(b) ≠ $S")
-  ktypeof(c) == S || error("ktypeof(c) ≠ $S")
+  ktypeof(b) <: S || error("ktypeof(b) ≠ $S")
+  ktypeof(c) <: S || error("ktypeof(c) ≠ $S")
 
   # Compute the adjoint of A
   Aᴴ = A'

--- a/test/gpu/amd.jl
+++ b/test/gpu/amd.jl
@@ -97,5 +97,9 @@ include("gpu.jl")
     # @testset "processes -- $FC" begin
     #   test_processes(S, M)
     # end
+
+    @testset "solver -- $FC" begin
+      test_solver(S, M)
+    end
   end
 end

--- a/test/gpu/gpu.jl
+++ b/test/gpu/gpu.jl
@@ -4,8 +4,8 @@ using Krylov
 include("../test_utils.jl")
 
 function test_processes(S, M)
-  n = 250
-  m = 500
+  m = 250
+  n = 500
   k = 20
   FC = eltype(S)
 
@@ -22,17 +22,26 @@ function test_processes(S, M)
   gpu_A, gpu_b = M(cpu_A), S(cpu_b)
   V, H = arnoldi(gpu_A, gpu_b, k)
 
-  cpu_A, cpu_b = under_consistent(n, m, FC=FC)
+  cpu_A, cpu_b = under_consistent(m, n, FC=FC)
   gpu_A, gpu_b = M(cpu_A), S(cpu_b)
   V, U, L = golub_kahan(gpu_A, gpu_b, k)
 
-  cpu_A, cpu_b = under_consistent(n, m, FC=FC)
-  _, cpu_c = over_consistent(m, n, FC=FC)
+  cpu_A, cpu_b = under_consistent(m, n, FC=FC)
+  _, cpu_c = over_consistent(n, m, FC=FC)
   gpu_A, gpu_b, gpu_c = M(cpu_A), S(cpu_b), S(cpu_c)
   V, T, U, Tᴴ = saunders_simon_yip(gpu_A, gpu_b, gpu_c, k)
 
-  cpu_A, cpu_b = under_consistent(n, m, FC=FC)
-  cpu_B, cpu_c = over_consistent(m, n, FC=FC)
+  cpu_A, cpu_b = under_consistent(m, n, FC=FC)
+  cpu_B, cpu_c = over_consistent(n, m, FC=FC)
   gpu_A, gpu_B, gpu_b, gpu_c = M(cpu_A), M(cpu_B), S(cpu_b), S(cpu_c)
   V, H, U, F = montoison_orban(gpu_A, gpu_B, gpu_b, gpu_c, k)
+end
+
+function test_solver(S, M)
+  n = 10
+  A = M(undef, n, n)
+  b = S(undef, n)
+  FC = eltype(S)
+  solver = GmresSolver(n, n, S)
+  solve!(solver, A, b)  # Test that we don't have errors
 end

--- a/test/gpu/gpu.jl
+++ b/test/gpu/gpu.jl
@@ -39,9 +39,9 @@ end
 
 function test_solver(S, M)
   n = 10
+  memory = 5
   A = M(undef, n, n)
   b = S(undef, n)
-  FC = eltype(S)
-  solver = GmresSolver(n, n, S)
+  solver = GmresSolver(n, n, memory, S)
   solve!(solver, A, b)  # Test that we don't have errors
 end

--- a/test/gpu/intel.jl
+++ b/test/gpu/intel.jl
@@ -105,5 +105,9 @@ end
     # @testset "processes -- $FC" begin
     #   test_processes(S, M)
     # end
+
+    @testset "solver -- $FC" begin
+      test_solver(S, M)
+    end
   end
 end

--- a/test/gpu/metal.jl
+++ b/test/gpu/metal.jl
@@ -109,5 +109,9 @@ end
     # @testset "processes -- $FC" begin
     #   test_processes(S, M)
     # end
+
+    @testset "solver -- $FC" begin
+      test_solver(S, M)
+    end
   end
 end

--- a/test/gpu/nvidia.jl
+++ b/test/gpu/nvidia.jl
@@ -173,5 +173,9 @@ include("gpu.jl")
     @testset "processes -- $FC" begin
       test_processes(S, M)
     end
+
+    @testset "solver -- $FC" begin
+      test_solver(S, M)
+    end
   end
 end


### PR DESCRIPTION
GPUArrays have three parameters:
- the precision `T`;
- the dimension `N`:
- the buffer type `B`.

When we work with `Arrays`, we only have two types (`T`, `N`).

When we create a `CuVector` for example with `b = CUDA.rand(Float64, 10)`, we will have
`typeof(b)  == CuArray{Float64, 1, CUDA.Mem.DeviceBuffer}` and it's this type that will be used when we create a Krylov solver with
```julia
solver = CgSolver(A, b).
```
When we create a Krylov solver with the other constructor
```julia
solver = CgSolver(10, 10, CuVector{Float64})
```
we will be able to create the vectors in the solver without giving the buffer type `B`.
It's not an issue but the parameter `S` of the Krylov solver will be a little bit different and we need to take into account that `typeof(b) <: S` (`CuArray{Float64, 1} <: CuArray{Float64, 1, CUDA.Mem.DeviceBuffer}`) sometimes and not always `typeof(b) == S`.