### PR TITLE
Update timemax when a KrylovSolver is allocated

### DIFF
--- a/src/bicgstab.jl
+++ b/src/bicgstab.jl
@@ -107,20 +107,26 @@ kwargs_bicgstab = (:c, :M, :N, :ldiv, :atol, :rtol, :itmax, :timemax, :verbose, 
 
 @eval begin
   function bicgstab(A, b :: AbstractVector{FC}, x0 :: AbstractVector; $(def_kwargs_bicgstab...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+    start_time = time_ns()
     solver = BicgstabSolver(A, b)
     warm_start!(solver, x0)
+    timemax -= (time_ns() - start_time) / 1e9
     bicgstab!(solver, A, b; $(kwargs_bicgstab...))
     return (solver.x, solver.stats)
   end
 
   function bicgstab(A, b :: AbstractVector{FC}; $(def_kwargs_bicgstab...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+    start_time = time_ns()
     solver = BicgstabSolver(A, b)
+    timemax -= (time_ns() - start_time) / 1e9
     bicgstab!(solver, A, b; $(kwargs_bicgstab...))
     return (solver.x, solver.stats)
   end
 
   function bicgstab!(solver :: BicgstabSolver{T,FC,S}, A, b :: AbstractVector{FC}, x0 :: AbstractVector; $(def_kwargs_bicgstab...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: AbstractVector{FC}}
+    start_time = time_ns()
     warm_start!(solver, x0)
+    timemax -= (time_ns() - start_time) / 1e9
     bicgstab!(solver, A, b; $(kwargs_bicgstab...))
     return solver
   end

--- a/src/bilq.jl
+++ b/src/bilq.jl
@@ -92,20 +92,26 @@ kwargs_bilq = (:c, :transfer_to_bicg, :atol, :rtol, :itmax, :timemax, :verbose, 
 
 @eval begin
   function bilq(A, b :: AbstractVector{FC}, x0 :: AbstractVector; $(def_kwargs_bilq...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+    start_time = time_ns()
     solver = BilqSolver(A, b)
     warm_start!(solver, x0)
+    timemax -= (time_ns() - start_time) / 1e9
     bilq!(solver, A, b; $(kwargs_bilq...))
     return (solver.x, solver.stats)
   end
 
   function bilq(A, b :: AbstractVector{FC}; $(def_kwargs_bilq...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+    start_time = time_ns()
     solver = BilqSolver(A, b)
+    timemax -= (time_ns() - start_time) / 1e9
     bilq!(solver, A, b; $(kwargs_bilq...))
     return (solver.x, solver.stats)
   end
 
   function bilq!(solver :: BilqSolver{T,FC,S}, A, b :: AbstractVector{FC}, x0 :: AbstractVector; $(def_kwargs_bilq...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: AbstractVector{FC}}
+    start_time = time_ns()
     warm_start!(solver, x0)
+    timemax -= (time_ns() - start_time) / 1e9
     bilq!(solver, A, b; $(kwargs_bilq...))
     return solver
   end

--- a/src/bilqr.jl
+++ b/src/bilqr.jl
@@ -96,20 +96,26 @@ kwargs_bilqr = (:transfer_to_bicg, :atol, :rtol, :itmax, :timemax, :verbose, :hi
 
 @eval begin
   function bilqr(A, b :: AbstractVector{FC}, c :: AbstractVector{FC}, x0 :: AbstractVector, y0 :: AbstractVector; $(def_kwargs_bilqr...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+    start_time = time_ns()
     solver = BilqrSolver(A, b)
     warm_start!(solver, x0, y0)
+    timemax -= (time_ns() - start_time) / 1e9
     bilqr!(solver, A, b, c; $(kwargs_bilqr...))
     return (solver.x, solver.y, solver.stats)
   end
 
   function bilqr(A, b :: AbstractVector{FC}, c :: AbstractVector{FC}; $(def_kwargs_bilqr...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+    start_time = time_ns()
     solver = BilqrSolver(A, b)
+    timemax -= (time_ns() - start_time) / 1e9
     bilqr!(solver, A, b, c; $(kwargs_bilqr...))
     return (solver.x, solver.y, solver.stats)
   end
 
   function bilqr!(solver :: BilqrSolver{T,FC,S}, A, b :: AbstractVector{FC}, c :: AbstractVector{FC}, x0 :: AbstractVector, y0 :: AbstractVector; $(def_kwargs_bilqr...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: AbstractVector{FC}}
+    start_time = time_ns()
     warm_start!(solver, x0, y0)
+    timemax -= (time_ns() - start_time) / 1e9
     bilqr!(solver, A, b, c; $(kwargs_bilqr...))
     return solver
   end

--- a/src/cg.jl
+++ b/src/cg.jl
@@ -99,20 +99,26 @@ kwargs_cg = (:M, :ldiv, :radius, :linesearch, :atol, :rtol, :itmax, :timemax, :v
 
 @eval begin
   function cg(A, b :: AbstractVector{FC}, x0 :: AbstractVector; $(def_kwargs_cg...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+    start_time = time_ns()
     solver = CgSolver(A, b)
     warm_start!(solver, x0)
+    timemax -= (time_ns() - start_time) / 1e9
     cg!(solver, A, b; $(kwargs_cg...))
     return (solver.x, solver.stats)
   end
 
   function cg(A, b :: AbstractVector{FC}; $(def_kwargs_cg...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+    start_time = time_ns()
     solver = CgSolver(A, b)
+    timemax -= (time_ns() - start_time) / 1e9
     cg!(solver, A, b; $(kwargs_cg...))
     return (solver.x, solver.stats)
   end
 
   function cg!(solver :: CgSolver{T,FC,S}, A, b :: AbstractVector{FC}, x0 :: AbstractVector; $(def_kwargs_cg...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: AbstractVector{FC}}
+    start_time = time_ns()
     warm_start!(solver, x0)
+    timemax -= (time_ns() - start_time) / 1e9
     cg!(solver, A, b; $(kwargs_cg...))
     return solver
   end

--- a/src/cg_lanczos.jl
+++ b/src/cg_lanczos.jl
@@ -95,20 +95,26 @@ kwargs_cg_lanczos = (:M, :ldiv, :check_curvature, :atol, :rtol, :itmax, :timemax
 
 @eval begin
   function cg_lanczos(A, b :: AbstractVector{FC}, x0 :: AbstractVector; $(def_kwargs_cg_lanczos...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+    start_time = time_ns()
     solver = CgLanczosSolver(A, b)
     warm_start!(solver, x0)
+    timemax -= (time_ns() - start_time) / 1e9
     cg_lanczos!(solver, A, b; $(kwargs_cg_lanczos...))
     return (solver.x, solver.stats)
   end
 
   function cg_lanczos(A, b :: AbstractVector{FC}; $(def_kwargs_cg_lanczos...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+    start_time = time_ns()
     solver = CgLanczosSolver(A, b)
+    timemax -= (time_ns() - start_time) / 1e9
     cg_lanczos!(solver, A, b; $(kwargs_cg_lanczos...))
     return (solver.x, solver.stats)
   end
 
   function cg_lanczos!(solver :: CgLanczosSolver{T,FC,S}, A, b :: AbstractVector{FC}, x0 :: AbstractVector; $(def_kwargs_cg_lanczos...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: AbstractVector{FC}}
+    start_time = time_ns()
     warm_start!(solver, x0)
+    timemax -= (time_ns() - start_time) / 1e9
     cg_lanczos!(solver, A, b; $(kwargs_cg_lanczos...))
     return solver
   end

--- a/src/cg_lanczos_shift.jl
+++ b/src/cg_lanczos_shift.jl
@@ -90,8 +90,10 @@ kwargs_cg_lanczos_shift = (:M, :ldiv, :check_curvature, :atol, :rtol, :itmax, :t
 
 @eval begin
   function cg_lanczos_shift(A, b :: AbstractVector{FC}, shifts :: AbstractVector{T}; $(def_kwargs_cg_lanczos_shift...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+    start_time = time_ns()
     nshifts = length(shifts)
     solver = CgLanczosShiftSolver(A, b, nshifts)
+    timemax -= (time_ns() - start_time) / 1e9
     cg_lanczos_shift!(solver, A, b, shifts; $(kwargs_cg_lanczos_shift...))
     return (solver.x, solver.stats)
   end

--- a/src/cgls.jl
+++ b/src/cgls.jl
@@ -114,7 +114,9 @@ kwargs_cgls = (:M, :ldiv, :radius, :λ, :atol, :rtol, :itmax, :timemax, :verbose
 
 @eval begin
   function cgls(A, b :: AbstractVector{FC}; $(def_kwargs_cgls...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+    start_time = time_ns()
     solver = CglsSolver(A, b)
+    timemax -= (time_ns() - start_time) / 1e9
     cgls!(solver, A, b; $(kwargs_cgls...))
     return (solver.x, solver.stats)
   end

--- a/src/cgne.jl
+++ b/src/cgne.jl
@@ -119,7 +119,9 @@ kwargs_cgne = (:N, :ldiv, :λ, :atol, :rtol, :itmax, :timemax, :verbose, :histor
 
 @eval begin
   function cgne(A, b :: AbstractVector{FC}; $(def_kwargs_cgne...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+    start_time = time_ns()
     solver = CgneSolver(A, b)
+    timemax -= (time_ns() - start_time) / 1e9
     cgne!(solver, A, b; $(kwargs_cgne...))
     return (solver.x, solver.stats)
   end

--- a/src/cgs.jl
+++ b/src/cgs.jl
@@ -108,20 +108,26 @@ kwargs_cgs = (:c, :M, :N, :ldiv, :atol, :rtol, :itmax, :timemax, :verbose, :hist
 
 @eval begin
   function cgs(A, b :: AbstractVector{FC}, x0 :: AbstractVector; $(def_kwargs_cgs...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+    start_time = time_ns()
     solver = CgsSolver(A, b)
     warm_start!(solver, x0)
+    timemax -= (time_ns() - start_time) / 1e9
     cgs!(solver, A, b; $(kwargs_cgs...))
     return (solver.x, solver.stats)
   end
 
   function cgs(A, b :: AbstractVector{FC}; $(def_kwargs_cgs...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+    start_time = time_ns()
     solver = CgsSolver(A, b)
+    timemax -= (time_ns() - start_time) / 1e9
     cgs!(solver, A, b; $(kwargs_cgs...))
     return (solver.x, solver.stats)
   end
 
   function cgs!(solver :: CgsSolver{T,FC,S}, A, b :: AbstractVector{FC}, x0 :: AbstractVector; $(def_kwargs_cgs...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: AbstractVector{FC}}
+    start_time = time_ns()
     warm_start!(solver, x0)
+    timemax -= (time_ns() - start_time) / 1e9
     cgs!(solver, A, b; $(kwargs_cgs...))
     return solver
   end

--- a/src/cr.jl
+++ b/src/cr.jl
@@ -106,20 +106,26 @@ kwargs_cr = (:M, :ldiv, :radius, :linesearch, :γ, :atol, :rtol, :itmax, :timema
 
 @eval begin
   function cr(A, b :: AbstractVector{FC}, x0 :: AbstractVector; $(def_kwargs_cr...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+    start_time = time_ns()
     solver = CrSolver(A, b)
     warm_start!(solver, x0)
+    timemax -= (time_ns() - start_time) / 1e9
     cr!(solver, A, b; $(kwargs_cr...))
     return (solver.x, solver.stats)
   end
 
   function cr(A, b :: AbstractVector{FC}; $(def_kwargs_cr...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+    start_time = time_ns()
     solver = CrSolver(A, b)
+    timemax -= (time_ns() - start_time) / 1e9
     cr!(solver, A, b; $(kwargs_cr...))
     return (solver.x, solver.stats)
   end
 
   function cr!(solver :: CrSolver{T,FC,S}, A, b :: AbstractVector{FC}, x0 :: AbstractVector; $(def_kwargs_cr...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: AbstractVector{FC}}
+    start_time = time_ns()
     warm_start!(solver, x0)
+    timemax -= (time_ns() - start_time) / 1e9
     cr!(solver, A, b; $(kwargs_cr...))
     return solver
   end

--- a/src/craig.jl
+++ b/src/craig.jl
@@ -157,7 +157,9 @@ kwargs_craig = (:M, :N, :ldiv, :transfer_to_lsqr, :sqd, :λ, :btol, :conlim, :at
 
 @eval begin
   function craig(A, b :: AbstractVector{FC}; $(def_kwargs_craig...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+    start_time = time_ns()
     solver = CraigSolver(A, b)
+    timemax -= (time_ns() - start_time) / 1e9
     craig!(solver, A, b; $(kwargs_craig...))
     return (solver.x, solver.y, solver.stats)
   end

--- a/src/craigmr.jl
+++ b/src/craigmr.jl
@@ -146,7 +146,9 @@ kwargs_craigmr = (:M, :N, :ldiv, :sqd, :λ, :atol, :rtol, :itmax, :timemax, :ver
 
 @eval begin
   function craigmr(A, b :: AbstractVector{FC}; $(def_kwargs_craigmr...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+    start_time = time_ns()
     solver = CraigmrSolver(A, b)
+    timemax -= (time_ns() - start_time) / 1e9
     craigmr!(solver, A, b; $(kwargs_craigmr...))
     return (solver.x, solver.y, solver.stats)
   end

--- a/src/crls.jl
+++ b/src/crls.jl
@@ -105,7 +105,9 @@ kwargs_crls = (:M, :ldiv, :radius, :λ, :atol, :rtol, :itmax, :timemax, :verbose
 
 @eval begin
   function crls(A, b :: AbstractVector{FC}; $(def_kwargs_crls...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+    start_time = time_ns()
     solver = CrlsSolver(A, b)
+    timemax -= (time_ns() - start_time) / 1e9
     crls!(solver, A, b; $(kwargs_crls...))
     return (solver.x, solver.stats)
   end

--- a/src/crmr.jl
+++ b/src/crmr.jl
@@ -117,7 +117,9 @@ kwargs_crmr = (:N, :ldiv, :λ, :atol, :rtol, :itmax, :timemax, :verbose, :histor
 
 @eval begin
   function crmr(A, b :: AbstractVector{FC}; $(def_kwargs_crmr...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+    start_time = time_ns()
     solver = CrmrSolver(A, b)
+    timemax -= (time_ns() - start_time) / 1e9
     crmr!(solver, A, b; $(kwargs_crmr...))
     return (solver.x, solver.stats)
   end

--- a/src/diom.jl
+++ b/src/diom.jl
@@ -103,20 +103,26 @@ kwargs_diom = (:M, :N, :ldiv, :reorthogonalization, :atol, :rtol, :itmax, :timem
 
 @eval begin
   function diom(A, b :: AbstractVector{FC}, x0 :: AbstractVector; memory :: Int=20, $(def_kwargs_diom...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+    start_time = time_ns()
     solver = DiomSolver(A, b, memory)
     warm_start!(solver, x0)
+    timemax -= (time_ns() - start_time) / 1e9
     diom!(solver, A, b; $(kwargs_diom...))
     return (solver.x, solver.stats)
   end
 
   function diom(A, b :: AbstractVector{FC}; memory :: Int=20, $(def_kwargs_diom...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+    start_time = time_ns()
     solver = DiomSolver(A, b, memory)
+    timemax -= (time_ns() - start_time) / 1e9
     diom!(solver, A, b; $(kwargs_diom...))
     return (solver.x, solver.stats)
   end
 
   function diom!(solver :: DiomSolver{T,FC,S}, A, b :: AbstractVector{FC}, x0 :: AbstractVector; $(def_kwargs_diom...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: AbstractVector{FC}}
+    start_time = time_ns()
     warm_start!(solver, x0)
+    timemax -= (time_ns() - start_time) / 1e9
     diom!(solver, A, b; $(kwargs_diom...))
     return solver
   end

--- a/src/dqgmres.jl
+++ b/src/dqgmres.jl
@@ -103,20 +103,26 @@ kwargs_dqgmres = (:M, :N, :ldiv, :reorthogonalization, :atol, :rtol, :itmax, :ti
 
 @eval begin
   function dqgmres(A, b :: AbstractVector{FC}, x0 :: AbstractVector; memory :: Int=20, $(def_kwargs_dqgmres...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+    start_time = time_ns()
     solver = DqgmresSolver(A, b, memory)
     warm_start!(solver, x0)
+    timemax -= (time_ns() - start_time) / 1e9
     dqgmres!(solver, A, b; $(kwargs_dqgmres...))
     return (solver.x, solver.stats)
   end
 
   function dqgmres(A, b :: AbstractVector{FC}; memory :: Int=20, $(def_kwargs_dqgmres...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+    start_time = time_ns()
     solver = DqgmresSolver(A, b, memory)
+    timemax -= (time_ns() - start_time) / 1e9
     dqgmres!(solver, A, b; $(kwargs_dqgmres...))
     return (solver.x, solver.stats)
   end
 
   function dqgmres!(solver :: DqgmresSolver{T,FC,S}, A, b :: AbstractVector{FC}, x0 :: AbstractVector; $(def_kwargs_dqgmres...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: AbstractVector{FC}}
+    start_time = time_ns()
     warm_start!(solver, x0)
+    timemax -= (time_ns() - start_time) / 1e9
     dqgmres!(solver, A, b; $(kwargs_dqgmres...))
     return solver
   end

--- a/src/fgmres.jl
+++ b/src/fgmres.jl
@@ -106,20 +106,26 @@ kwargs_fgmres = (:M, :N, :ldiv, :restart, :reorthogonalization, :atol, :rtol, :i
 
 @eval begin
   function fgmres(A, b :: AbstractVector{FC}, x0 :: AbstractVector; memory :: Int=20, $(def_kwargs_fgmres...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+    start_time = time_ns()
     solver = FgmresSolver(A, b, memory)
     warm_start!(solver, x0)
+    timemax -= (time_ns() - start_time) / 1e9
     fgmres!(solver, A, b; $(kwargs_fgmres...))
     return (solver.x, solver.stats)
   end
 
   function fgmres(A, b :: AbstractVector{FC}; memory :: Int=20, $(def_kwargs_fgmres...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+    start_time = time_ns()
     solver = FgmresSolver(A, b, memory)
+    timemax -= (time_ns() - start_time) / 1e9
     fgmres!(solver, A, b; $(kwargs_fgmres...))
     return (solver.x, solver.stats)
   end
 
   function fgmres!(solver :: FgmresSolver{T,FC,S}, A, b :: AbstractVector{FC}, x0 :: AbstractVector; $(def_kwargs_fgmres...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: AbstractVector{FC}}
+    start_time = time_ns()
     warm_start!(solver, x0)
+    timemax -= (time_ns() - start_time) / 1e9
     fgmres!(solver, A, b; $(kwargs_fgmres...))
     return solver
   end

--- a/src/fom.jl
+++ b/src/fom.jl
@@ -99,20 +99,26 @@ kwargs_fom = (:M, :N, :ldiv, :restart, :reorthogonalization, :atol, :rtol, :itma
 
 @eval begin
   function fom(A, b :: AbstractVector{FC}, x0 :: AbstractVector; memory :: Int=20, $(def_kwargs_fom...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+    start_time = time_ns()
     solver = FomSolver(A, b, memory)
     warm_start!(solver, x0)
+    timemax -= (time_ns() - start_time) / 1e9
     fom!(solver, A, b; $(kwargs_fom...))
     return (solver.x, solver.stats)
   end
 
   function fom(A, b :: AbstractVector{FC}; memory :: Int=20, $(def_kwargs_fom...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+    start_time = time_ns()
     solver = FomSolver(A, b, memory)
+    timemax -= (time_ns() - start_time) / 1e9
     fom!(solver, A, b; $(kwargs_fom...))
     return (solver.x, solver.stats)
   end
 
   function fom!(solver :: FomSolver{T,FC,S}, A, b :: AbstractVector{FC}, x0 :: AbstractVector; $(def_kwargs_fom...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: AbstractVector{FC}}
+    start_time = time_ns()
     warm_start!(solver, x0)
+    timemax -= (time_ns() - start_time) / 1e9
     fom!(solver, A, b; $(kwargs_fom...))
     return solver
   end

--- a/src/gmres.jl
+++ b/src/gmres.jl
@@ -99,20 +99,26 @@ kwargs_gmres = (:M, :N, :ldiv, :restart, :reorthogonalization, :atol, :rtol, :it
 
 @eval begin
   function gmres(A, b :: AbstractVector{FC}, x0 :: AbstractVector; memory :: Int=20, $(def_kwargs_gmres...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+    start_time = time_ns()
     solver = GmresSolver(A, b, memory)
     warm_start!(solver, x0)
+    timemax -= (time_ns() - start_time) / 1e9
     gmres!(solver, A, b; $(kwargs_gmres...))
     return (solver.x, solver.stats)
   end
 
   function gmres(A, b :: AbstractVector{FC}; memory :: Int=20, $(def_kwargs_gmres...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+    start_time = time_ns()
     solver = GmresSolver(A, b, memory)
+    timemax -= (time_ns() - start_time) / 1e9
     gmres!(solver, A, b; $(kwargs_gmres...))
     return (solver.x, solver.stats)
   end
 
   function gmres!(solver :: GmresSolver{T,FC,S}, A, b :: AbstractVector{FC}, x0 :: AbstractVector; $(def_kwargs_gmres...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: AbstractVector{FC}}
+    start_time = time_ns()
     warm_start!(solver, x0)
+    timemax -= (time_ns() - start_time) / 1e9
     gmres!(solver, A, b; $(kwargs_gmres...))
     return solver
   end

--- a/src/gpmr.jl
+++ b/src/gpmr.jl
@@ -139,20 +139,26 @@ kwargs_gpmr = (:C, :D, :E, :F, :ldiv, :gsp, :λ, :μ, :reorthogonalization, :ato
 
 @eval begin
   function gpmr(A, B, b :: AbstractVector{FC}, c :: AbstractVector{FC}, x0 :: AbstractVector, y0 :: AbstractVector; memory :: Int=20, $(def_kwargs_gpmr...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+    start_time = time_ns()
     solver = GpmrSolver(A, b, memory)
     warm_start!(solver, x0, y0)
+    timemax -= (time_ns() - start_time) / 1e9
     gpmr!(solver, A, B, b, c; $(kwargs_gpmr...))
     return (solver.x, solver.y, solver.stats)
   end
 
   function gpmr(A, B, b :: AbstractVector{FC}, c :: AbstractVector{FC}; memory :: Int=20, $(def_kwargs_gpmr...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+    start_time = time_ns()
     solver = GpmrSolver(A, b, memory)
+    timemax -= (time_ns() - start_time) / 1e9
     gpmr!(solver, A, B, b, c; $(kwargs_gpmr...))
     return (solver.x, solver.y, solver.stats)
   end
 
   function gpmr!(solver :: GpmrSolver{T,FC,S}, A, B, b :: AbstractVector{FC}, c :: AbstractVector{FC}, x0 :: AbstractVector, y0 :: AbstractVector; $(def_kwargs_gpmr...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: AbstractVector{FC}}
+    start_time = time_ns()
     warm_start!(solver, x0, y0)
+    timemax -= (time_ns() - start_time) / 1e9
     gpmr!(solver, A, B, b, c; $(kwargs_gpmr...))
     return solver
   end

--- a/src/lnlq.jl
+++ b/src/lnlq.jl
@@ -153,7 +153,9 @@ kwargs_lnlq = (:M, :N, :ldiv, :transfer_to_craig, :sqd, :λ, :σ, :utolx, :utoly
 
 @eval begin
   function lnlq(A, b :: AbstractVector{FC}; $(def_kwargs_lnlq...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+    start_time = time_ns()
     solver = LnlqSolver(A, b)
+    timemax -= (time_ns() - start_time) / 1e9
     lnlq!(solver, A, b; $(kwargs_lnlq...))
     return (solver.x, solver.y, solver.stats)
   end

--- a/src/lslq.jl
+++ b/src/lslq.jl
@@ -179,7 +179,9 @@ kwargs_lslq = (:M, :N, :ldiv, :transfer_to_lsqr, :sqd, :λ, :σ, :etol, :utol, :
 
 @eval begin
   function lslq(A, b :: AbstractVector{FC}; window :: Int=5, $(def_kwargs_lslq...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+    start_time = time_ns()
     solver = LslqSolver(A, b; window)
+    timemax -= (time_ns() - start_time) / 1e9
     lslq!(solver, A, b; $(kwargs_lslq...))
     return (solver.x, solver.stats)
   end

--- a/src/lsmr.jl
+++ b/src/lsmr.jl
@@ -156,7 +156,9 @@ kwargs_lsmr = (:M, :N, :ldiv, :sqd, :λ, :radius, :etol, :axtol, :btol, :conlim,
 
 @eval begin
   function lsmr(A, b :: AbstractVector{FC}; window :: Int=5, $(def_kwargs_lsmr...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+    start_time = time_ns()
     solver = LsmrSolver(A, b; window)
+    timemax -= (time_ns() - start_time) / 1e9
     lsmr!(solver, A, b; $(kwargs_lsmr...))
     return (solver.x, solver.stats)
   end

--- a/src/lsqr.jl
+++ b/src/lsqr.jl
@@ -152,7 +152,9 @@ kwargs_lsqr = (:M, :N, :ldiv, :sqd, :λ, :radius, :etol, :axtol, :btol, :conlim,
 
 @eval begin
   function lsqr(A, b :: AbstractVector{FC}; window :: Int=5, $(def_kwargs_lsqr...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+    start_time = time_ns()
     solver = LsqrSolver(A, b; window)
+    timemax -= (time_ns() - start_time) / 1e9
     lsqr!(solver, A, b; $(kwargs_lsqr...))
     return (solver.x, solver.stats)
   end

--- a/src/minres.jl
+++ b/src/minres.jl
@@ -121,20 +121,26 @@ kwargs_minres = (:M, :ldiv, :λ, :atol, :rtol, :etol, :conlim, :itmax, :timemax,
 
 @eval begin
   function minres(A, b :: AbstractVector{FC}, x0 :: AbstractVector; window :: Int=5, $(def_kwargs_minres...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+    start_time = time_ns()
     solver = MinresSolver(A, b; window)
     warm_start!(solver, x0)
+    timemax -= (time_ns() - start_time) / 1e9
     minres!(solver, A, b; $(kwargs_minres...))
     return (solver.x, solver.stats)
   end
 
   function minres(A, b :: AbstractVector{FC}; window :: Int=5, $(def_kwargs_minres...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+    start_time = time_ns()
     solver = MinresSolver(A, b; window)
+    timemax -= (time_ns() - start_time) / 1e9
     minres!(solver, A, b; $(kwargs_minres...))
     return (solver.x, solver.stats)
   end
 
   function minres!(solver :: MinresSolver{T,FC,S}, A, b :: AbstractVector{FC}, x0 :: AbstractVector; $(def_kwargs_minres...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: AbstractVector{FC}}
+    start_time = time_ns()
     warm_start!(solver, x0)
+    timemax -= (time_ns() - start_time) / 1e9
     minres!(solver, A, b; $(kwargs_minres...))
     return solver
   end

--- a/src/minres_qlp.jl
+++ b/src/minres_qlp.jl
@@ -103,20 +103,26 @@ kwargs_minres_qlp = (:M, :ldiv, :λ, :atol, :rtol, :Artol, :itmax, :timemax, :ve
 
 @eval begin
   function minres_qlp(A, b :: AbstractVector{FC}, x0 :: AbstractVector; $(def_kwargs_minres_qlp...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+    start_time = time_ns()
     solver = MinresQlpSolver(A, b)
     warm_start!(solver, x0)
+    timemax -= (time_ns() - start_time) / 1e9
     minres_qlp!(solver, A, b; $(kwargs_minres_qlp...))
     return (solver.x, solver.stats)
   end
 
   function minres_qlp(A, b :: AbstractVector{FC}; $(def_kwargs_minres_qlp...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+    start_time = time_ns()
     solver = MinresQlpSolver(A, b)
+    timemax -= (time_ns() - start_time) / 1e9
     minres_qlp!(solver, A, b; $(kwargs_minres_qlp...))
     return (solver.x, solver.stats)
   end
 
   function minres_qlp!(solver :: MinresQlpSolver{T,FC,S}, A, b :: AbstractVector{FC}, x0 :: AbstractVector; $(def_kwargs_minres_qlp...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: AbstractVector{FC}}
+    start_time = time_ns()
     warm_start!(solver, x0)
+    timemax -= (time_ns() - start_time) / 1e9
     minres_qlp!(solver, A, b; $(kwargs_minres_qlp...))
     return solver
   end

--- a/src/qmr.jl
+++ b/src/qmr.jl
@@ -99,20 +99,26 @@ kwargs_qmr = (:c, :atol, :rtol, :itmax, :timemax, :verbose, :history, :callback,
 
 @eval begin
   function qmr(A, b :: AbstractVector{FC}, x0 :: AbstractVector; $(def_kwargs_qmr...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+    start_time = time_ns()
     solver = QmrSolver(A, b)
     warm_start!(solver, x0)
+    timemax -= (time_ns() - start_time) / 1e9
     qmr!(solver, A, b; $(kwargs_qmr...))
     return (solver.x, solver.stats)
   end
 
   function qmr(A, b :: AbstractVector{FC}; $(def_kwargs_qmr...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+    start_time = time_ns()
     solver = QmrSolver(A, b)
+    timemax -= (time_ns() - start_time) / 1e9
     qmr!(solver, A, b; $(kwargs_qmr...))
     return (solver.x, solver.stats)
   end
 
   function qmr!(solver :: QmrSolver{T,FC,S}, A, b :: AbstractVector{FC}, x0 :: AbstractVector; $(def_kwargs_qmr...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: AbstractVector{FC}}
+    start_time = time_ns()
     warm_start!(solver, x0)
+    timemax -= (time_ns() - start_time) / 1e9
     qmr!(solver, A, b; $(kwargs_qmr...))
     return solver
   end

--- a/src/symmlq.jl
+++ b/src/symmlq.jl
@@ -107,20 +107,26 @@ kwargs_symmlq = (:M, :ldiv, :transfer_to_cg, :λ, :λest, :atol, :rtol, :etol, :
 
 @eval begin
   function symmlq(A, b :: AbstractVector{FC}, x0 :: AbstractVector; window :: Int=5, $(def_kwargs_symmlq...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+    start_time = time_ns()
     solver = SymmlqSolver(A, b; window)
     warm_start!(solver, x0)
+    timemax -= (time_ns() - start_time) / 1e9
     symmlq!(solver, A, b; $(kwargs_symmlq...))
     return (solver.x, solver.stats)
   end
 
   function symmlq(A, b :: AbstractVector{FC}; window :: Int=5, $(def_kwargs_symmlq...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+    start_time = time_ns()
     solver = SymmlqSolver(A, b; window)
+    timemax -= (time_ns() - start_time) / 1e9
     symmlq!(solver, A, b; $(kwargs_symmlq...))
     return (solver.x, solver.stats)
   end
 
   function symmlq!(solver :: SymmlqSolver{T,FC,S}, A, b :: AbstractVector{FC}, x0 :: AbstractVector; $(def_kwargs_symmlq...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: AbstractVector{FC}}
+    start_time = time_ns()
     warm_start!(solver, x0)
+    timemax -= (time_ns() - start_time) / 1e9
     symmlq!(solver, A, b; $(kwargs_symmlq...))
     return solver
   end

--- a/src/tricg.jl
+++ b/src/tricg.jl
@@ -126,20 +126,26 @@ kwargs_tricg = (:M, :N, :ldiv, :spd, :snd, :flip, :τ, :ν, :atol, :rtol, :itmax
 
 @eval begin
   function tricg(A, b :: AbstractVector{FC}, c :: AbstractVector{FC}, x0 :: AbstractVector, y0 :: AbstractVector; $(def_kwargs_tricg...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+    start_time = time_ns()
     solver = TricgSolver(A, b)
     warm_start!(solver, x0, y0)
+    timemax -= (time_ns() - start_time) / 1e9
     tricg!(solver, A, b, c; $(kwargs_tricg...))
     return (solver.x, solver.y, solver.stats)
   end
 
   function tricg(A, b :: AbstractVector{FC}, c :: AbstractVector{FC}; $(def_kwargs_tricg...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+    start_time = time_ns()
     solver = TricgSolver(A, b)
+    timemax -= (time_ns() - start_time) / 1e9
     tricg!(solver, A, b, c; $(kwargs_tricg...))
     return (solver.x, solver.y, solver.stats)
   end
 
   function tricg!(solver :: TricgSolver{T,FC,S}, A, b :: AbstractVector{FC}, c :: AbstractVector{FC}, x0 :: AbstractVector, y0 :: AbstractVector; $(def_kwargs_tricg...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: AbstractVector{FC}}
+    start_time = time_ns()
     warm_start!(solver, x0, y0)
+    timemax -= (time_ns() - start_time) / 1e9
     tricg!(solver, A, b, c; $(kwargs_tricg...))
     return solver
   end

--- a/src/trilqr.jl
+++ b/src/trilqr.jl
@@ -95,20 +95,26 @@ kwargs_trilqr = (:transfer_to_usymcg, :atol, :rtol, :itmax, :timemax, :verbose, 
 
 @eval begin
   function trilqr(A, b :: AbstractVector{FC}, c :: AbstractVector{FC}, x0 :: AbstractVector, y0 :: AbstractVector; $(def_kwargs_trilqr...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+    start_time = time_ns()
     solver = TrilqrSolver(A, b)
     warm_start!(solver, x0, y0)
+    timemax -= (time_ns() - start_time) / 1e9
     trilqr!(solver, A, b, c; $(kwargs_trilqr...))
     return (solver.x, solver.y, solver.stats)
   end
 
   function trilqr(A, b :: AbstractVector{FC}, c :: AbstractVector{FC}; $(def_kwargs_trilqr...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+    start_time = time_ns()
     solver = TrilqrSolver(A, b)
+    timemax -= (time_ns() - start_time) / 1e9
     trilqr!(solver, A, b, c; $(kwargs_trilqr...))
     return (solver.x, solver.y, solver.stats)
   end
 
   function trilqr!(solver :: TrilqrSolver{T,FC,S}, A, b :: AbstractVector{FC}, c :: AbstractVector{FC}, x0 :: AbstractVector, y0 :: AbstractVector; $(def_kwargs_trilqr...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: AbstractVector{FC}}
+    start_time = time_ns()
     warm_start!(solver, x0, y0)
+    timemax -= (time_ns() - start_time) / 1e9
     trilqr!(solver, A, b, c; $(kwargs_trilqr...))
     return solver
   end

--- a/src/trimr.jl
+++ b/src/trimr.jl
@@ -127,20 +127,26 @@ kwargs_trimr = (:M, :N, :ldiv, :spd, :snd, :flip, :sp, :τ, :ν, :atol, :rtol, :
 
 @eval begin
   function trimr(A, b :: AbstractVector{FC}, c :: AbstractVector{FC}, x0 :: AbstractVector, y0 :: AbstractVector; $(def_kwargs_trimr...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+    start_time = time_ns()
     solver = TrimrSolver(A, b)
     warm_start!(solver, x0, y0)
+    timemax -= (time_ns() - start_time) / 1e9
     trimr!(solver, A, b, c; $(kwargs_trimr...))
     return (solver.x, solver.y, solver.stats)
   end
 
   function trimr(A, b :: AbstractVector{FC}, c :: AbstractVector{FC}; $(def_kwargs_trimr...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+    start_time = time_ns()
     solver = TrimrSolver(A, b)
+    timemax -= (time_ns() - start_time) / 1e9
     trimr!(solver, A, b, c; $(kwargs_trimr...))
     return (solver.x, solver.y, solver.stats)
   end
 
   function trimr!(solver :: TrimrSolver{T,FC,S}, A, b :: AbstractVector{FC}, c :: AbstractVector{FC}, x0 :: AbstractVector, y0 :: AbstractVector; $(def_kwargs_trimr...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: AbstractVector{FC}}
+    start_time = time_ns()
     warm_start!(solver, x0, y0)
+    timemax -= (time_ns() - start_time) / 1e9
     trimr!(solver, A, b, c; $(kwargs_trimr...))
     return solver
   end

--- a/src/usymlq.jl
+++ b/src/usymlq.jl
@@ -104,20 +104,26 @@ kwargs_usymlq = (:transfer_to_usymcg, :atol, :rtol, :itmax, :timemax, :verbose, 
 
 @eval begin
   function usymlq(A, b :: AbstractVector{FC}, c :: AbstractVector{FC}, x0 :: AbstractVector; $(def_kwargs_usymlq...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+    start_time = time_ns()
     solver = UsymlqSolver(A, b)
     warm_start!(solver, x0)
+    timemax -= (time_ns() - start_time) / 1e9
     usymlq!(solver, A, b, c; $(kwargs_usymlq...))
     return (solver.x, solver.stats)
   end
 
   function usymlq(A, b :: AbstractVector{FC}, c :: AbstractVector{FC}; $(def_kwargs_usymlq...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+    start_time = time_ns()
     solver = UsymlqSolver(A, b)
+    timemax -= (time_ns() - start_time) / 1e9
     usymlq!(solver, A, b, c; $(kwargs_usymlq...))
     return (solver.x, solver.stats)
   end
 
   function usymlq!(solver :: UsymlqSolver{T,FC,S}, A, b :: AbstractVector{FC}, c :: AbstractVector{FC}, x0 :: AbstractVector; $(def_kwargs_usymlq...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: AbstractVector{FC}}
+    start_time = time_ns()
     warm_start!(solver, x0)
+    timemax -= (time_ns() - start_time) / 1e9
     usymlq!(solver, A, b, c; $(kwargs_usymlq...))
     return solver
   end

--- a/src/usymqr.jl
+++ b/src/usymqr.jl
@@ -102,20 +102,26 @@ kwargs_usymqr = (:atol, :rtol, :itmax, :timemax, :verbose, :history, :callback, 
 
 @eval begin
   function usymqr(A, b :: AbstractVector{FC}, c :: AbstractVector{FC}, x0 :: AbstractVector; $(def_kwargs_usymqr...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+    start_time = time_ns()
     solver = UsymqrSolver(A, b)
     warm_start!(solver, x0)
+    timemax -= (time_ns() - start_time) / 1e9
     usymqr!(solver, A, b, c; $(kwargs_usymqr...))
     return (solver.x, solver.stats)
   end
 
   function usymqr(A, b :: AbstractVector{FC}, c :: AbstractVector{FC}; $(def_kwargs_usymqr...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+    start_time = time_ns()
     solver = UsymqrSolver(A, b)
+    timemax -= (time_ns() - start_time) / 1e9
     usymqr!(solver, A, b, c; $(kwargs_usymqr...))
     return (solver.x, solver.stats)
   end
 
   function usymqr!(solver :: UsymqrSolver{T,FC,S}, A, b :: AbstractVector{FC}, c :: AbstractVector{FC}, x0 :: AbstractVector; $(def_kwargs_usymqr...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: AbstractVector{FC}}
+    start_time = time_ns()
     warm_start!(solver, x0)
+    timemax -= (time_ns() - start_time) / 1e9
     usymqr!(solver, A, b, c; $(kwargs_usymqr...))
     return solver
   end


### PR DESCRIPTION
Take into account the time to allocate the KrylovSolver and perform warm-start when the timemax option is used.