### PR TITLE
Test Krylov.jl with CUDA 12.1.1

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,7 +13,7 @@ steps:
         Pkg.add("LinearOperators")
         Pkg.instantiate()
         using CUDA
-        CUDA.set_runtime_version!(v"11.8")'
+        # CUDA.set_runtime_version!(v"11.8")'
 
       julia --color=yes --project -e '
         include("test/gpu/nvidia.jl")'

--- a/docs/src/gpu.md
+++ b/docs/src/gpu.md
@@ -144,9 +144,6 @@ if CUDA.functional()
 end
 ```
 
-!!! note
-    The `CUSPARSE` library of CUDA toolkits `v"12.x"` is unstable. We recommend using CUDA toolkit v"11.8" with `CUDA.set_runtime_version!(v"11.8")`.
-
 ## AMD GPUs
 
 All solvers in Krylov.jl can be used with [AMDGPU.jl](https://github.com/JuliaGPU/AMDGPU.jl) and allow computations on AMD GPUs.


### PR DESCRIPTION
When I updated CUDA.jl for CUDA Toolkit 12.0, I found a few bugs in the new CUDA Toolkit.
I reported the issues to NVIDIA and my contact at NVIDIA explained that the fixes will be in the release 12.1.1.