### PR TITLE
Use metaprogramming to define the kwargs of all Krylov methods

### DIFF
--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -6,10 +6,11 @@
 ```
 
 ```@docs
-Krylov.kstdout
 Krylov.FloatOrComplex
 Krylov.niterations
 Krylov.Aprod
 Krylov.Atprod
+Krylov.kstdout
+Krylov.extract_parameters
 Base.show
 ```

--- a/src/bicgstab.jl
+++ b/src/bicgstab.jl
@@ -101,7 +101,7 @@ def_kwargs_bicgstab = (:(; c::AbstractVector{FC} = b ),
                        :(; callback = solver -> false),
                        :(; iostream::IO = kstdout    ))
 
-def_kwargs_bicgstab = reduce(vcat, kw.args[1].args for kw in def_kwargs_bicgstab)
+def_kwargs_bicgstab = mapreduce(extract_parameters, vcat, def_kwargs_bicgstab)
 
 kwargs_bicgstab = (:c, :M, :N, :ldiv, :atol, :rtol, :itmax, :timemax, :verbose, :history, :callback, :iostream)
 

--- a/src/bilq.jl
+++ b/src/bilq.jl
@@ -86,7 +86,7 @@ def_kwargs_bilq = (:(; c::AbstractVector{FC} = b    ),
                    :(; callback = solver -> false   ),
                    :(; iostream::IO = kstdout       ))
 
-def_kwargs_bilq = reduce(vcat, kw.args[1].args for kw in def_kwargs_bilq)
+def_kwargs_bilq = mapreduce(extract_parameters, vcat, def_kwargs_bilq)
 
 kwargs_bilq = (:c, :transfer_to_bicg, :atol, :rtol, :itmax, :timemax, :verbose, :history, :callback, :iostream)
 

--- a/src/bilqr.jl
+++ b/src/bilqr.jl
@@ -90,7 +90,7 @@ def_kwargs_bilqr = (:(; transfer_to_bicg::Bool = true),
                     :(; callback = solver -> false   ),
                     :(; iostream::IO = kstdout       ))
 
-def_kwargs_bilqr = reduce(vcat, kw.args[1].args for kw in def_kwargs_bilqr)
+def_kwargs_bilqr = mapreduce(extract_parameters, vcat, def_kwargs_bilqr)
 
 kwargs_bilqr = (:transfer_to_bicg, :atol, :rtol, :itmax, :timemax, :verbose, :history, :callback, :iostream)
 

--- a/src/cg.jl
+++ b/src/cg.jl
@@ -93,7 +93,7 @@ def_kwargs_cg = (:(; M = I                     ),
                  :(; callback = solver -> false),
                  :(; iostream::IO = kstdout    ))
 
-def_kwargs_cg = reduce(vcat, kw.args[1].args for kw in def_kwargs_cg)
+def_kwargs_cg = mapreduce(extract_parameters, vcat, def_kwargs_cg)
 
 kwargs_cg = (:M, :ldiv, :radius, :linesearch, :atol, :rtol, :itmax, :timemax, :verbose, :history, :callback, :iostream)
 

--- a/src/cg_lanczos.jl
+++ b/src/cg_lanczos.jl
@@ -89,7 +89,7 @@ def_kwargs_cg_lanczos = (:(; M = I                        ),
                          :(; callback = solver -> false   ),
                          :(; iostream::IO = kstdout       ))
 
-def_kwargs_cg_lanczos = reduce(vcat, kw.args[1].args for kw in def_kwargs_cg_lanczos)
+def_kwargs_cg_lanczos = mapreduce(extract_parameters, vcat, def_kwargs_cg_lanczos)
 
 kwargs_cg_lanczos = (:M, :ldiv, :check_curvature, :atol, :rtol, :itmax, :timemax, :verbose, :history, :callback, :iostream)
 

--- a/src/cg_lanczos_shift.jl
+++ b/src/cg_lanczos_shift.jl
@@ -84,7 +84,7 @@ def_kwargs_cg_lanczos_shift = (:(; M = I                        ),
                                :(; callback = solver -> false   ),
                                :(; iostream::IO = kstdout       ))
 
-def_kwargs_cg_lanczos_shift = reduce(vcat, kw.args[1].args for kw in def_kwargs_cg_lanczos_shift)
+def_kwargs_cg_lanczos_shift = mapreduce(extract_parameters, vcat, def_kwargs_cg_lanczos_shift)
 
 kwargs_cg_lanczos_shift = (:M, :ldiv, :check_curvature, :atol, :rtol, :itmax, :timemax, :verbose, :history, :callback, :iostream)
 

--- a/src/cgls.jl
+++ b/src/cgls.jl
@@ -108,7 +108,7 @@ def_kwargs_cgls = (:(; M = I                     ),
                    :(; callback = solver -> false),
                    :(; iostream::IO = kstdout    ))
 
-def_kwargs_cgls = reduce(vcat, kw.args[1].args for kw in def_kwargs_cgls)
+def_kwargs_cgls = mapreduce(extract_parameters, vcat, def_kwargs_cgls)
 
 kwargs_cgls = (:M, :ldiv, :radius, :λ, :atol, :rtol, :itmax, :timemax, :verbose, :history, :callback, :iostream)
 

--- a/src/cgne.jl
+++ b/src/cgne.jl
@@ -113,7 +113,7 @@ def_kwargs_cgne = (:(; N = I                     ),
                    :(; callback = solver -> false),
                    :(; iostream::IO = kstdout    ))
 
-def_kwargs_cgne = reduce(vcat, kw.args[1].args for kw in def_kwargs_cgne)
+def_kwargs_cgne = mapreduce(extract_parameters, vcat, def_kwargs_cgne)
 
 kwargs_cgne = (:N, :ldiv, :λ, :atol, :rtol, :itmax, :timemax, :verbose, :history, :callback, :iostream)
 

--- a/src/cgs.jl
+++ b/src/cgs.jl
@@ -102,7 +102,7 @@ def_kwargs_cgs = (:(; c::AbstractVector{FC} = b ),
                   :(; callback = solver -> false),
                   :(; iostream::IO = kstdout    ))
 
-def_kwargs_cgs = reduce(vcat, kw.args[1].args for kw in def_kwargs_cgs)
+def_kwargs_cgs = mapreduce(extract_parameters, vcat, def_kwargs_cgs)
 
 kwargs_cgs = (:c, :M, :N, :ldiv, :atol, :rtol, :itmax, :timemax, :verbose, :history, :callback, :iostream)
 

--- a/src/cr.jl
+++ b/src/cr.jl
@@ -100,7 +100,7 @@ def_kwargs_cr = (:(; M = I                     ),
                  :(; callback = solver -> false),
                  :(; iostream::IO = kstdout    ))
 
-def_kwargs_cr = reduce(vcat, kw.args[1].args for kw in def_kwargs_cr)
+def_kwargs_cr = mapreduce(extract_parameters, vcat, def_kwargs_cr)
 
 kwargs_cr = (:M, :ldiv, :radius, :linesearch, :γ, :atol, :rtol, :itmax, :timemax, :verbose, :history, :callback, :iostream)
 

--- a/src/craig.jl
+++ b/src/craig.jl
@@ -151,7 +151,7 @@ def_kwargs_craig = (:(; M = I                         ),
                     :(; callback = solver -> false    ),
                     :(; iostream::IO = kstdout        ))
 
-def_kwargs_craig = reduce(vcat, kw.args[1].args for kw in def_kwargs_craig)
+def_kwargs_craig = mapreduce(extract_parameters, vcat, def_kwargs_craig)
 
 kwargs_craig = (:M, :N, :ldiv, :transfer_to_lsqr, :sqd, :λ, :btol, :conlim, :atol, :rtol, :itmax, :timemax, :verbose, :history, :callback, :iostream)
 

--- a/src/craigmr.jl
+++ b/src/craigmr.jl
@@ -117,12 +117,6 @@ returned.
 """
 function craigmr end
 
-function craigmr(A, b :: AbstractVector{FC}; kwargs...) where FC <: FloatOrComplex
-  solver = CraigmrSolver(A, b)
-  craigmr!(solver, A, b; kwargs...)
-  return (solver.x, solver.y, solver.stats)
-end
-
 """
     solver = craigmr!(solver::CraigmrSolver, A, b; kwargs...)
 
@@ -131,6 +125,32 @@ where `kwargs` are keyword arguments of [`craigmr`](@ref).
 See [`CraigmrSolver`](@ref) for more details about the `solver`.
 """
 function craigmr! end
+
+def_kwargs_craigmr = (:(; M = I                     ),
+                      :(; N = I                     ),
+                      :(; ldiv::Bool = false        ),
+                      :(; sqd::Bool = false         ),
+                      :(; λ::T = zero(T)            ),
+                      :(; atol::T = √eps(T)         ),
+                      :(; rtol::T = √eps(T)         ),
+                      :(; itmax::Int = 0            ),
+                      :(; timemax::Float64 = Inf    ),
+                      :(; verbose::Int = 0          ),
+                      :(; history::Bool = false     ),
+                      :(; callback = solver -> false),
+                      :(; iostream::IO = kstdout    ))
+
+def_kwargs_craigmr = reduce(vcat, kw.args[1].args for kw in def_kwargs_craigmr)
+
+kwargs_craigmr = (:M, :N, :ldiv, :sqd, :λ, :atol, :rtol, :itmax, :timemax, :verbose, :history, :callback, :iostream)
+
+@eval begin
+  function craigmr(A, b :: AbstractVector{FC}; $(def_kwargs_craigmr...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+    solver = CraigmrSolver(A, b)
+    craigmr!(solver, A, b; $(kwargs_craigmr...))
+    return (solver.x, solver.y, solver.stats)
+  end
+end
 
 function craigmr!(solver :: CraigmrSolver{T,FC,S}, A, b :: AbstractVector{FC};
                   M=I, N=I, ldiv :: Bool=false,

--- a/src/craigmr.jl
+++ b/src/craigmr.jl
@@ -140,7 +140,7 @@ def_kwargs_craigmr = (:(; M = I                     ),
                       :(; callback = solver -> false),
                       :(; iostream::IO = kstdout    ))
 
-def_kwargs_craigmr = reduce(vcat, kw.args[1].args for kw in def_kwargs_craigmr)
+def_kwargs_craigmr = mapreduce(extract_parameters, vcat, def_kwargs_craigmr)
 
 kwargs_craigmr = (:M, :N, :ldiv, :sqd, :λ, :atol, :rtol, :itmax, :timemax, :verbose, :history, :callback, :iostream)
 

--- a/src/crls.jl
+++ b/src/crls.jl
@@ -99,7 +99,7 @@ def_kwargs_crls = (:(; M = I                     ),
                    :(; callback = solver -> false),
                    :(; iostream::IO = kstdout    ))
 
-def_kwargs_crls = reduce(vcat, kw.args[1].args for kw in def_kwargs_crls)
+def_kwargs_crls = mapreduce(extract_parameters, vcat, def_kwargs_crls)
 
 kwargs_crls = (:M, :ldiv, :radius, :λ, :atol, :rtol, :itmax, :timemax, :verbose, :history, :callback, :iostream)
 

--- a/src/crmr.jl
+++ b/src/crmr.jl
@@ -111,7 +111,7 @@ def_kwargs_crmr = (:(; N = I                     ),
                    :(; callback = solver -> false),
                    :(; iostream::IO = kstdout    ))
 
-def_kwargs_crmr = reduce(vcat, kw.args[1].args for kw in def_kwargs_crmr)
+def_kwargs_crmr = mapreduce(extract_parameters, vcat, def_kwargs_crmr)
 
 kwargs_crmr = (:N, :ldiv, :λ, :atol, :rtol, :itmax, :timemax, :verbose, :history, :callback, :iostream)
 

--- a/src/diom.jl
+++ b/src/diom.jl
@@ -97,7 +97,7 @@ def_kwargs_diom = (:(; M = I                            ),
                    :(; callback = solver -> false       ),
                    :(; iostream::IO = kstdout           ))
 
-def_kwargs_diom = reduce(vcat, kw.args[1].args for kw in def_kwargs_diom)
+def_kwargs_diom = mapreduce(extract_parameters, vcat, def_kwargs_diom)
 
 kwargs_diom = (:M, :N, :ldiv, :reorthogonalization, :atol, :rtol, :itmax, :timemax, :verbose, :history, :callback, :iostream)
 

--- a/src/dqgmres.jl
+++ b/src/dqgmres.jl
@@ -97,7 +97,7 @@ def_kwargs_dqgmres = (:(; M = I                            ),
                       :(; callback = solver -> false       ),
                       :(; iostream::IO = kstdout           ))
 
-def_kwargs_dqgmres = reduce(vcat, kw.args[1].args for kw in def_kwargs_dqgmres)
+def_kwargs_dqgmres = mapreduce(extract_parameters, vcat, def_kwargs_dqgmres)
 
 kwargs_dqgmres = (:M, :N, :ldiv, :reorthogonalization, :atol, :rtol, :itmax, :timemax, :verbose, :history, :callback, :iostream)
 

--- a/src/fgmres.jl
+++ b/src/fgmres.jl
@@ -100,7 +100,7 @@ def_kwargs_fgmres = (:(; M = I                            ),
                      :(; callback = solver -> false       ),
                      :(; iostream::IO = kstdout           ))
 
-def_kwargs_fgmres = reduce(vcat, kw.args[1].args for kw in def_kwargs_fgmres)
+def_kwargs_fgmres = mapreduce(extract_parameters, vcat, def_kwargs_fgmres)
 
 kwargs_fgmres = (:M, :N, :ldiv, :restart, :reorthogonalization, :atol, :rtol, :itmax, :timemax, :verbose, :history, :callback, :iostream)
 

--- a/src/fom.jl
+++ b/src/fom.jl
@@ -93,7 +93,7 @@ def_kwargs_fom = (:(; M = I                            ),
                   :(; callback = solver -> false       ),
                   :(; iostream::IO = kstdout           ))
 
-def_kwargs_fom = reduce(vcat, kw.args[1].args for kw in def_kwargs_fom)
+def_kwargs_fom = mapreduce(extract_parameters, vcat, def_kwargs_fom)
 
 kwargs_fom = (:M, :N, :ldiv, :restart, :reorthogonalization, :atol, :rtol, :itmax, :timemax, :verbose, :history, :callback, :iostream)
 

--- a/src/gmres.jl
+++ b/src/gmres.jl
@@ -93,7 +93,7 @@ def_kwargs_gmres = (:(; M = I                            ),
                     :(; callback = solver -> false       ),
                     :(; iostream::IO = kstdout           ))
 
-def_kwargs_gmres = reduce(vcat, kw.args[1].args for kw in def_kwargs_gmres)
+def_kwargs_gmres = mapreduce(extract_parameters, vcat, def_kwargs_gmres)
 
 kwargs_gmres = (:M, :N, :ldiv, :restart, :reorthogonalization, :atol, :rtol, :itmax, :timemax, :verbose, :history, :callback, :iostream)
 

--- a/src/gpmr.jl
+++ b/src/gpmr.jl
@@ -133,7 +133,7 @@ def_kwargs_gpmr = (:(; C = I                            ),
                    :(; callback = solver -> false       ),
                    :(; iostream::IO = kstdout           ))
 
-def_kwargs_gpmr = reduce(vcat, kw.args[1].args for kw in def_kwargs_gpmr)
+def_kwargs_gpmr = mapreduce(extract_parameters, vcat, def_kwargs_gpmr)
 
 kwargs_gpmr = (:C, :D, :E, :F, :ldiv, :gsp, :λ, :μ, :reorthogonalization, :atol, :rtol, :itmax, :timemax, :verbose, :history, :callback, :iostream)
 

--- a/src/krylov_utils.jl
+++ b/src/krylov_utils.jl
@@ -394,3 +394,16 @@ function to_boundary(n :: Int, x :: AbstractVector{FC}, d :: AbstractVector{FC},
   roots = roots_quadratic(dNorm2, 2 * rxd, xNorm2 - radius2)
   return roots  # `σ1` and `σ2`
 end
+
+"""
+    arguments = extract_parameters(ex::Expr)
+
+Extract the arguments of an expression that is keyword parameter tuple.
+Implementation suggested by Mitchell J. O'Sullivan (@mosullivan93).
+"""
+function extract_parameters(ex::Expr)
+  Meta.isexpr(ex, :tuple, 1) &&
+  Meta.isexpr((@inbounds p = ex.args[1]), :parameters) &&
+  all(Base.Docs.validcall, p.args) || throw(ArgumentError("Given expression is not a kw parameter tuple [e.g. :(; x)]: $ex"))
+  return p.args
+end

--- a/src/lnlq.jl
+++ b/src/lnlq.jl
@@ -147,7 +147,7 @@ def_kwargs_lnlq = (:(; M = I                         ),
                    :(; callback = solver -> false    ),
                    :(; iostream::IO = kstdout        ))
 
-def_kwargs_lnlq = reduce(vcat, kw.args[1].args for kw in def_kwargs_lnlq)
+def_kwargs_lnlq = mapreduce(extract_parameters, vcat, def_kwargs_lnlq)
 
 kwargs_lnlq = (:M, :N, :ldiv, :transfer_to_craig, :sqd, :λ, :σ, :utolx, :utoly, :atol, :rtol, :itmax, :timemax, :verbose, :history, :callback, :iostream)
 

--- a/src/lslq.jl
+++ b/src/lslq.jl
@@ -173,7 +173,7 @@ def_kwargs_lslq = (:(; M = I                         ),
                    :(; callback = solver -> false    ),
                    :(; iostream::IO = kstdout        ))
 
-def_kwargs_lslq = reduce(vcat, kw.args[1].args for kw in def_kwargs_lslq)
+def_kwargs_lslq = mapreduce(extract_parameters, vcat, def_kwargs_lslq)
 
 kwargs_lslq = (:M, :N, :ldiv, :transfer_to_lsqr, :sqd, :λ, :σ, :etol, :utol, :btol, :conlim, :atol, :rtol, :itmax, :timemax, :verbose, :history, :callback, :iostream)
 

--- a/src/lsmr.jl
+++ b/src/lsmr.jl
@@ -150,7 +150,7 @@ def_kwargs_lsmr = (:(; M = I                     ),
                    :(; callback = solver -> false),
                    :(; iostream::IO = kstdout    ))
 
-def_kwargs_lsmr = reduce(vcat, kw.args[1].args for kw in def_kwargs_lsmr)
+def_kwargs_lsmr = mapreduce(extract_parameters, vcat, def_kwargs_lsmr)
 
 kwargs_lsmr = (:M, :N, :ldiv, :sqd, :λ, :radius, :etol, :axtol, :btol, :conlim, :atol, :rtol, :itmax, :timemax, :verbose, :history, :callback, :iostream)
 

--- a/src/lsqr.jl
+++ b/src/lsqr.jl
@@ -146,7 +146,7 @@ def_kwargs_lsqr = (:(; M = I                     ),
                    :(; callback = solver -> false),
                    :(; iostream::IO = kstdout    ))
 
-def_kwargs_lsqr = reduce(vcat, kw.args[1].args for kw in def_kwargs_lsqr)
+def_kwargs_lsqr = mapreduce(extract_parameters, vcat, def_kwargs_lsqr)
 
 kwargs_lsqr = (:M, :N, :ldiv, :sqd, :λ, :radius, :etol, :axtol, :btol, :conlim, :atol, :rtol, :itmax, :timemax, :verbose, :history, :callback, :iostream)
 

--- a/src/minres.jl
+++ b/src/minres.jl
@@ -115,7 +115,7 @@ def_kwargs_minres = (:(; M = I                     ),
                      :(; callback = solver -> false),
                      :(; iostream::IO = kstdout    ))
 
-def_kwargs_minres = reduce(vcat, kw.args[1].args for kw in def_kwargs_minres)
+def_kwargs_minres = mapreduce(extract_parameters, vcat, def_kwargs_minres)
 
 kwargs_minres = (:M, :ldiv, :λ, :atol, :rtol, :etol, :conlim, :itmax, :timemax, :verbose, :history, :callback, :iostream)
 

--- a/src/minres_qlp.jl
+++ b/src/minres_qlp.jl
@@ -97,7 +97,7 @@ def_kwargs_minres_qlp = (:(; M = I                     ),
                          :(; callback = solver -> false),
                          :(; iostream::IO = kstdout    ))
 
-def_kwargs_minres_qlp = reduce(vcat, kw.args[1].args for kw in def_kwargs_minres_qlp)
+def_kwargs_minres_qlp = mapreduce(extract_parameters, vcat, def_kwargs_minres_qlp)
 
 kwargs_minres_qlp = (:M, :ldiv, :λ, :atol, :rtol, :Artol, :itmax, :timemax, :verbose, :history, :callback, :iostream)
 

--- a/src/qmr.jl
+++ b/src/qmr.jl
@@ -93,7 +93,7 @@ def_kwargs_qmr = (:(; c::AbstractVector{FC} = b ),
                   :(; callback = solver -> false),
                   :(; iostream::IO = kstdout    ))
 
-def_kwargs_qmr = reduce(vcat, kw.args[1].args for kw in def_kwargs_qmr)
+def_kwargs_qmr = mapreduce(extract_parameters, vcat, def_kwargs_qmr)
 
 kwargs_qmr = (:c, :atol, :rtol, :itmax, :timemax, :verbose, :history, :callback, :iostream)
 

--- a/src/symmlq.jl
+++ b/src/symmlq.jl
@@ -101,7 +101,7 @@ def_kwargs_symmlq = (:(; M = I                      ),
                      :(; callback = solver -> false ),
                      :(; iostream::IO = kstdout     ))
 
-def_kwargs_symmlq = reduce(vcat, kw.args[1].args for kw in def_kwargs_symmlq)
+def_kwargs_symmlq = mapreduce(extract_parameters, vcat, def_kwargs_symmlq)
 
 kwargs_symmlq = (:M, :ldiv, :transfer_to_cg, :λ, :λest, :atol, :rtol, :etol, :conlim, :itmax, :timemax, :verbose, :history, :callback, :iostream)
 

--- a/src/tricg.jl
+++ b/src/tricg.jl
@@ -120,7 +120,7 @@ def_kwargs_tricg = (:(; M = I                     ),
                     :(; callback = solver -> false),
                     :(; iostream::IO = kstdout    ))
 
-def_kwargs_tricg = reduce(vcat, kw.args[1].args for kw in def_kwargs_tricg)
+def_kwargs_tricg = mapreduce(extract_parameters, vcat, def_kwargs_tricg)
 
 kwargs_tricg = (:M, :N, :ldiv, :spd, :snd, :flip, :τ, :ν, :atol, :rtol, :itmax, :timemax, :verbose, :history, :callback, :iostream)
 

--- a/src/trilqr.jl
+++ b/src/trilqr.jl
@@ -89,7 +89,7 @@ def_kwargs_trilqr = (:(; transfer_to_usymcg::Bool = true),
                      :(; callback = solver -> false     ),
                      :(; iostream::IO = kstdout         ))
 
-def_kwargs_trilqr = reduce(vcat, kw.args[1].args for kw in def_kwargs_trilqr)
+def_kwargs_trilqr = mapreduce(extract_parameters, vcat, def_kwargs_trilqr)
 
 kwargs_trilqr = (:transfer_to_usymcg, :atol, :rtol, :itmax, :timemax, :verbose, :history, :callback, :iostream)
 

--- a/src/trimr.jl
+++ b/src/trimr.jl
@@ -121,7 +121,7 @@ def_kwargs_trimr = (:(; M = I                     ),
                     :(; callback = solver -> false),
                     :(; iostream::IO = kstdout    ))
 
-def_kwargs_trimr = reduce(vcat, kw.args[1].args for kw in def_kwargs_trimr)
+def_kwargs_trimr = mapreduce(extract_parameters, vcat, def_kwargs_trimr)
 
 kwargs_trimr = (:M, :N, :ldiv, :spd, :snd, :flip, :sp, :τ, :ν, :atol, :rtol, :itmax, :timemax, :verbose, :history, :callback, :iostream)
 

--- a/src/usymlq.jl
+++ b/src/usymlq.jl
@@ -98,7 +98,7 @@ def_kwargs_usymlq = (:(; transfer_to_usymcg::Bool = true),
                      :(; callback = solver -> false     ),
                      :(; iostream::IO = kstdout         ))
 
-def_kwargs_usymlq = reduce(vcat, kw.args[1].args for kw in def_kwargs_usymlq)
+def_kwargs_usymlq = mapreduce(extract_parameters, vcat, def_kwargs_usymlq)
 
 kwargs_usymlq = (:transfer_to_usymcg, :atol, :rtol, :itmax, :timemax, :verbose, :history, :callback, :iostream)
 

--- a/src/usymqr.jl
+++ b/src/usymqr.jl
@@ -96,7 +96,7 @@ def_kwargs_usymqr = (:(; atol::T = √eps(T)         ),
                      :(; callback = solver -> false),
                      :(; iostream::IO = kstdout    ))
 
-def_kwargs_usymqr = reduce(vcat, kw.args[1].args for kw in def_kwargs_usymqr)
+def_kwargs_usymqr = mapreduce(extract_parameters, vcat, def_kwargs_usymqr)
 
 kwargs_usymqr = (:atol, :rtol, :itmax, :timemax, :verbose, :history, :callback, :iostream)
 


### PR DESCRIPTION
Thanks @mosullivan93 for your help with metaprogramming!
@dpo @tmigot Julia will not recompile the non in-place methods anymore if we use different keyword arguments.

It will be also easier to maintain.

ps: I found some mistakes in the docstrings of `CRLS`, `CGLS`, `CGNE` and `CRMR`.