### PR TITLE
[documentation] Use CUDA.zeros instead of similar

### DIFF
--- a/docs/src/gpu.md
+++ b/docs/src/gpu.md
@@ -70,7 +70,7 @@ if CUDA.functional()
   # Additional vector required for solving triangular systems
   n = length(b_gpu)
   T = eltype(b_gpu)
-  z = similar(CuVector{T}, n)
+  z = CUDA.zeros(T, n)
 
   # Solve Py = x
   function ldiv_ic0!(P::CuSparseMatrixCSR, x, y, z)
@@ -116,7 +116,7 @@ if CUDA.functional()
   # Additional vector required for solving triangular systems
   n = length(b_gpu)
   T = eltype(b_gpu)
-  z = similar(CuVector{T}, n)
+  z = CUDA.zeros(T, n)
 
   # Solve Py = x
   function ldiv_ilu0!(P::CuSparseMatrixCSR, x, y, z)

--- a/test/gpu/nvidia.jl
+++ b/test/gpu/nvidia.jl
@@ -27,7 +27,7 @@ include("gpu.jl")
       b_gpu = CuVector(b_cpu)
       n = length(b_gpu)
       T = eltype(b_gpu)
-      z = similar(CuVector{T}, n)
+      z = CUDA.zeros(T, n)
       symmetric = hermitian = true
 
       A_gpu = CuSparseMatrixCSC(A_cpu)
@@ -72,7 +72,7 @@ include("gpu.jl")
       b_gpu = CuVector(b_cpu)
       n = length(b_gpu)
       T = eltype(b_gpu)
-      z = similar(CuVector{T}, n)
+      z = CUDA.zeros(T, n)
       symmetric = hermitian = false
 
       A_gpu = CuSparseMatrixCSC(A_cpu[:,p])


### PR DESCRIPTION
`ldiv!(y, P, x)` returns a vector with `NaN` numbers if `y` has a `NaN`.
I thought that it was not a problem to have some `NaN` in `y` because the vector is overwritten by the result of `P \ x`.
It works fine on CPU but `NaN` is probably represented differently on GPU. I suspect that they use a pointer to a "CUDA" void.