### PR TITLE
Add new tests for GPUs

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -18,7 +18,7 @@ steps:
   - label: "AMD GPUs -- AMDGPU.jl"
     plugins:
       - JuliaCI/julia#v1:
-          version: 1.8
+          version: 1.9-nightly
     agents:
       queue: "juliagpu"
       rocm: "*"
@@ -26,7 +26,6 @@ steps:
     env:
       JULIA_AMDGPU_CORE_MUST_LOAD: "1"
       JULIA_AMDGPU_HIP_MUST_LOAD: "1"
-      JULIA_AMDGPU_DISABLE_ARTIFACTS: "1"
     command: |
       julia --color=yes --project -e '
       using Pkg

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -29,7 +29,8 @@ steps:
     command: |
       julia --color=yes --project -e '
       using Pkg
-      Pkg.add("AMDGPU")
+      # Pkg.add("AMDGPU")
+      Pkg.add(url="https://github.com/JuliaGPU/AMDGPU.jl", rev="master")
       Pkg.instantiate()
       include("test/gpu/amd.jl")'
     timeout_in_minutes: 30

--- a/docs/src/gpu.md
+++ b/docs/src/gpu.md
@@ -145,7 +145,7 @@ x, stats = minres(A_gpu, b_gpu)
 
 ## Intel GPUs
 
-All solvers in Krylov.jl, except [`MINRES-QLP`](@ref minres_qlp), can be used with [oneAPI.jl](https://github.com/JuliaGPU/oneAPI.jl) and allow computations on Intel GPUs.
+All solvers in Krylov.jl can be used with [oneAPI.jl](https://github.com/JuliaGPU/oneAPI.jl) and allow computations on Intel GPUs.
 Problems stored in CPU format (`Matrix` and `Vector`) must first be converted to the related GPU format (`oneMatrix` and `oneVector`).
 
 ```julia
@@ -172,7 +172,7 @@ x, stats = lsqr(A_gpu, b_gpu)
 
 ## Apple M1 GPUs
 
-All solvers in Krylov.jl, except [`MINRES-QLP`](@ref minres_qlp), can be used with [Metal.jl](https://github.com/JuliaGPU/Metal.jl) and allow computations on Apple M1 GPUs.
+All solvers in Krylov.jl can be used with [Metal.jl](https://github.com/JuliaGPU/Metal.jl) and allow computations on Apple M1 GPUs.
 Problems stored in CPU format (`Matrix` and `Vector`) must first be converted to the related GPU format (`MtlMatrix` and `MtlVector`).
 
 ```julia

--- a/src/minres.jl
+++ b/src/minres.jl
@@ -336,7 +336,7 @@ function minres!(solver :: MinresSolver{T,FC,S}, A, b :: AbstractVector{FC};
     tired = iter ≥ itmax
     ill_cond_lim = (one(T) / Acond ≤ ctol)
     solved_lim = (test2 ≤ ε)
-    zero_resid_lim = MisI && (test1 ≤ ε)
+    zero_resid_lim = MisI && (test1 ≤ eps(T))
     resid_decrease_lim = (rNorm ≤ ε)
     iter ≥ window && (fwd_err = err_lbnd ≤ etol * sqrt(xENorm²))
 

--- a/src/minres_qlp.jl
+++ b/src/minres_qlp.jl
@@ -406,7 +406,7 @@ function minres_qlp!(solver :: MinresQlpSolver{T,FC,S}, A, b :: AbstractVector{F
     # Stopping conditions based on user-provided tolerances.
     tired = iter ≥ itmax
     resid_decrease_lim = (rNorm ≤ ε)
-    zero_resid_lim = MisI && (backward ≤ ε)
+    zero_resid_lim = MisI && (backward ≤ eps(T))
     breakdown = βₖ₊₁ ≤ btol
 
     user_requested_exit = callback(solver) :: Bool

--- a/test/gpu/amd.jl
+++ b/test/gpu/amd.jl
@@ -93,7 +93,7 @@ include("gpu.jl")
     end
 
     @testset "MINRES-QLP -- $FC" begin
-      A, b = symmetric_definite(FC=FC, verbose=1)
+      A, b = symmetric_indefinite(FC=FC)
       A = M(A)
       b = S(b)
       x, stats = minres_qlp(A, b)

--- a/test/gpu/amd.jl
+++ b/test/gpu/amd.jl
@@ -64,9 +64,9 @@ include("gpu.jl")
       Krylov.@kswap(x, y)
     end
 
-    # @testset "kref! -- $FC" begin
-    #   Krylov.@kref!(n, x, y, c, s)
-    # end
+    @testset "kref! -- $FC" begin
+      Krylov.@kref!(n, x, y, c, s)
+    end
 
     @testset "conversion -- $FC" begin
       test_conversion(S, M)
@@ -78,17 +78,25 @@ include("gpu.jl")
 
     @testset "GMRES -- $FC" begin
       A, b = nonsymmetric_indefinite(FC=FC)
-      A = ROCMatrix{FC}(A)
-      b = ROCVector{FC}(b)
+      A = M(A)
+      b = S(b)
       x, stats = gmres(A, b)
       @test norm(b - A * x) ≤ atol + rtol * norm(b)
     end
 
     @testset "CG -- $FC" begin
       A, b = symmetric_definite(FC=FC)
-      A = ROCMatrix{FC}(A)
-      b = ROCVector{FC}(b)
+      A = M(A)
+      b = S(b)
       x, stats = cg(A, b)
+      @test norm(b - A * x) ≤ atol + rtol * norm(b)
+    end
+
+    @testset "MINRES-QLP -- $FC" begin
+      A, b = symmetric_indefinite(FC=FC)
+      A = M(A)
+      b = S(b)
+      x, stats = minres_qlp(A, b)
       @test norm(b - A * x) ≤ atol + rtol * norm(b)
     end
 

--- a/test/gpu/amd.jl
+++ b/test/gpu/amd.jl
@@ -93,7 +93,7 @@ include("gpu.jl")
     end
 
     @testset "MINRES-QLP -- $FC" begin
-      A, b = symmetric_definite(FC=FC)
+      A, b = symmetric_definite(FC=FC, verbose=1)
       A = M(A)
       b = S(b)
       x, stats = minres_qlp(A, b)

--- a/test/gpu/amd.jl
+++ b/test/gpu/amd.jl
@@ -93,7 +93,7 @@ include("gpu.jl")
     end
 
     @testset "MINRES-QLP -- $FC" begin
-      A, b = symmetric_indefinite(FC=FC)
+      A, b = sparse_laplacian(FC=FC)
       A = M(A)
       b = S(b)
       x, stats = minres_qlp(A, b)

--- a/test/gpu/amd.jl
+++ b/test/gpu/amd.jl
@@ -93,7 +93,7 @@ include("gpu.jl")
     end
 
     @testset "MINRES-QLP -- $FC" begin
-      A, b = sparse_laplacian(FC=FC)
+      A, b = symmetric_definite(FC=FC)
       A = M(A)
       b = S(b)
       x, stats = minres_qlp(A, b)

--- a/test/gpu/intel.jl
+++ b/test/gpu/intel.jl
@@ -98,7 +98,7 @@ include("gpu.jl")
       A, b = symmetric_definite(FC=FC)
       A = M(A)
       b = S(b)
-      x, stats = minres_qlp(A, b)
+      x, stats = minres_qlp(A, b, verbose=1)
       @test norm(b - A * x) ≤ atol + rtol * norm(b)
     end
 

--- a/test/gpu/intel.jl
+++ b/test/gpu/intel.jl
@@ -95,10 +95,10 @@ include("gpu.jl")
     end
 
     @testset "MINRES-QLP -- $FC" begin
-      A, b = symmetric_definite(FC=FC)
+      A, b = symmetric_indefinite(FC=FC)
       A = M(A)
       b = S(b)
-      x, stats = minres_qlp(A, b, verbose=1)
+      x, stats = minres_qlp(A, b)
       @test norm(b - A * x) ≤ atol + rtol * norm(b)
     end
 

--- a/test/gpu/intel.jl
+++ b/test/gpu/intel.jl
@@ -95,7 +95,7 @@ include("gpu.jl")
     end
 
     @testset "MINRES-QLP -- $FC" begin
-      A, b = sparse_laplacian(FC=FC)
+      A, b = symmetric_definite(FC=FC)
       A = M(A)
       b = S(b)
       x, stats = minres_qlp(A, b)

--- a/test/gpu/intel.jl
+++ b/test/gpu/intel.jl
@@ -95,7 +95,7 @@ include("gpu.jl")
     end
 
     @testset "MINRES-QLP -- $FC" begin
-      A, b = symmetric_indefinite(FC=FC)
+      A, b = sparse_laplacian(FC=FC)
       A = M(A)
       b = S(b)
       x, stats = minres_qlp(A, b)

--- a/test/gpu/metal.jl
+++ b/test/gpu/metal.jl
@@ -98,7 +98,7 @@ include("gpu.jl")
       A, b = symmetric_definite(FC=FC)
       A = M(A)
       b = S(b)
-      x, stats = minres_qlp(A, b)
+      x, stats = minres_qlp(A, b, verbose=1)
       @test norm(b - A * x) ≤ atol + rtol * norm(b)
     end
 

--- a/test/gpu/metal.jl
+++ b/test/gpu/metal.jl
@@ -95,10 +95,10 @@ include("gpu.jl")
     end
 
     @testset "MINRES-QLP -- $FC" begin
-      A, b = symmetric_definite(FC=FC)
+      A, b = symmetric_indefinite(FC=FC)
       A = M(A)
       b = S(b)
-      x, stats = minres_qlp(A, b, verbose=1)
+      x, stats = minres_qlp(A, b)
       @test norm(b - A * x) ≤ atol + rtol * norm(b)
     end
 

--- a/test/gpu/metal.jl
+++ b/test/gpu/metal.jl
@@ -95,7 +95,7 @@ include("gpu.jl")
     end
 
     @testset "MINRES-QLP -- $FC" begin
-      A, b = sparse_laplacian(FC=FC)
+      A, b = symmetric_definite(FC=FC)
       A = M(A)
       b = S(b)
       x, stats = minres_qlp(A, b)

--- a/test/gpu/metal.jl
+++ b/test/gpu/metal.jl
@@ -95,7 +95,7 @@ include("gpu.jl")
     end
 
     @testset "MINRES-QLP -- $FC" begin
-      A, b = symmetric_indefinite(FC=FC)
+      A, b = sparse_laplacian(FC=FC)
       A = M(A)
       b = S(b)
       x, stats = minres_qlp(A, b)

--- a/test/gpu/metal.jl
+++ b/test/gpu/metal.jl
@@ -2,16 +2,6 @@ using Metal
 
 include("gpu.jl")
 
-# https://github.com/JuliaGPU/Metal.jl/pull/48
-const MtlVector{T} = MtlArray{T,1}
-const MtlMatrix{T} = MtlArray{T,2}
-
-# https://github.com/JuliaGPU/GPUArrays.jl/pull/427
-import Krylov.kdot
-function kdot(n :: Integer, x :: MtlVector{T}, dx :: Integer, y :: MtlVector{T}, dy :: Integer) where T <: Krylov.FloatOrComplex
-  return mapreduce(dot, +, x, y)
-end
-
 @testset "Apple M1 GPUs -- Metal.jl" begin
 
   # @test Metal.functional()
@@ -76,9 +66,9 @@ end
       Krylov.@kswap(x, y)
     end
 
-    # @testset "kref! -- $FC" begin
-    #   Krylov.@kref!(n, x, y, c, s)
-    # end
+    @testset "kref! -- $FC" begin
+      Krylov.@kref!(n, x, y, c, s)
+    end
 
     @testset "conversion -- $FC" begin
       test_conversion(S, M)
@@ -90,17 +80,25 @@ end
 
     @testset "GMRES -- $FC" begin
       A, b = nonsymmetric_indefinite(FC=FC)
-      A = MtlMatrix{FC}(A)
-      b = MtlVector{FC}(b)
+      A = M(A)
+      b = S(b)
       x, stats = gmres(A, b)
       @test norm(b - A * x) ≤ atol + rtol * norm(b)
     end
 
     @testset "CG -- $FC" begin
-     A, b = symmetric_definite(FC=FC)
-      A = MtlMatrix{FC}(A)
-      b = MtlVector{FC}(b)
+      A, b = symmetric_definite(FC=FC)
+      A = M(A)
+      b = S(b)
       x, stats = cg(A, b)
+      @test norm(b - A * x) ≤ atol + rtol * norm(b)
+    end
+
+    @testset "MINRES-QLP -- $FC" begin
+      A, b = symmetric_indefinite(FC=FC)
+      A = M(A)
+      b = S(b)
+      x, stats = minres_qlp(A, b)
       @test norm(b - A * x) ≤ atol + rtol * norm(b)
     end
 

--- a/test/gpu/nvidia.jl
+++ b/test/gpu/nvidia.jl
@@ -170,10 +170,10 @@ include("gpu.jl")
     end
 
     @testset "MINRES-QLP -- $FC" begin
-      A, b = symmetric_definite(FC=FC)
+      A, b = symmetric_indefinite(FC=FC)
       A = M(A)
       b = S(b)
-      x, stats = minres_qlp(A, b, verbose=1)
+      x, stats = minres_qlp(A, b)
       @test norm(b - A * x) ≤ atol + rtol * norm(b)
     end
 

--- a/test/gpu/nvidia.jl
+++ b/test/gpu/nvidia.jl
@@ -155,17 +155,25 @@ include("gpu.jl")
 
     @testset "GMRES -- $FC" begin
       A, b = nonsymmetric_indefinite(FC=FC)
-      A = CuMatrix{FC}(A)
-      b = CuVector{FC}(b)
+      A = M(A)
+      b = S(b)
       x, stats = gmres(A, b)
       @test norm(b - A * x) ≤ atol + rtol * norm(b)
     end
 
     @testset "CG -- $FC" begin
       A, b = symmetric_definite(FC=FC)
-      A = CuMatrix{FC}(A)
-      b = CuVector{FC}(b)
+      A = M(A)
+      b = S(b)
       x, stats = cg(A, b)
+      @test norm(b - A * x) ≤ atol + rtol * norm(b)
+    end
+
+    @testset "MINRES-QLP -- $FC" begin
+      A, b = symmetric_indefinite(FC=FC)
+      A = M(A)
+      b = S(b)
+      x, stats = minres_qlp(A, b)
       @test norm(b - A * x) ≤ atol + rtol * norm(b)
     end
 

--- a/test/gpu/nvidia.jl
+++ b/test/gpu/nvidia.jl
@@ -170,7 +170,7 @@ include("gpu.jl")
     end
 
     @testset "MINRES-QLP -- $FC" begin
-      A, b = symmetric_indefinite(FC=FC)
+      A, b = sparse_laplacian(FC=FC)
       A = M(A)
       b = S(b)
       x, stats = minres_qlp(A, b)

--- a/test/gpu/nvidia.jl
+++ b/test/gpu/nvidia.jl
@@ -173,7 +173,7 @@ include("gpu.jl")
       A, b = symmetric_definite(FC=FC)
       A = M(A)
       b = S(b)
-      x, stats = minres_qlp(A, b)
+      x, stats = minres_qlp(A, b, verbose=1)
       @test norm(b - A * x) ≤ atol + rtol * norm(b)
     end
 

--- a/test/gpu/nvidia.jl
+++ b/test/gpu/nvidia.jl
@@ -170,7 +170,7 @@ include("gpu.jl")
     end
 
     @testset "MINRES-QLP -- $FC" begin
-      A, b = sparse_laplacian(FC=FC)
+      A, b = symmetric_definite(FC=FC)
       A = M(A)
       b = S(b)
       x, stats = minres_qlp(A, b)


### PR DESCRIPTION
A new release of `GPUArrays.jl` is available.
My generic fallbacks for `dot` and `reflect!` should work now.
It will solve some issues with Intel / Apple M1 GPUs.