### PR TITLE
Improve type inference of extract_parameters

### DIFF
--- a/src/bicgstab.jl
+++ b/src/bicgstab.jl
@@ -106,7 +106,7 @@ def_kwargs_bicgstab = (:(; c::AbstractVector{FC} = b ),
                        :(; callback = solver -> false),
                        :(; iostream::IO = kstdout    ))
 
-def_kwargs_bicgstab = mapreduce(extract_parameters, vcat, def_kwargs_bicgstab)
+def_kwargs_bicgstab = extract_parameters.(def_kwargs_bicgstab)
 
 args_bicgstab = (:A, :b)
 optargs_bicgstab = (:x0,)

--- a/src/bilq.jl
+++ b/src/bilq.jl
@@ -99,7 +99,7 @@ def_kwargs_bilq = (:(; c::AbstractVector{FC} = b    ),
                    :(; callback = solver -> false   ),
                    :(; iostream::IO = kstdout       ))
 
-def_kwargs_bilq = mapreduce(extract_parameters, vcat, def_kwargs_bilq)
+def_kwargs_bilq = extract_parameters.(def_kwargs_bilq)
 
 args_bilq = (:A, :b)
 optargs_bilq = (:x0,)

--- a/src/bilqr.jl
+++ b/src/bilqr.jl
@@ -97,7 +97,7 @@ def_kwargs_bilqr = (:(; transfer_to_bicg::Bool = true),
                     :(; callback = solver -> false   ),
                     :(; iostream::IO = kstdout       ))
 
-def_kwargs_bilqr = mapreduce(extract_parameters, vcat, def_kwargs_bilqr)
+def_kwargs_bilqr = extract_parameters.(def_kwargs_bilqr)
 
 args_bilqr = (:A, :b, :c)
 optargs_bilqr = (:x0, :y0)

--- a/src/block_gmres.jl
+++ b/src/block_gmres.jl
@@ -84,7 +84,7 @@ def_kwargs_block_gmres = (:(; M = I                            ),
                           :(; callback = solver -> false       ),
                           :(; iostream::IO = kstdout           ))
 
-def_kwargs_block_gmres = mapreduce(extract_parameters, vcat, def_kwargs_block_gmres)
+def_kwargs_block_gmres = extract_parameters.(def_kwargs_block_gmres)
 
 args_block_gmres = (:A, :B)
 optargs_block_gmres = (:X0,)

--- a/src/car.jl
+++ b/src/car.jl
@@ -88,7 +88,7 @@ def_kwargs_car = (:(; M = I                     ),
                   :(; callback = solver -> false),
                   :(; iostream::IO = kstdout    ))
 
-def_kwargs_car = mapreduce(extract_parameters, vcat, def_kwargs_car)
+def_kwargs_car = extract_parameters.(def_kwargs_car)
 
 args_car = (:A, :b)
 optargs_car = (:x0,)

--- a/src/cg.jl
+++ b/src/cg.jl
@@ -98,7 +98,7 @@ def_kwargs_cg = (:(; M = I                     ),
                  :(; callback = solver -> false),
                  :(; iostream::IO = kstdout    ))
 
-def_kwargs_cg = mapreduce(extract_parameters, vcat, def_kwargs_cg)
+def_kwargs_cg = extract_parameters.(def_kwargs_cg)
 
 args_cg = (:A, :b)
 optargs_cg = (:x0,)

--- a/src/cg_lanczos.jl
+++ b/src/cg_lanczos.jl
@@ -94,7 +94,7 @@ def_kwargs_cg_lanczos = (:(; M = I                        ),
                          :(; callback = solver -> false   ),
                          :(; iostream::IO = kstdout       ))
 
-def_kwargs_cg_lanczos = mapreduce(extract_parameters, vcat, def_kwargs_cg_lanczos)
+def_kwargs_cg_lanczos = extract_parameters.(def_kwargs_cg_lanczos)
 
 args_cg_lanczos = (:A, :b)
 optargs_cg_lanczos = (:x0,)

--- a/src/cg_lanczos_shift.jl
+++ b/src/cg_lanczos_shift.jl
@@ -88,7 +88,7 @@ def_kwargs_cg_lanczos_shift = (:(; M = I                        ),
                                :(; callback = solver -> false   ),
                                :(; iostream::IO = kstdout       ))
 
-def_kwargs_cg_lanczos_shift = mapreduce(extract_parameters, vcat, def_kwargs_cg_lanczos_shift)
+def_kwargs_cg_lanczos_shift = extract_parameters.(def_kwargs_cg_lanczos_shift)
 
 args_cg_lanczos_shift = (:A, :b, :shifts)
 kwargs_cg_lanczos_shift = (:M, :ldiv, :check_curvature, :atol, :rtol, :itmax, :timemax, :verbose, :history, :callback, :iostream)

--- a/src/cgls.jl
+++ b/src/cgls.jl
@@ -111,7 +111,7 @@ def_kwargs_cgls = (:(; M = I                     ),
                    :(; callback = solver -> false),
                    :(; iostream::IO = kstdout    ))
 
-def_kwargs_cgls = mapreduce(extract_parameters, vcat, def_kwargs_cgls)
+def_kwargs_cgls = extract_parameters.(def_kwargs_cgls)
 
 args_cgls = (:A, :b)
 kwargs_cgls = (:M, :ldiv, :radius, :λ, :atol, :rtol, :itmax, :timemax, :verbose, :history, :callback, :iostream)

--- a/src/cgne.jl
+++ b/src/cgne.jl
@@ -116,7 +116,7 @@ def_kwargs_cgne = (:(; N = I                     ),
                    :(; callback = solver -> false),
                    :(; iostream::IO = kstdout    ))
 
-def_kwargs_cgne = mapreduce(extract_parameters, vcat, def_kwargs_cgne)
+def_kwargs_cgne = extract_parameters.(def_kwargs_cgne)
 
 args_cgne = (:A, :b)
 kwargs_cgne = (:N, :ldiv, :λ, :atol, :rtol, :itmax, :timemax, :verbose, :history, :callback, :iostream)

--- a/src/cgs.jl
+++ b/src/cgs.jl
@@ -107,7 +107,7 @@ def_kwargs_cgs = (:(; c::AbstractVector{FC} = b ),
                   :(; callback = solver -> false),
                   :(; iostream::IO = kstdout    ))
 
-def_kwargs_cgs = mapreduce(extract_parameters, vcat, def_kwargs_cgs)
+def_kwargs_cgs = extract_parameters.(def_kwargs_cgs)
 
 args_cgs = (:A, :b)
 optargs_cgs = (:x0,)

--- a/src/cr.jl
+++ b/src/cr.jl
@@ -105,7 +105,7 @@ def_kwargs_cr = (:(; M = I                     ),
                  :(; callback = solver -> false),
                  :(; iostream::IO = kstdout    ))
 
-def_kwargs_cr = mapreduce(extract_parameters, vcat, def_kwargs_cr)
+def_kwargs_cr = extract_parameters.(def_kwargs_cr)
 
 args_cr = (:A, :b)
 optargs_cr = (:x0,)

--- a/src/craig.jl
+++ b/src/craig.jl
@@ -156,7 +156,7 @@ def_kwargs_craig = (:(; M = I                         ),
                     :(; callback = solver -> false    ),
                     :(; iostream::IO = kstdout        ))
 
-def_kwargs_craig = mapreduce(extract_parameters, vcat, def_kwargs_craig)
+def_kwargs_craig = extract_parameters.(def_kwargs_craig)
 
 args_craig = (:A, :b)
 kwargs_craig = (:M, :N, :ldiv, :transfer_to_lsqr, :sqd, :λ, :btol, :conlim, :atol, :rtol, :itmax, :timemax, :verbose, :history, :callback, :iostream)

--- a/src/craigmr.jl
+++ b/src/craigmr.jl
@@ -143,7 +143,7 @@ def_kwargs_craigmr = (:(; M = I                     ),
                       :(; callback = solver -> false),
                       :(; iostream::IO = kstdout    ))
 
-def_kwargs_craigmr = mapreduce(extract_parameters, vcat, def_kwargs_craigmr)
+def_kwargs_craigmr = extract_parameters.(def_kwargs_craigmr)
 
 args_craigmr = (:A, :b)
 kwargs_craigmr = (:M, :N, :ldiv, :sqd, :λ, :atol, :rtol, :itmax, :timemax, :verbose, :history, :callback, :iostream)

--- a/src/crls.jl
+++ b/src/crls.jl
@@ -102,7 +102,7 @@ def_kwargs_crls = (:(; M = I                     ),
                    :(; callback = solver -> false),
                    :(; iostream::IO = kstdout    ))
 
-def_kwargs_crls = mapreduce(extract_parameters, vcat, def_kwargs_crls)
+def_kwargs_crls = extract_parameters.(def_kwargs_crls)
 
 args_crls = (:A, :b)
 kwargs_crls = (:M, :ldiv, :radius, :λ, :atol, :rtol, :itmax, :timemax, :verbose, :history, :callback, :iostream)

--- a/src/crmr.jl
+++ b/src/crmr.jl
@@ -114,7 +114,7 @@ def_kwargs_crmr = (:(; N = I                     ),
                    :(; callback = solver -> false),
                    :(; iostream::IO = kstdout    ))
 
-def_kwargs_crmr = mapreduce(extract_parameters, vcat, def_kwargs_crmr)
+def_kwargs_crmr = extract_parameters.(def_kwargs_crmr)
 
 args_crmr = (:A, :b)
 kwargs_crmr = (:N, :ldiv, :λ, :atol, :rtol, :itmax, :timemax, :verbose, :history, :callback, :iostream)

--- a/src/diom.jl
+++ b/src/diom.jl
@@ -102,7 +102,7 @@ def_kwargs_diom = (:(; M = I                            ),
                    :(; callback = solver -> false       ),
                    :(; iostream::IO = kstdout           ))
 
-def_kwargs_diom = mapreduce(extract_parameters, vcat, def_kwargs_diom)
+def_kwargs_diom = extract_parameters.(def_kwargs_diom)
 
 args_diom = (:A, :b)
 optargs_diom = (:x0,)

--- a/src/dqgmres.jl
+++ b/src/dqgmres.jl
@@ -102,7 +102,7 @@ def_kwargs_dqgmres = (:(; M = I                            ),
                       :(; callback = solver -> false       ),
                       :(; iostream::IO = kstdout           ))
 
-def_kwargs_dqgmres = mapreduce(extract_parameters, vcat, def_kwargs_dqgmres)
+def_kwargs_dqgmres = extract_parameters.(def_kwargs_dqgmres)
 
 args_dqgmres = (:A, :b)
 optargs_dqgmres = (:x0,)

--- a/src/fgmres.jl
+++ b/src/fgmres.jl
@@ -105,7 +105,7 @@ def_kwargs_fgmres = (:(; M = I                            ),
                      :(; callback = solver -> false       ),
                      :(; iostream::IO = kstdout           ))
 
-def_kwargs_fgmres = mapreduce(extract_parameters, vcat, def_kwargs_fgmres)
+def_kwargs_fgmres = extract_parameters.(def_kwargs_fgmres)
 
 args_fgmres = (:A, :b)
 optargs_fgmres = (:x0,)

--- a/src/fom.jl
+++ b/src/fom.jl
@@ -98,7 +98,7 @@ def_kwargs_fom = (:(; M = I                            ),
                   :(; callback = solver -> false       ),
                   :(; iostream::IO = kstdout           ))
 
-def_kwargs_fom = mapreduce(extract_parameters, vcat, def_kwargs_fom)
+def_kwargs_fom = extract_parameters.(def_kwargs_fom)
 
 args_fom = (:A, :b)
 optargs_fom = (:x0,)

--- a/src/gmres.jl
+++ b/src/gmres.jl
@@ -98,7 +98,7 @@ def_kwargs_gmres = (:(; M = I                            ),
                     :(; callback = solver -> false       ),
                     :(; iostream::IO = kstdout           ))
 
-def_kwargs_gmres = mapreduce(extract_parameters, vcat, def_kwargs_gmres)
+def_kwargs_gmres = extract_parameters.(def_kwargs_gmres)
 
 args_gmres = (:A, :b)
 optargs_gmres = (:x0,)

--- a/src/gpmr.jl
+++ b/src/gpmr.jl
@@ -141,7 +141,7 @@ def_kwargs_gpmr = (:(; C = I                            ),
                    :(; callback = solver -> false       ),
                    :(; iostream::IO = kstdout           ))
 
-def_kwargs_gpmr = mapreduce(extract_parameters, vcat, def_kwargs_gpmr)
+def_kwargs_gpmr = extract_parameters.(def_kwargs_gpmr)
 
 args_gpmr = (:A, :B, :b, :c)
 optargs_gpmr = (:x0, :y0)

--- a/src/krylov_utils.jl
+++ b/src/krylov_utils.jl
@@ -443,6 +443,6 @@ Implementation suggested by Mitchell J. O'Sullivan (@mosullivan93).
 function extract_parameters(ex::Expr)
   Meta.isexpr(ex, :tuple, 1) &&
   Meta.isexpr((@inbounds p = ex.args[1]), :parameters) &&
-  all(Base.Docs.validcall, p.args) || throw(ArgumentError("Given expression is not a kw parameter tuple [e.g. :(; x)]: $ex"))
-  return p.args
+  Base.Docs.validcall(p.args[]) || throw(ArgumentError("Given expression is not a kw parameter tuple [e.g. :(; x)]: $ex"))
+  return p.args[]
 end

--- a/src/lnlq.jl
+++ b/src/lnlq.jl
@@ -150,7 +150,7 @@ def_kwargs_lnlq = (:(; M = I                         ),
                    :(; callback = solver -> false    ),
                    :(; iostream::IO = kstdout        ))
 
-def_kwargs_lnlq = mapreduce(extract_parameters, vcat, def_kwargs_lnlq)
+def_kwargs_lnlq = extract_parameters.(def_kwargs_lnlq)
 
 args_lnlq = (:A, :b)
 kwargs_lnlq = (:M, :N, :ldiv, :transfer_to_craig, :sqd, :λ, :σ, :utolx, :utoly, :atol, :rtol, :itmax, :timemax, :verbose, :history, :callback, :iostream)

--- a/src/lslq.jl
+++ b/src/lslq.jl
@@ -176,7 +176,7 @@ def_kwargs_lslq = (:(; M = I                         ),
                    :(; callback = solver -> false    ),
                    :(; iostream::IO = kstdout        ))
 
-def_kwargs_lslq = mapreduce(extract_parameters, vcat, def_kwargs_lslq)
+def_kwargs_lslq = extract_parameters.(def_kwargs_lslq)
 
 args_lslq = (:A, :b)
 kwargs_lslq = (:M, :N, :ldiv, :transfer_to_lsqr, :sqd, :λ, :σ, :etol, :utol, :btol, :conlim, :atol, :rtol, :itmax, :timemax, :verbose, :history, :callback, :iostream)

--- a/src/lsmr.jl
+++ b/src/lsmr.jl
@@ -153,7 +153,7 @@ def_kwargs_lsmr = (:(; M = I                     ),
                    :(; callback = solver -> false),
                    :(; iostream::IO = kstdout    ))
 
-def_kwargs_lsmr = mapreduce(extract_parameters, vcat, def_kwargs_lsmr)
+def_kwargs_lsmr = extract_parameters.(def_kwargs_lsmr)
 
 args_lsmr = (:A, :b)
 kwargs_lsmr = (:M, :N, :ldiv, :sqd, :λ, :radius, :etol, :axtol, :btol, :conlim, :atol, :rtol, :itmax, :timemax, :verbose, :history, :callback, :iostream)

--- a/src/lsqr.jl
+++ b/src/lsqr.jl
@@ -149,7 +149,7 @@ def_kwargs_lsqr = (:(; M = I                     ),
                    :(; callback = solver -> false),
                    :(; iostream::IO = kstdout    ))
 
-def_kwargs_lsqr = mapreduce(extract_parameters, vcat, def_kwargs_lsqr)
+def_kwargs_lsqr = extract_parameters.(def_kwargs_lsqr)
 
 args_lsqr = (:A, :b)
 kwargs_lsqr = (:M, :N, :ldiv, :sqd, :λ, :radius, :etol, :axtol, :btol, :conlim, :atol, :rtol, :itmax, :timemax, :verbose, :history, :callback, :iostream)

--- a/src/minares.jl
+++ b/src/minares.jl
@@ -93,7 +93,7 @@ def_kwargs_minares = (:(; M = I                     ),
                       :(; callback = solver -> false),
                       :(; iostream::IO = kstdout    ))
 
-def_kwargs_minares = mapreduce(extract_parameters, vcat, def_kwargs_minares)
+def_kwargs_minares = extract_parameters.(def_kwargs_minares)
 
 args_minares = (:A, :b)
 optargs_minares = (:x0,)

--- a/src/minres.jl
+++ b/src/minres.jl
@@ -120,7 +120,7 @@ def_kwargs_minres = (:(; M = I                     ),
                      :(; callback = solver -> false),
                      :(; iostream::IO = kstdout    ))
 
-def_kwargs_minres = mapreduce(extract_parameters, vcat, def_kwargs_minres)
+def_kwargs_minres = extract_parameters.(def_kwargs_minres)
 
 args_minres = (:A, :b)
 optargs_minres = (:x0,)

--- a/src/minres_qlp.jl
+++ b/src/minres_qlp.jl
@@ -102,7 +102,7 @@ def_kwargs_minres_qlp = (:(; M = I                     ),
                          :(; callback = solver -> false),
                          :(; iostream::IO = kstdout    ))
 
-def_kwargs_minres_qlp = mapreduce(extract_parameters, vcat, def_kwargs_minres_qlp)
+def_kwargs_minres_qlp = extract_parameters.(def_kwargs_minres_qlp)
 
 args_minres_qlp = (:A, :b)
 optargs_minres_qlp = (:x0,)

--- a/src/qmr.jl
+++ b/src/qmr.jl
@@ -105,7 +105,7 @@ def_kwargs_qmr = (:(; c::AbstractVector{FC} = b ),
                   :(; callback = solver -> false),
                   :(; iostream::IO = kstdout    ))
 
-def_kwargs_qmr = mapreduce(extract_parameters, vcat, def_kwargs_qmr)
+def_kwargs_qmr = extract_parameters.(def_kwargs_qmr)
 
 args_qmr = (:A, :b)
 optargs_qmr = (:x0,)

--- a/src/symmlq.jl
+++ b/src/symmlq.jl
@@ -106,7 +106,7 @@ def_kwargs_symmlq = (:(; M = I                      ),
                      :(; callback = solver -> false ),
                      :(; iostream::IO = kstdout     ))
 
-def_kwargs_symmlq = mapreduce(extract_parameters, vcat, def_kwargs_symmlq)
+def_kwargs_symmlq = extract_parameters.(def_kwargs_symmlq)
 
 args_symmlq = (:A, :b)
 optargs_symmlq = (:x0,)

--- a/src/tricg.jl
+++ b/src/tricg.jl
@@ -127,7 +127,7 @@ def_kwargs_tricg = (:(; M = I                     ),
                     :(; callback = solver -> false),
                     :(; iostream::IO = kstdout    ))
 
-def_kwargs_tricg = mapreduce(extract_parameters, vcat, def_kwargs_tricg)
+def_kwargs_tricg = extract_parameters.(def_kwargs_tricg)
 
 args_tricg = (:A, :b, :c)
 optargs_tricg = (:x0, :y0)

--- a/src/trilqr.jl
+++ b/src/trilqr.jl
@@ -96,7 +96,7 @@ def_kwargs_trilqr = (:(; transfer_to_usymcg::Bool = true),
                      :(; callback = solver -> false     ),
                      :(; iostream::IO = kstdout         ))
 
-def_kwargs_trilqr = mapreduce(extract_parameters, vcat, def_kwargs_trilqr)
+def_kwargs_trilqr = extract_parameters.(def_kwargs_trilqr)
 
 args_trilqr = (:A, :b, :c)
 optargs_trilqr = (:x0, :y0)

--- a/src/trimr.jl
+++ b/src/trimr.jl
@@ -128,7 +128,7 @@ def_kwargs_trimr = (:(; M = I                     ),
                     :(; callback = solver -> false),
                     :(; iostream::IO = kstdout    ))
 
-def_kwargs_trimr = mapreduce(extract_parameters, vcat, def_kwargs_trimr)
+def_kwargs_trimr = extract_parameters.(def_kwargs_trimr)
 
 args_trimr = (:A, :b, :c)
 optargs_trimr = (:x0, :y0)

--- a/src/usymlq.jl
+++ b/src/usymlq.jl
@@ -105,7 +105,7 @@ def_kwargs_usymlq = (:(; transfer_to_usymcg::Bool = true),
                      :(; callback = solver -> false     ),
                      :(; iostream::IO = kstdout         ))
 
-def_kwargs_usymlq = mapreduce(extract_parameters, vcat, def_kwargs_usymlq)
+def_kwargs_usymlq = extract_parameters.(def_kwargs_usymlq)
 
 args_usymlq = (:A, :b, :c)
 optargs_usymlq = (:x0,)

--- a/src/usymqr.jl
+++ b/src/usymqr.jl
@@ -108,7 +108,7 @@ def_kwargs_usymqr = (:(; atol::T = √eps(T)         ),
                      :(; callback = solver -> false),
                      :(; iostream::IO = kstdout    ))
 
-def_kwargs_usymqr = mapreduce(extract_parameters, vcat, def_kwargs_usymqr)
+def_kwargs_usymqr = extract_parameters.(def_kwargs_usymqr)
 
 args_usymqr = (:A, :b, :c)
 optargs_usymqr = (:x0,)


### PR DESCRIPTION
@mosullivan93
Could you please confirm if, for a vector of `Expr` like the following:

```julia
def_kwargs_cg = (:(; M = I                     ),
                 :(; ldiv::Bool = false        ),
                 :(; radius::T = zero(T)       ),
                 :(; linesearch::Bool = false  ),
                 :(; atol::T = √eps(T)         ),
                 :(; rtol::T = √eps(T)         ),
                 :(; itmax::Int = 0            ),
                 :(; timemax::Float64 = Inf    ),
                 :(; verbose::Int = 0          ),
                 :(; history::Bool = false     ),
                 :(; callback = solver -> false),
                 :(; iostream::IO = kstdout    ))
```

Is it always the case that for each expression `ex`, the length of `ex.args[1].args` is equal to 1?
I want to improve the type inference of the function `extract_parameters` that you suggested a long time ago.