### PR TITLE
Improve Krylov processes

### DIFF
--- a/test/test_processes.jl
+++ b/test/test_processes.jl
@@ -26,7 +26,7 @@ end
     nbits_R = sizeof(R)
     nbits_I = sizeof(Int)
 
-    @testset "Data Type: FC" begin
+    @testset "Data Type: $FC" begin
       
       @testset "Hermitian Lanczos" begin
         A, b = symmetric_indefinite(n, FC=FC)
@@ -41,7 +41,7 @@ end
         @test expected_hermitian_lanczos_bytes ≤ actual_hermitian_lanczos_bytes ≤ 1.02 * expected_hermitian_lanczos_bytes
       end
 
-      @testset "Non-hermitian Lanczos" begin
+      @testset "Non-Hermitian Lanczos" begin
         A, b = nonsymmetric_definite(n, FC=FC)
         c = -b
         V, T, U, Tᴴ = nonhermitian_lanczos(A, b, c, k)
@@ -64,8 +64,7 @@ end
         @test A * V[:,1:k] ≈ V * H
 
         function storage_arnoldi_bytes(n, k)
-          nnz = div(k*(k+1), 2) + k
-          return (nnz + k+1) * nbits_I + nnz * nbits_FC + n*(k+1) * nbits_FC
+          return k*(k+1) * nbits_FC + n*(k+1) * nbits_FC
         end
 
         expected_arnoldi_bytes = storage_arnoldi_bytes(n, k)
@@ -135,8 +134,7 @@ end
         @test K * Wₖ ≈ Wₖ₊₁ * G
 
         function storage_montoison_orban_bytes(m, n, k)
-          nnz = div(k*(k+1), 2) + k
-          return (nnz + k+1) * nbits_I + 2*nnz * nbits_FC + (n+m)*(k+1) * nbits_FC
+          return 2*k*(k+1) * nbits_FC + (n+m)*(k+1) * nbits_FC
         end
 
         expected_montoison_orban_bytes = storage_montoison_orban_bytes(m, n, k)


### PR DESCRIPTION
- The upper Hessenberg matrices are now stored as dense matrices (`Arnoldi` and `montoison_orban` processes).
It's less expensive in storage for `Float32`, `Float64`, `ComplexF32` and the difference is quite small for `ComplexF64`.

- For the four other processes, I replaced all `M[i,j]` where `M` is the projection of `A` in the Krylov subspace (`T`, `Tᴴ` or `L` variables) by `nzval[k]` where `k` is the index of `M[i,j]` in `M.nzval`.
It will be a little bit faster because Julia won't need to compute the index `k` and check if `M[i,j]` is already allocated. 

**Note:** I don't want to store a sparse matrix `A` with the type `SparseMatrixCSC{T,Int32}` instead of `SparseMatrixCSC{T,Int64}` because `A \ b` is not working for this type.
We must use `Int64` to dispatch to `SuiteSparse` routines.