### PR TITLE
Use rmul! instead of broadcast for kscal!

### DIFF
--- a/src/krylov_utils.jl
+++ b/src/krylov_utils.jl
@@ -318,7 +318,7 @@ knorm(n :: Integer, x :: AbstractVector{T}) where T <: FloatOrComplex = norm(x)
 knorm_elliptic(n :: Integer, x :: AbstractVector{T}, y :: AbstractVector{T}) where T <: FloatOrComplex = (x === y) ? knorm(n, x) : sqrt(kdotr(n, x, y))
 
 kscal!(n :: Integer, s :: T, x :: Vector{T}) where T <: BLAS.BlasFloat = BLAS.scal!(n, s, x, 1)
-kscal!(n :: Integer, s :: T, x :: AbstractVector{T}) where T <: FloatOrComplex = (x .*= s)
+kscal!(n :: Integer, s :: T, x :: AbstractVector{T}) where T <: FloatOrComplex = rmul!(x, s)
 kscal!(n :: Integer, s :: T, x :: AbstractVector{Complex{T}}) where T <: AbstractFloat = kscal!(n, Complex{T}(s), x)
 
 kaxpy!(n :: Integer, s :: T, x :: Vector{T}, y :: Vector{T}) where T <: BLAS.BlasFloat = BLAS.axpy!(n, s, x, 1, y, 1)


### PR DESCRIPTION
`rmul!` will dispatch to BLAS routines on GPUs:
- https://github.com/JuliaGPU/CUDA.jl/blob/master/lib/cublas/linalg.jl#L9
- https://github.com/JuliaGPU/AMDGPU.jl/blob/master/src/blas/highlevel.jl#L7
- https://github.com/JuliaGPU/oneAPI.jl/blob/master/lib/mkl/linalg.jl#L14

It will be also faster for CPU types, the code is
```julia
function rmul!(X::AbstractArray, s::Number)
    @simd for I in eachindex(X)
        @inbounds X[I] *= s
    end
    X
end
```
in the source code of Julia (`julia/stdlib/v1.11/LinearAlgebra/src/generic.jl`).