### PR TITLE
Upgrade TriCG, TriMR and GPMR

### DIFF
--- a/src/gpmr.jl
+++ b/src/gpmr.jl
@@ -36,7 +36,7 @@ GPMR solves the non-Hermitian partitioned linear system
 
 of size (n+m) × (n+m) where λ and μ are real or complex numbers.
 `A` can have any shape and `B` has the shape of `Aᴴ`.
-`A`, `B`, `b` and `c` must be all nonzero.
+`A` and `B` must both be nonzero.
 
 This implementation allows left and right block diagonal preconditioners
 
@@ -239,13 +239,21 @@ kwargs_gpmr = (:C, :D, :E, :F, :ldiv, :gsp, :λ, :μ, :reorthogonalization, :ato
     # Initialize the orthogonal Hessenberg reduction process.
     # βv₁ = Cb
     β = knorm(m, b₀)
-    β ≠ 0 || error("b must be nonzero")
-    V[1] .= b₀ ./ β
+    if β ≠ 0
+      V[1] .= b₀ ./ β
+    else
+      # β = ‖b₀‖₂ = 0
+      kfill!(V[1], zero(FC))  # v₁ = 0 such that v₁ ⊥ Span{v₁, ..., vₖ}
+    end
 
     # γu₁ = Dc
     γ = knorm(n, c₀)
-    γ ≠ 0 || error("c must be nonzero")
-    U[1] .= c₀ ./ γ
+    if γ ≠ 0
+      U[1] .= c₀ ./ γ
+    else
+      # γ = ‖c₀‖₂ = 0
+      kfill!(U[1], zero(FC))  # u₁ = 0 such that u₁ ⊥ Span{u₁, ..., uₖ}
+    end
 
     # Compute ‖r₀‖² = γ² + β²
     rNorm = sqrt(γ^2 + β^2)

--- a/test/test_gpmr.jl
+++ b/test/test_gpmr.jl
@@ -6,17 +6,17 @@
 
       # Test specific brekdowns
       A, b, c = ssy_mo_breakdown2(FC)
-      K = [I A; A' -I]
+      K = [I A; A' I]
       d = [b; c]
-      x, y, stats = gpmr(A, b, c)
+      x, y, stats = gpmr(A, A', b, c)
       r = d - K * [x; y]
       resid = norm(r) / norm(d)
       @test(resid ≤ gpmr_tol)
 
       A, b, c = ssy_mo_breakdown3(FC)
-      K = [I A; A' -I]
+      K = [I A; A' I]
       d = [b; c]
-      x, y, stats = gpmr(A, b, c)
+      x, y, stats = gpmr(A, A', b, c)
       r = d - K * [x; y]
       resid = norm(r) / norm(d)
       @test(resid ≤ gpmr_tol)

--- a/test/test_tricg.jl
+++ b/test/test_tricg.jl
@@ -122,11 +122,37 @@
       resid = norm(r) / norm(B)
       @test(resid ≤ tricg_tol)
 
-      # Test b=0 or c=0
-      c .= 0
-      @test_throws ErrorException("c must be nonzero") tricg(A, b, c)
-      b .= 0
-      @test_throws ErrorException("b must be nonzero") tricg(A, b, c)
+      # Test b == 0 or c == 0
+      b_zero = zeros(m)
+      x, y, stats = tricg(A, b_zero, c)
+      rhs = [b_zero; c]
+      r =  rhs - [I A; A' -I] * [x; y]
+      resid = norm(r) / norm(rhs)
+      @test(resid ≤ tricg_tol)
+
+      c_zero = zeros(n)
+      x, y, stats = tricg(A, b, c_zero)
+      rhs = [b; c_zero]
+      r =  rhs - [I A; A' -I] * [x; y]
+      resid = norm(r) / norm(rhs)
+      @test(resid ≤ tricg_tol)
+
+      # Test specific brekdowns
+      A, b, c = ssy_mo_breakdown2(FC)
+      K = [I A; A' -I]
+      d = [b; c]
+      x, y, stats = tricg(A, b, c)
+      r = d - K * [x; y]
+      resid = norm(r) / norm(d)
+      @test(resid ≤ tricg_tol)
+
+      A, b, c = ssy_mo_breakdown3(FC)
+      K = [I A; A' -I]
+      d = [b; c]
+      x, y, stats = tricg(A, b, c)
+      r = d - K * [x; y]
+      resid = norm(r) / norm(d)
+      @test(resid ≤ tricg_tol)
 
       # Test dimension of additional vectors
       for transpose ∈ (false, true)

--- a/test/test_trimr.jl
+++ b/test/test_trimr.jl
@@ -162,11 +162,37 @@
       resid = norm(r) / norm(B)
       @test(resid ≤ trimr_tol)
 
-      # Test b=0 or c=0
-      c .= 0
-      @test_throws ErrorException("c must be nonzero") trimr(A, b, c)
-      b .= 0
-      @test_throws ErrorException("b must be nonzero") trimr(A, b, c)
+      # Test b == 0 or c == 0
+      b_zero = zeros(m)
+      x, y, stats = trimr(A, b_zero, c)
+      rhs = [b_zero; c]
+      r =  rhs - [I A; A' -I] * [x; y]
+      resid = norm(r) / norm(rhs)
+      @test(resid ≤ trimr_tol)
+
+      c_zero = zeros(n)
+      x, y, stats = trimr(A, b, c_zero)
+      rhs = [b; c_zero]
+      r =  rhs - [I A; A' -I] * [x; y]
+      resid = norm(r) / norm(rhs)
+      @test(resid ≤ trimr_tol)
+
+      # Test specific brekdowns
+      A, b, c = ssy_mo_breakdown2(FC)
+      K = [I A; A' -I]
+      d = [b; c]
+      x, y, stats = trimr(A, b, c)
+      r = d - K * [x; y]
+      resid = norm(r) / norm(d)
+      @test(resid ≤ trimr_tol)
+
+      A, b, c = ssy_mo_breakdown3(FC)
+      K = [I A; A' -I]
+      d = [b; c]
+      x, y, stats = trimr(A, b, c)
+      r = d - K * [x; y]
+      resid = norm(r) / norm(d)
+      @test(resid ≤ trimr_tol)
 
       # Test dimension of additional vectors
       for transpose ∈ (false, true)

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -345,13 +345,27 @@ end
 # Generate a breakdown in the orthogonal tridiagonalization process and the orthogonal Hessenberg reduction process.
 function ssy_mo_breakdown(transpose :: Bool=false; FC=Float64)
   if transpose
-    A = [1.0 -1.0; 0.0 1.0; -1.0 0.0]
+    A = FC[1 -1; 0 1; -1 0]
   else
-    A = [1.0 0.0 -1.0; -1.0 1.0 0.0]
+    A = FC[1 0 -1; -1 1 0]
   end
   n, m = size(A)
-  b = ones(n)
-  c = ones(m)
+  b = ones(FC, n)
+  c = ones(FC, m)
+  return A, b, c
+end
+
+function ssy_mo_breakdown2(FC=Float64)
+  A = FC[-1 2 0; 1 -1 1; 0 0 -1]
+  b = FC[1; 0; 0]
+  c = FC[1; 0; 0]
+  return A, b, c
+end
+
+function ssy_mo_breakdown3(FC=Float64)
+  A = FC[-1 1 0; 3 -1 0; 0 1 -1]
+  b = FC[1; 0; 0]
+  c = FC[1; 0; 0]
   return A, b, c
 end
 


### PR DESCRIPTION
@dpo 
The PR could interest you, `b` or `c` can be zero now in `TriCG`, `TriMR` and `GPMR`.
We didn't know that we wrote the papers on these methods.
`USYMLQR` is probably also concerned.

I also started to proofread iTriCG and iTriMR, and it seems that we can be smarter in how we handle the breakdown in SSY and MO processes.  
From what they explain in the paper, SSY can be simplified into Golub-Kahan if `b = 0` or `c = 0`.
I need to check if it’s correct or not; I have some doubts.