### PR TITLE
Add optional argument(s) in the docstrings

### DIFF
--- a/src/bicgstab.jl
+++ b/src/bicgstab.jl
@@ -16,13 +16,18 @@
 export bicgstab, bicgstab!
 
 """
-    (x, stats) = bicgstab(A, b::AbstractVector{FC}; c::AbstractVector{FC}=b,
-                          M=I, N=I, atol::T=√eps(T), rtol::T=√eps(T),
-                          itmax::Int=0, verbose::Int=0, history::Bool=false,
+    (x, stats) = bicgstab(A, b::AbstractVector{FC};
+                          c::AbstractVector{FC}=b, M=I, N=I,
+                          atol::T=√eps(T), rtol::T=√eps(T), itmax::Int=0,
+                          verbose::Int=0, history::Bool=false,
                           ldiv::Bool=false, callback=solver->false)
 
 `T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
 `FC` is `T` or `Complex{T}`.
+
+    (x, stats) = bicgstab(A, b, x0::AbstractVector; kwargs...)
+
+BICGSTAB can be warm-started from an initial guess `x0` where `kwargs` are the same keyword arguments as above.
 
 Solve the square linear system Ax = b of size n using BICGSTAB.
 BICGSTAB requires two initial vectors `b` and `c`.
@@ -42,12 +47,6 @@ Information will be displayed every `verbose` iterations.
 
 This implementation allows a left preconditioner `M` and a right preconditioner `N`.
 
-BICGSTAB can be warm-started from an initial guess `x0` with
-
-    (x, stats) = bicgstab(A, b, x0; kwargs...)
-
-where `kwargs` are the same keyword arguments as above.
-
 The callback is called as `callback(solver)` and should return `true` if the main loop should terminate,
 and `false` otherwise.
 
@@ -55,6 +54,10 @@ and `false` otherwise.
 
 * `A`: a linear operator that models a matrix of dimension n;
 * `b`: a vector of length n.
+
+#### Optional argument
+
+* `x0`: a vector of length n that represents an initial guess of the solution x.
 
 #### Output arguments
 

--- a/src/bilq.jl
+++ b/src/bilq.jl
@@ -13,28 +13,26 @@
 export bilq, bilq!
 
 """
-    (x, stats) = bilq(A, b::AbstractVector{FC}; c::AbstractVector{FC}=b,
-                      atol::T=√eps(T), rtol::T=√eps(T), transfer_to_bicg::Bool=true,
-                      itmax::Int=0, verbose::Int=0, history::Bool=false,
-                      callback=solver->false)
+    (x, stats) = bilq(A, b::AbstractVector{FC};
+                      c::AbstractVector{FC}=b, atol::T=√eps(T),
+                      rtol::T=√eps(T), transfer_to_bicg::Bool=true,
+                      itmax::Int=0, verbose::Int=0,
+                      history::Bool=false, callback=solver->false)
 
 `T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
 `FC` is `T` or `Complex{T}`.
 
-Solve the square linear system Ax = b of size n using BiLQ.
+    (x, stats) = bilq(A, b, x0::AbstractVector; kwargs...)
 
+BiLQ can be warm-started from an initial guess `x0` where `kwargs` are the same keyword arguments as above.
+
+Solve the square linear system Ax = b of size n using BiLQ.
 BiLQ is based on the Lanczos biorthogonalization process and requires two initial vectors `b` and `c`.
 The relation `bᴴc ≠ 0` must be satisfied and by default `c = b`.
 When `A` is symmetric and `b = c`, BiLQ is equivalent to SYMMLQ.
 
 An option gives the possibility of transferring to the BiCG point,
 when it exists. The transfer is based on the residual norm.
-
-BiLQ can be warm-started from an initial guess `x0` with
-
-    (x, stats) = bilq(A, b, x0; kwargs...)
-
-where `kwargs` are the same keyword arguments as above.
 
 The callback is called as `callback(solver)` and should return `true` if the main loop should terminate,
 and `false` otherwise.
@@ -43,6 +41,10 @@ and `false` otherwise.
 
 * `A`: a linear operator that models a matrix of dimension n;
 * `b`: a vector of length n.
+
+#### Optional argument
+
+* `x0`: a vector of length n that represents an initial guess of the solution x.
 
 #### Output arguments
 

--- a/src/bilqr.jl
+++ b/src/bilqr.jl
@@ -21,6 +21,10 @@ export bilqr, bilqr!
 `T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
 `FC` is `T` or `Complex{T}`.
 
+    (x, y, stats) = bilqr(A, b, c, x0::AbstractVector, y0::AbstractVector; kwargs...)
+
+BiLQR can be warm-started from initial guesses `x0` and `y0` where `kwargs` are the same keyword arguments as above.
+
 Combine BiLQ and QMR to solve adjoint systems.
 
     [0  A] [y] = [b]
@@ -33,12 +37,6 @@ QMR is used for solving dual system `Aᴴy = c` of size n.
 An option gives the possibility of transferring from the BiLQ point to the
 BiCG point, when it exists. The transfer is based on the residual norm.
 
-BiLQR can be warm-started from initial guesses `x0` and `y0` with
-
-    (x, y, stats) = bilqr(A, b, c, x0, y0; kwargs...)
-
-where `kwargs` are the same keyword arguments as above.
-
 The callback is called as `callback(solver)` and should return `true` if the main loop should terminate,
 and `false` otherwise.
 
@@ -48,11 +46,16 @@ and `false` otherwise.
 * `b`: a vector of length n;
 * `c`: a vector of length n.
 
+#### Optional arguments
+
+* `x0`: a vector of length n that represents an initial guess of the solution x;
+* `y0`: a vector of length n that represents an initial guess of the solution y.
+
 #### Output arguments
 
 * `x`: a dense vector of length n;
 * `y`: a dense vector of length n;
-* `stats`: statistics collected on the run in a [`AdjointStats`](@ref) structure.
+* `stats`: statistics collected on the run in an [`AdjointStats`](@ref) structure.
 
 #### Reference
 

--- a/src/cg.jl
+++ b/src/cg.jl
@@ -26,6 +26,10 @@ export cg, cg!
 `T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
 `FC` is `T` or `Complex{T}`.
 
+    (x, stats) = cg(A, b, x0::AbstractVector; kwargs...)
+
+CG can be warm-started from an initial guess `x0` where `kwargs` are the same keyword arguments as above.
+
 The conjugate gradient method to solve the Hermitian linear system Ax = b of size n.
 
 The method does _not_ abort if A is not definite.
@@ -36,12 +40,6 @@ M also indicates the weighted norm in which residuals are measured.
 
 If `itmax=0`, the default number of iterations is set to `2 * n`.
 
-CG can be warm-started from an initial guess `x0` with
-
-    (x, stats) = cg(A, b, x0; kwargs...)
-
-where `kwargs` are the same keyword arguments as above.
-
 The callback is called as `callback(solver)` and should return `true` if the main loop should terminate,
 and `false` otherwise.
 
@@ -49,6 +47,10 @@ and `false` otherwise.
 
 * `A`: a linear operator that models a Hermitian positive definite matrix of dimension n;
 * `b`: a vector of length n.
+
+#### Optional argument
+
+* `x0`: a vector of length n that represents an initial guess of the solution x.
 
 #### Output arguments
 

--- a/src/cg_lanczos.jl
+++ b/src/cg_lanczos.jl
@@ -22,6 +22,10 @@ export cg_lanczos, cg_lanczos!
 `T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
 `FC` is `T` or `Complex{T}`.
 
+    (x, stats) = cg_lanczos(A, b, x0::AbstractVector; kwargs...)
+
+CG-LANCZOS can be warm-started from an initial guess `x0` where `kwargs` are the same keyword arguments as above.
+
 The Lanczos version of the conjugate gradient method to solve the
 Hermitian linear system Ax = b of size n.
 
@@ -30,12 +34,6 @@ The method does _not_ abort if A is not definite.
 A preconditioner M may be provided in the form of a linear operator and is
 assumed to be Hermitian and positive definite.
 
-CG-LANCZOS can be warm-started from an initial guess `x0` with
-
-    (x, stats) = cg_lanczos(A, b, x0; kwargs...)
-
-where `kwargs` are the same keyword arguments as above.
-
 The callback is called as `callback(solver)` and should return `true` if the main loop should terminate,
 and `false` otherwise.
 
@@ -43,6 +41,10 @@ and `false` otherwise.
 
 * `A`: a linear operator that models a Hermitian matrix of dimension n;
 * `b`: a vector of length n.
+
+#### Optional argument
+
+* `x0`: a vector of length n that represents an initial guess of the solution x.
 
 #### Output arguments
 

--- a/src/cgs.jl
+++ b/src/cgs.jl
@@ -11,13 +11,17 @@
 export cgs, cgs!
 
 """
-    (x, stats) = cgs(A, b::AbstractVector{FC}; c::AbstractVector{FC}=b,
-                     M=I, N=I, atol::T=√eps(T), rtol::T=√eps(T),
-                     itmax::Int=0, verbose::Int=0, history::Bool=false,
-                     ldiv::Bool=false, callback=solver->false)
+    (x, stats) = cgs(A, b::AbstractVector{FC};
+                     c::AbstractVector{FC}=b, M=I, N=I, atol::T=√eps(T),
+                     rtol::T=√eps(T), itmax::Int=0, verbose::Int=0,
+                     history::Bool=false, ldiv::Bool=false, callback=solver->false)
 
 `T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
 `FC` is `T` or `Complex{T}`.
+
+    (x, stats) = cgs(A, b, x0::AbstractVector; kwargs...)
+
+CGS can be warm-started from an initial guess `x0` where `kwargs` are the same keyword arguments as above.
 
 Solve the consistent linear system Ax = b of size n using CGS.
 CGS requires two initial vectors `b` and `c`.
@@ -40,12 +44,6 @@ TFQMR and BICGSTAB were developed to remedy this difficulty.»
 
 This implementation allows a left preconditioner M and a right preconditioner N.
 
-CGS can be warm-started from an initial guess `x0` with
-
-    (x, stats) = cgs(A, b, x0; kwargs...)
-
-where `kwargs` are the same keyword arguments as above.
-
 The callback is called as `callback(solver)` and should return `true` if the main loop should terminate,
 and `false` otherwise.
 
@@ -53,6 +51,10 @@ and `false` otherwise.
 
 * `A`: a linear operator that models a matrix of dimension n;
 * `b`: a vector of length n.
+
+#### Optional argument
+
+* `x0`: a vector of length n that represents an initial guess of the solution x.
 
 #### Output arguments
 

--- a/src/cr.jl
+++ b/src/cr.jl
@@ -16,12 +16,17 @@ export cr, cr!
 
 """
     (x, stats) = cr(A, b::AbstractVector{FC};
-                    M=I, atol::T=√eps(T), rtol::T=√eps(T), γ::T=√eps(T), itmax::Int=0,
-                    radius::T=zero(T), verbose::Int=0, linesearch::Bool=false, history::Bool=false,
+                    M=I, atol::T=√eps(T), rtol::T=√eps(T), γ::T=√eps(T),
+                    itmax::Int=0, radius::T=zero(T), verbose::Int=0,
+                    linesearch::Bool=false, history::Bool=false,
                     ldiv::Bool=false, callback=solver->false)
 
 `T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
 `FC` is `T` or `Complex{T}`.
+
+    (x, stats) = cr(A, b, x0::AbstractVector; kwargs...)
+
+CR can be warm-started from an initial guess `x0` where `kwargs` are the same keyword arguments as above.
 
 A truncated version of Stiefel’s Conjugate Residual method to solve the Hermitian linear system Ax = b
 of size n or the least-squares problem min ‖b - Ax‖ if A is singular.
@@ -34,12 +39,6 @@ In a linesearch context, 'linesearch' must be set to 'true'.
 
 If `itmax=0`, the default number of iterations is set to `2 * n`.
 
-CR can be warm-started from an initial guess `x0` with
-
-    (x, stats) = cr(A, b, x0; kwargs...)
-
-where `kwargs` are the same keyword arguments as above.
-
 The callback is called as `callback(solver)` and should return `true` if the main loop should terminate,
 and `false` otherwise.
 
@@ -47,6 +46,10 @@ and `false` otherwise.
 
 * `A`: a linear operator that models a Hermitian positive definite matrix of dimension n;
 * `b`: a vector of length n.
+
+#### Optional argument
+
+* `x0`: a vector of length n that represents an initial guess of the solution x.
 
 #### Output arguments
 

--- a/src/diom.jl
+++ b/src/diom.jl
@@ -11,14 +11,18 @@
 export diom, diom!
 
 """
-    (x, stats) = diom(A, b::AbstractVector{FC}; memory::Int=20,
-                      M=I, N=I, atol::T=√eps(T), rtol::T=√eps(T),
-                      reorthogonalization::Bool=false, itmax::Int=0,
-                      verbose::Int=0, history::Bool=false,
+    (x, stats) = diom(A, b::AbstractVector{FC};
+                      memory::Int=20, M=I, N=I, atol::T=√eps(T),
+                      rtol::T=√eps(T), reorthogonalization::Bool=false,
+                      itmax::Int=0, verbose::Int=0, history::Bool=false,
                       ldiv::Bool=false, callback=solver->false)
 
 `T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
 `FC` is `T` or `Complex{T}`.
+
+    (x, stats) = diom(A, b, x0::AbstractVector; kwargs...)
+
+DIOM can be warm-started from an initial guess `x0` where `kwargs` are the same keyword arguments as above.
 
 Solve the consistent linear system Ax = b of size n using DIOM.
 
@@ -34,12 +38,6 @@ and indefinite systems of linear equations can be handled by this single algorit
 
 This implementation allows a left preconditioner M and a right preconditioner N.
 
-DIOM can be warm-started from an initial guess `x0` with
-
-    (x, stats) = diom(A, b, x0; kwargs...)
-
-where `kwargs` are the same keyword arguments as above.
-
 The callback is called as `callback(solver)` and should return `true` if the main loop should terminate,
 and `false` otherwise.
 
@@ -47,6 +45,10 @@ and `false` otherwise.
 
 * `A`: a linear operator that models a matrix of dimension n;
 * `b`: a vector of length n.
+
+#### Optional argument
+
+* `x0`: a vector of length n that represents an initial guess of the solution x.
 
 #### Output arguments
 

--- a/src/dqgmres.jl
+++ b/src/dqgmres.jl
@@ -11,14 +11,18 @@
 export dqgmres, dqgmres!
 
 """
-    (x, stats) = dqgmres(A, b::AbstractVector{FC}; memory::Int=20,
-                         M=I, N=I, atol::T=√eps(T), rtol::T=√eps(T),
-                         reorthogonalization::Bool=false, itmax::Int=0,
-                         verbose::Int=0, history::Bool=false,
+    (x, stats) = dqgmres(A, b::AbstractVector{FC};
+                         memory::Int=20, M=I, N=I, atol::T=√eps(T),
+                         rtol::T=√eps(T), reorthogonalization::Bool=false,
+                         itmax::Int=0, verbose::Int=0, history::Bool=false,
                          ldiv::Bool=false, callback=solver->false)
 
 `T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
 `FC` is `T` or `Complex{T}`.
+
+    (x, stats) = dqgmres(A, b, x0::AbstractVector; kwargs...)
+
+DQGMRES can be warm-started from an initial guess `x0` where `kwargs` are the same keyword arguments as above.
 
 Solve the consistent linear system Ax = b of size n using DQGMRES.
 
@@ -34,12 +38,6 @@ Partial reorthogonalization is available with the `reorthogonalization` option.
 
 This implementation allows a left preconditioner M and a right preconditioner N.
 
-DQGMRES can be warm-started from an initial guess `x0` with
-
-    (x, stats) = dqgmres(A, b, x0; kwargs...)
-
-where `kwargs` are the same keyword arguments as above.
-
 The callback is called as `callback(solver)` and should return `true` if the main loop should terminate,
 and `false` otherwise.
 
@@ -47,6 +45,10 @@ and `false` otherwise.
 
 * `A`: a linear operator that models a matrix of dimension n;
 * `b`: a vector of length n.
+
+#### Optional argument
+
+* `x0`: a vector of length n that represents an initial guess of the solution x.
 
 #### Output arguments
 

--- a/src/fgmres.jl
+++ b/src/fgmres.jl
@@ -11,14 +11,18 @@
 export fgmres, fgmres!
 
 """
-    (x, stats) = fgmres(A, b::AbstractVector{FC}; memory::Int=20,
-                        M=I, N=I, atol::T=√eps(T), rtol::T=√eps(T),
+    (x, stats) = fgmres(A, b::AbstractVector{FC};
+                        memory::Int=20, M=I, N=I, atol::T=√eps(T), rtol::T=√eps(T),
                         reorthogonalization::Bool=false, itmax::Int=0,
                         restart::Bool=false, verbose::Int=0, history::Bool=false,
                         ldiv::Bool=false, callback=solver->false)
 
 `T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
 `FC` is `T` or `Complex{T}`.
+
+    (x, stats) = fgmres(A, b, x0::AbstractVector; kwargs...)
+
+FGMRES can be warm-started from an initial guess `x0` where `kwargs` are the same keyword arguments as above.
 
 Solve the linear system Ax = b of size n using FGMRES.
 
@@ -37,12 +41,6 @@ If `restart = true`, the restarted version FGMRES(k) is used with `k = memory`.
 If `restart = false`, the parameter `memory` should be used as a hint of the number of iterations to limit dynamic memory allocations.
 More storage will be allocated only if the number of iterations exceeds `memory`.
 
-FGMRES can be warm-started from an initial guess `x0` with
-
-    (x, stats) = fgmres(A, b, x0; kwargs...)
-
-where `kwargs` are the same keyword arguments as above.
-
 The callback is called as `callback(solver)` and should return `true` if the main loop should terminate,
 and `false` otherwise.
 
@@ -50,6 +48,10 @@ and `false` otherwise.
 
 * `A`: a linear operator that models a matrix of dimension n;
 * `b`: a vector of length n.
+
+#### Optional argument
+
+* `x0`: a vector of length n that represents an initial guess of the solution x.
 
 #### Output arguments
 

--- a/src/fom.jl
+++ b/src/fom.jl
@@ -11,14 +11,18 @@
 export fom, fom!
 
 """
-    (x, stats) = fom(A, b::AbstractVector{FC}; memory::Int=20,
-                     M=I, N=I, atol::T=√eps(T), rtol::T=√eps(T),
+    (x, stats) = fom(A, b::AbstractVector{FC};
+                     memory::Int=20, M=I, N=I, atol::T=√eps(T), rtol::T=√eps(T),
                      reorthogonalization::Bool=false, itmax::Int=0,
                      restart::Bool=false, verbose::Int=0, history::Bool=false,
                      ldiv::Bool=false, callback=solver->false)
 
 `T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
 `FC` is `T` or `Complex{T}`.
+
+    (x, stats) = fom(A, b, x0::AbstractVector; kwargs...)
+
+FOM can be warm-started from an initial guess `x0` where `kwargs` are the same keyword arguments as above.
 
 Solve the linear system Ax = b of size n using FOM.
 
@@ -31,12 +35,6 @@ If `restart = true`, the restarted version FOM(k) is used with `k = memory`.
 If `restart = false`, the parameter `memory` should be used as a hint of the number of iterations to limit dynamic memory allocations.
 More storage will be allocated only if the number of iterations exceeds `memory`.
 
-FOM can be warm-started from an initial guess `x0` with
-
-    (x, stats) = fom(A, b, x0; kwargs...)
-
-where `kwargs` are the same keyword arguments as above.
-
 The callback is called as `callback(solver)` and should return `true` if the main loop should terminate,
 and `false` otherwise.
 
@@ -44,6 +42,10 @@ and `false` otherwise.
 
 * `A`: a linear operator that models a matrix of dimension n;
 * `b`: a vector of length n.
+
+#### Optional argument
+
+* `x0`: a vector of length n that represents an initial guess of the solution x.
 
 #### Output arguments
 

--- a/src/gmres.jl
+++ b/src/gmres.jl
@@ -11,14 +11,18 @@
 export gmres, gmres!
 
 """
-    (x, stats) = gmres(A, b::AbstractVector{FC}; memory::Int=20,
-                       M=I, N=I, atol::T=√eps(T), rtol::T=√eps(T),
+    (x, stats) = gmres(A, b::AbstractVector{FC};
+                       memory::Int=20, M=I, N=I, atol::T=√eps(T), rtol::T=√eps(T),
                        reorthogonalization::Bool=false, itmax::Int=0,
                        restart::Bool=false, verbose::Int=0, history::Bool=false,
                        ldiv::Bool=false, callback=solver->false)
 
 `T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
 `FC` is `T` or `Complex{T}`.
+
+    (x, stats) = gmres(A, b, x0::AbstractVector; kwargs...)
+
+GMRES can be warm-started from an initial guess `x0` where `kwargs` are the same keyword arguments as above.
 
 Solve the linear system Ax = b of size n using GMRES.
 
@@ -31,12 +35,6 @@ If `restart = true`, the restarted version GMRES(k) is used with `k = memory`.
 If `restart = false`, the parameter `memory` should be used as a hint of the number of iterations to limit dynamic memory allocations.
 More storage will be allocated only if the number of iterations exceeds `memory`.
 
-GMRES can be warm-started from an initial guess `x0` with
-
-    (x, stats) = gmres(A, b, x0; kwargs...)
-
-where `kwargs` are the same keyword arguments as above.
-
 The callback is called as `callback(solver)` and should return `true` if the main loop should terminate,
 and `false` otherwise.
 
@@ -44,6 +42,10 @@ and `false` otherwise.
 
 * `A`: a linear operator that models a matrix of dimension n;
 * `b`: a vector of length n.
+
+#### Optional argument
+
+* `x0`: a vector of length n that represents an initial guess of the solution x.
 
 #### Output arguments
 

--- a/src/gpmr.jl
+++ b/src/gpmr.jl
@@ -12,15 +12,19 @@
 export gpmr, gpmr!
 
 """
-    (x, y, stats) = gpmr(A, B, b::AbstractVector{FC}, c::AbstractVector{FC}; memory::Int=20,
-                         C=I, D=I, E=I, F=I, atol::T=√eps(T), rtol::T=√eps(T),
-                         gsp::Bool=false, reorthogonalization::Bool=false,
-                         itmax::Int=0, λ::FC=one(FC), μ::FC=one(FC),
-                         verbose::Int=0, history::Bool=false,
-                         ldiv::Bool=false, callback=solver->false)
+    (x, y, stats) = gpmr(A, B, b::AbstractVector{FC}, c::AbstractVector{FC};
+                         memory::Int=20, C=I, D=I, E=I, F=I,
+                         atol::T=√eps(T), rtol::T=√eps(T), gsp::Bool=false,
+                         reorthogonalization::Bool=false, itmax::Int=0,
+                         λ::FC=one(FC), μ::FC=one(FC), verbose::Int=0,
+                         history::Bool=false, ldiv::Bool=false, callback=solver->false)
 
 `T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
 `FC` is `T` or `Complex{T}`.
+
+    (x, y, stats) = gpmr(A, B, b, c, x0::AbstractVector, y0::AbstractVector; kwargs...)
+
+GPMR can be warm-started from initial guesses `x0` and `y0` where `kwargs` are the same keyword arguments as above.
 
 Given matrices `A` of dimension m × n and `B` of dimension n × m,
 GPMR solves the unsymmetric partitioned linear system
@@ -59,12 +63,6 @@ Full reorthogonalization is available with the `reorthogonalization` option.
 Additional details can be displayed if verbose mode is enabled (verbose > 0).
 Information will be displayed every `verbose` iterations.
 
-GPMR can be warm-started from initial guesses `x0` and `y0` with
-
-    (x, y, stats) = gpmr(A, B, b, c, x0, y0; kwargs...)
-
-where `kwargs` are the same keyword arguments as above.
-
 The callback is called as `callback(solver)` and should return `true` if the main loop should terminate,
 and `false` otherwise.
 
@@ -74,6 +72,11 @@ and `false` otherwise.
 * `B`: a linear operator that models a matrix of dimension n × m;
 * `b`: a vector of length m;
 * `c`: a vector of length n.
+
+#### Optional arguments
+
+* `x0`: a vector of length m that represents an initial guess of the solution x;
+* `y0`: a vector of length n that represents an initial guess of the solution y.
 
 #### Output arguments
 

--- a/src/minres.jl
+++ b/src/minres.jl
@@ -35,6 +35,10 @@ export minres, minres!
 `T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
 `FC` is `T` or `Complex{T}`.
 
+    (x, stats) = minres(A, b, x0::AbstractVector; kwargs...)
+
+MINRES can be warm-started from an initial guess `x0` where `kwargs` are the same keyword arguments as above.
+
 Solve the shifted linear least-squares problem
 
     minimize ‖b - (A + λI)x‖₂²
@@ -55,12 +59,6 @@ MINRES produces monotonic residuals ‖r‖₂ and optimality residuals ‖Aᴴr
 A preconditioner M may be provided in the form of a linear operator and is
 assumed to be Hermitian and positive definite.
 
-MINRES can be warm-started from an initial guess `x0` with
-
-    (x, stats) = minres(A, b, x0; kwargs...)
-
-where `kwargs` are the same keyword arguments as above.
-
 The callback is called as `callback(solver)` and should return `true` if the main loop should terminate,
 and `false` otherwise.
 
@@ -68,6 +66,10 @@ and `false` otherwise.
 
 * `A`: a linear operator that models a Hermitian matrix of dimension n;
 * `b`: a vector of length n.
+
+#### Optional argument
+
+* `x0`: a vector of length n that represents an initial guess of the solution x.
 
 #### Output arguments
 

--- a/src/minres_qlp.jl
+++ b/src/minres_qlp.jl
@@ -26,6 +26,10 @@ export minres_qlp, minres_qlp!
 `T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
 `FC` is `T` or `Complex{T}`.
 
+    (x, stats) = minres_qlp(A, b, x0::AbstractVector; kwargs...)
+
+MINRES-QLP can be warm-started from an initial guess `x0` where `kwargs` are the same keyword arguments as above.
+
 MINRES-QLP is the only method based on the Lanczos process that returns the minimum-norm
 solution on singular inconsistent systems (A + λI)x = b of size n, where λ is a shift parameter.
 It is significantly more complex but can be more reliable than MINRES when A is ill-conditioned.
@@ -34,12 +38,6 @@ A preconditioner M may be provided in the form of a linear operator and is
 assumed to be Hermitian and positive definite.
 M also indicates the weighted norm in which residuals are measured.
 
-MINRES-QLP can be warm-started from an initial guess `x0` with
-
-    (x, stats) = minres_qlp(A, b, x0; kwargs...)
-
-where `kwargs` are the same keyword arguments as above.
-
 The callback is called as `callback(solver)` and should return `true` if the main loop should terminate,
 and `false` otherwise.
 
@@ -47,6 +45,10 @@ and `false` otherwise.
 
 * `A`: a linear operator that models a Hermitian matrix of dimension n;
 * `b`: a vector of length n.
+
+#### Optional argument
+
+* `x0`: a vector of length n that represents an initial guess of the solution x.
 
 #### Output arguments
 

--- a/src/qmr.jl
+++ b/src/qmr.jl
@@ -21,25 +21,23 @@
 export qmr, qmr!
 
 """
-    (x, stats) = qmr(A, b::AbstractVector{FC}; c::AbstractVector{FC}=b,
-                     atol::T=√eps(T), rtol::T=√eps(T),
-                     itmax::Int=0, verbose::Int=0, history::Bool=false,
-                     callback=solver->false)
+    (x, stats) = qmr(A, b::AbstractVector{FC};
+                     c::AbstractVector{FC}=b, atol::T=√eps(T),
+                     rtol::T=√eps(T), itmax::Int=0, verbose::Int=0,
+                     history::Bool=false, callback=solver->false)
 
 `T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
 `FC` is `T` or `Complex{T}`.
+
+    (x, stats) = qmr(A, b, x0::AbstractVector; kwargs...)
+
+QMR can be warm-started from an initial guess `x0` where `kwargs` are the same keyword arguments as above.
 
 Solve the square linear system Ax = b of size n using QMR.
 
 QMR is based on the Lanczos biorthogonalization process and requires two initial vectors `b` and `c`.
 The relation `bᴴc ≠ 0` must be satisfied and by default `c = b`.
 When `A` is symmetric and `b = c`, QMR is equivalent to MINRES.
-
-QMR can be warm-started from an initial guess `x0` with
-
-    (x, stats) = qmr(A, b, x0; kwargs...)
-
-where `kwargs` are the same keyword arguments as above.
 
 The callback is called as `callback(solver)` and should return `true` if the main loop should terminate,
 and `false` otherwise.
@@ -48,6 +46,10 @@ and `false` otherwise.
 
 * `A`: a linear operator that models a matrix of dimension n;
 * `b`: a vector of length n.
+
+#### Optional argument
+
+* `x0`: a vector of length n that represents an initial guess of the solution x.
 
 #### Output arguments
 

--- a/src/symmlq.jl
+++ b/src/symmlq.jl
@@ -13,8 +13,8 @@ export symmlq, symmlq!
 
 
 """
-    (x, stats) = symmlq(A, b::AbstractVector{FC}; window::Int=0,
-                        M=I, λ::T=zero(T), transfer_to_cg::Bool=true,
+    (x, stats) = symmlq(A, b::AbstractVector{FC};
+                        window::Int=0, M=I, λ::T=zero(T), transfer_to_cg::Bool=true,
                         λest::T=zero(T), atol::T=√eps(T), rtol::T=√eps(T),
                         etol::T=√eps(T), itmax::Int=0, conlim::T=1/√eps(T),
                         verbose::Int=0, history::Bool=false,
@@ -22,6 +22,10 @@ export symmlq, symmlq!
 
 `T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
 `FC` is `T` or `Complex{T}`.
+
+    (x, stats) = symmlq(A, b, x0::AbstractVector; kwargs...)
+
+SYMMLQ can be warm-started from an initial guess `x0` where `kwargs` are the same keyword arguments as above
 
 Solve the shifted linear system
 
@@ -35,12 +39,6 @@ SYMMLQ produces monotonic errors ‖x* - x‖₂.
 A preconditioner M may be provided in the form of a linear operator and is
 assumed to be Hermitian and positive definite.
 
-SYMMLQ can be warm-started from an initial guess `x0` with
-
-    (x, stats) = symmlq(A, b, x0; kwargs...)
-
-where `kwargs` are the same keyword arguments as above.
-
 The callback is called as `callback(solver)` and should return `true` if the main loop should terminate,
 and `false` otherwise.
 
@@ -48,6 +46,10 @@ and `false` otherwise.
 
 * `A`: a linear operator that models a Hermitian matrix of dimension n;
 * `b`: a vector of length n.
+
+#### Optional argument
+
+* `x0`: a vector of length n that represents an initial guess of the solution x.
 
 #### Output arguments
 

--- a/src/tricg.jl
+++ b/src/tricg.jl
@@ -22,6 +22,10 @@ export tricg, tricg!
 `T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
 `FC` is `T` or `Complex{T}`.
 
+    (x, y, stats) = tricg(A, b, c, x0::AbstractVector, y0::AbstractVector; kwargs...)
+
+TriCG can be warm-started from initial guesses `x0` and `y0` where `kwargs` are the same keyword arguments as above.
+
 Given a matrix `A` of dimension m × n, TriCG solves the symmetric linear system
 
     [ τE    A ] [ x ] = [ b ]
@@ -53,12 +57,6 @@ TriCG stops when `itmax` iterations are reached or when `‖rₖ‖ ≤ atol + �
 Additional details can be displayed if verbose mode is enabled (verbose > 0).
 Information will be displayed every `verbose` iterations.
 
-TriCG can be warm-started from initial guesses `x0` and `y0` with
-
-    (x, y, stats) = tricg(A, b, c, x0, y0; kwargs...)
-
-where `kwargs` are the same keyword arguments as above.
-
 The callback is called as `callback(solver)` and should return `true` if the main loop should terminate,
 and `false` otherwise.
 
@@ -67,6 +65,11 @@ and `false` otherwise.
 * `A`: a linear operator that models a matrix of dimension m × n;
 * `b`: a vector of length m;
 * `c`: a vector of length n.
+
+#### Optional arguments
+
+* `x0`: a vector of length m that represents an initial guess of the solution x;
+* `y0`: a vector of length n that represents an initial guess of the solution y.
 
 #### Output arguments
 

--- a/src/trilqr.jl
+++ b/src/trilqr.jl
@@ -21,6 +21,10 @@ export trilqr, trilqr!
 `T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
 `FC` is `T` or `Complex{T}`.
 
+    (x, y, stats) = trilqr(A, b, c, x0::AbstractVector, y0::AbstractVector; kwargs...)
+
+TriLQR can be warm-started from initial guesses `x0` and `y0` where `kwargs` are the same keyword arguments as above.
+
 Combine USYMLQ and USYMQR to solve adjoint systems.
 
     [0  A] [y] = [b]
@@ -32,12 +36,6 @@ USYMQR is used for solving dual system `Aᴴy = c` of size n × m.
 An option gives the possibility of transferring from the USYMLQ point to the
 USYMCG point, when it exists. The transfer is based on the residual norm.
 
-TriLQR can be warm-started from initial guesses `x0` and `y0` with
-
-    (x, y, stats) = trilqr(A, b, c, x0, y0; kwargs...)
-
-where `kwargs` are the same keyword arguments as above.
-
 The callback is called as `callback(solver)` and should return `true` if the main loop should terminate,
 and `false` otherwise.
 
@@ -47,11 +45,16 @@ and `false` otherwise.
 * `b`: a vector of length m;
 * `c`: a vector of length n.
 
+#### Optional arguments
+
+* `x0`: a vector of length n that represents an initial guess of the solution x;
+* `y0`: a vector of length m that represents an initial guess of the solution y.
+
 #### Output arguments
 
 * `x`: a dense vector of length n;
 * `y`: a dense vector of length m;
-* `stats`: statistics collected on the run in a [`AdjointStats`](@ref) structure.
+* `stats`: statistics collected on the run in an [`AdjointStats`](@ref) structure.
 
 #### Reference
 

--- a/src/trimr.jl
+++ b/src/trimr.jl
@@ -22,6 +22,10 @@ export trimr, trimr!
 `T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
 `FC` is `T` or `Complex{T}`.
 
+    (x, y, stats) = trimr(A, b, c, x0::AbstractVector, y0::AbstractVector; kwargs...)
+
+TriMR can be warm-started from initial guesses `x0` and `y0` where `kwargs` are the same keyword arguments as above.
+
 Given a matrix `A` of dimension m × n, TriMR solves the symmetric linear system
 
     [ τE    A ] [ x ] = [ b ]
@@ -53,12 +57,6 @@ TriMR stops when `itmax` iterations are reached or when `‖rₖ‖ ≤ atol + �
 Additional details can be displayed if verbose mode is enabled (verbose > 0).
 Information will be displayed every `verbose` iterations.
 
-TriMR can be warm-started from initial guesses `x0` and `y0` with
-
-    (x, y, stats) = trimr(A, b, c, x0, y0; kwargs...)
-
-where `kwargs` are the same keyword arguments as above.
-
 The callback is called as `callback(solver)` and should return `true` if the main loop should terminate,
 and `false` otherwise.
 
@@ -67,6 +65,11 @@ and `false` otherwise.
 * `A`: a linear operator that models a matrix of dimension m × n;
 * `b`: a vector of length m;
 * `c`: a vector of length n.
+
+#### Optional arguments
+
+* `x0`: a vector of length m that represents an initial guess of the solution x;
+* `y0`: a vector of length n that represents an initial guess of the solution y.
 
 #### Output arguments
 

--- a/src/usymlq.jl
+++ b/src/usymlq.jl
@@ -21,12 +21,16 @@ export usymlq, usymlq!
 
 """
     (x, stats) = usymlq(A, b::AbstractVector{FC}, c::AbstractVector{FC};
-                        atol::T=√eps(T), rtol::T=√eps(T), transfer_to_usymcg::Bool=true,
-                        itmax::Int=0, verbose::Int=0, history::Bool=false,
-                        callback=solver->false)
+                        atol::T=√eps(T), rtol::T=√eps(T),
+                        transfer_to_usymcg::Bool=true, itmax::Int=0,
+                        verbose::Int=0, history::Bool=false, callback=solver->false)
 
 `T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
 `FC` is `T` or `Complex{T}`.
+
+    (x, stats) = usymlq(A, b, c, x0::AbstractVector; kwargs...)
+
+USYMLQ can be warm-started from an initial guess `x0` where `kwargs` are the same keyword arguments as above.
 
 Solve the linear system Ax = b of size m × n using the USYMLQ method.
 
@@ -41,12 +45,6 @@ In all cases, problems must be consistent.
 An option gives the possibility of transferring to the USYMCG point,
 when it exists. The transfer is based on the residual norm.
 
-USYMLQ can be warm-started from an initial guess `x0` with
-
-    (x, stats) = usymlq(A, b, c, x0; kwargs...)
-
-where `kwargs` are the same keyword arguments as above.
-
 The callback is called as `callback(solver)` and should return `true` if the main loop should terminate,
 and `false` otherwise.
 
@@ -55,6 +53,10 @@ and `false` otherwise.
 * `A`: a linear operator that models a matrix of dimension m × n;
 * `b`: a vector of length m;
 * `c`: a vector of length n.
+
+#### Optional argument
+
+* `x0`: a vector of length n that represents an initial guess of the solution x.
 
 #### Output arguments
 

--- a/src/usymqr.jl
+++ b/src/usymqr.jl
@@ -21,12 +21,15 @@ export usymqr, usymqr!
 
 """
     (x, stats) = usymqr(A, b::AbstractVector{FC}, c::AbstractVector{FC};
-                        atol::T=√eps(T), rtol::T=√eps(T),
-                        itmax::Int=0, verbose::Int=0, history::Bool=false,
-                        callback=solver->false)
+                        atol::T=√eps(T), rtol::T=√eps(T), itmax::Int=0,
+                        verbose::Int=0, history::Bool=false, callback=solver->false)
 
 `T` is an `AbstractFloat` such as `Float32`, `Float64` or `BigFloat`.
 `FC` is `T` or `Complex{T}`.
+
+    (x, stats) = usymqr(A, b, c, x0::AbstractVector; kwargs...)
+
+USYMQR can be warm-started from an initial guess `x0` where `kwargs` are the same keyword arguments as above.
 
 Solve the linear system Ax = b of size m × n using USYMQR.
 
@@ -38,12 +41,6 @@ It's considered as a generalization of MINRES.
 It can also be applied to under-determined and over-determined problems.
 USYMQR finds the minimum-norm solution if problems are inconsistent.
 
-USYMQR can be warm-started from an initial guess `x0` with
-
-    (x, stats) = usymqr(A, b, c, x0; kwargs...)
-
-where `kwargs` are the same keyword arguments as above.
-
 The callback is called as `callback(solver)` and should return `true` if the main loop should terminate,
 and `false` otherwise.
 
@@ -52,6 +49,10 @@ and `false` otherwise.
 * `A`: a linear operator that models a matrix of dimension m × n;
 * `b`: a vector of length m;
 * `c`: a vector of length n.
+
+#### Optional argument
+
+* `x0`: a vector of length n that represents an initial guess of the solution x.
 
 #### Output arguments
 


### PR DESCRIPTION
Is `⦗...⦘` well displayed on Windows and Mac?
I don't want to use`[]` for optional arguments but I hope that all OS have a font for this unicode character.
https://juliasmoothoptimizers.github.io/Krylov.jl/previews/PR656/solvers/spd/#CG