### PR TITLE
CR: Update iterate on first iteration for negative curvature with line search and when zero curvature is detected

### DIFF
--- a/src/cr.jl
+++ b/src/cr.jl
@@ -150,9 +150,7 @@ kwargs_cr = (:M, :ldiv, :radius, :linesearch, :γ, :atol, :rtol, :itmax, :timema
     end
     MisI && kcopy!(n, r, p)  # r ← p
     MisI || mulorldiv!(r, M, p, ldiv)
-    mul!(Ar, A, r)
-    ρ = kdotr(n, r, Ar)
-
+    
     rNorm = knorm_elliptic(n, r, p)  # ‖r‖
     history && push!(rNorms, rNorm)  # Values of ‖r‖
 
@@ -160,17 +158,20 @@ kwargs_cr = (:M, :ldiv, :radius, :linesearch, :γ, :atol, :rtol, :itmax, :timema
       stats.niter = 0
       stats.solved, stats.inconsistent = true, false
       stats.timer = start_time |> ktimer
-      stats.status = "x = 0 is a zero-residual solution"
+      stats.status = "x is a zero-residual solution"
       history && push!(ArNorms, zero(T))
       solver.warm_start = false
       return solver
     end
+
+    mul!(Ar, A, r)
+    ρ = kdotr(n, r, Ar)
     
     if ρ == 0
       stats.niter = 0
       stats.solved, stats.inconsistent = true, false
       stats.timer = start_time |> ktimer
-      stats.status = "0 is a zero-curvature direction"
+      stats.status = "b is a zero-curvature direction"
       history && push!(ArNorms, zero(T))
       solver.warm_start = false
       linesearch && kcopy!(n, x, b)  # x ← b

--- a/src/cr.jl
+++ b/src/cr.jl
@@ -201,8 +201,7 @@ kwargs_cr = (:M, :ldiv, :radius, :linesearch, :γ, :atol, :rtol, :itmax, :timema
         if (pAp ≤ γ * pNorm²) || (ρ ≤ γ * rNorm²)
           npcurv = true
           (verbose > 0) && @printf(iostream, "nonpositive curvature detected: pᴴAp = %8.1e and rᴴAr = %8.1e\n", pAp, ρ)
-          solved = true
-          stats.solved = solved
+          stats.solved = true
           stats.inconsistent = false
           stats.timer = start_time |> ktimer
           stats.status = "nonpositive curvature"

--- a/src/cr.jl
+++ b/src/cr.jl
@@ -163,6 +163,7 @@ kwargs_cr = (:M, :ldiv, :radius, :linesearch, :γ, :atol, :rtol, :itmax, :timema
       stats.status = "x = 0 is a zero-residual solution"
       history && push!(ArNorms, zero(T))
       solver.warm_start = false
+      linesearch && kcopy!(n, x, b)  # x ← b
       return solver
     end
     kcopy!(n, p, r)   # p ← r
@@ -200,10 +201,12 @@ kwargs_cr = (:M, :ldiv, :radius, :linesearch, :γ, :atol, :rtol, :itmax, :timema
         if (pAp ≤ γ * pNorm²) || (ρ ≤ γ * rNorm²)
           npcurv = true
           (verbose > 0) && @printf(iostream, "nonpositive curvature detected: pᴴAp = %8.1e and rᴴAr = %8.1e\n", pAp, ρ)
+          solved = true
           stats.solved = solved
           stats.inconsistent = false
           stats.timer = start_time |> ktimer
           stats.status = "nonpositive curvature"
+          iter == 0 && kcopy!(n, x, b)  # x ← b
           return solver
         end
       elseif pAp ≤ 0 && radius == 0

--- a/src/cr.jl
+++ b/src/cr.jl
@@ -156,16 +156,27 @@ kwargs_cr = (:M, :ldiv, :radius, :linesearch, :γ, :atol, :rtol, :itmax, :timema
     rNorm = knorm_elliptic(n, r, p)  # ‖r‖
     history && push!(rNorms, rNorm)  # Values of ‖r‖
 
+    if rNorm == 0
+      stats.niter = 0
+      stats.solved, stats.inconsistent = true, false
+      stats.timer = start_time |> ktimer
+      stats.status = "x = 0 is a zero-residual solution"
+      history && push!(ArNorms, zero(T))
+      solver.warm_start = false
+      return solver
+    end
+    
     if ρ == 0
       stats.niter = 0
       stats.solved, stats.inconsistent = true, false
       stats.timer = start_time |> ktimer
-      stats.status = "x is a zero-residual solution"
+      stats.status = "0 is a zero-curvature direction"
       history && push!(ArNorms, zero(T))
       solver.warm_start = false
       linesearch && kcopy!(n, x, b)  # x ← b
       return solver
     end
+
     kcopy!(n, p, r)   # p ← r
     kcopy!(n, q, Ar)  # q ← Ar
     (verbose > 0) && (m = zero(T))  # quadratic model

--- a/src/cr.jl
+++ b/src/cr.jl
@@ -160,7 +160,7 @@ kwargs_cr = (:M, :ldiv, :radius, :linesearch, :γ, :atol, :rtol, :itmax, :timema
       stats.niter = 0
       stats.solved, stats.inconsistent = true, false
       stats.timer = start_time |> ktimer
-      stats.status = "x = 0 is a zero-residual solution"
+      stats.status = "x is a zero-residual solution"
       history && push!(ArNorms, zero(T))
       solver.warm_start = false
       linesearch && kcopy!(n, x, b)  # x ← b
@@ -202,6 +202,7 @@ kwargs_cr = (:M, :ldiv, :radius, :linesearch, :γ, :atol, :rtol, :itmax, :timema
           npcurv = true
           (verbose > 0) && @printf(iostream, "nonpositive curvature detected: pᴴAp = %8.1e and rᴴAr = %8.1e\n", pAp, ρ)
           stats.solved = true
+          stats.niter = iter
           stats.inconsistent = false
           stats.timer = start_time |> ktimer
           stats.status = "nonpositive curvature"

--- a/test/test_cr.jl
+++ b/test/test_cr.jl
@@ -54,7 +54,6 @@
       @test norm(x) == 0
       @test stats.status == "x = 0 is a zero-residual solution"
 
-
       # Test with Jacobi (or diagonal) preconditioner
       A, b, M = square_preconditioned(FC=FC)
       (x, stats) = cr(A, b, M=M, atol=1e-5, rtol=0.0)

--- a/test/test_cr.jl
+++ b/test/test_cr.jl
@@ -52,7 +52,7 @@
       A, b = zero_rhs(FC=FC)
       (x, stats) = cr(A, b)
       @test norm(x) == 0
-      @test stats.status == "x = 0 is a zero-residual solution"
+      @test stats.status == "x is a zero-residual solution"
 
       # Test with Jacobi (or diagonal) preconditioner
       A, b, M = square_preconditioned(FC=FC)
@@ -62,6 +62,31 @@
       @test(resid ≤ 10 * cr_tol)
       @test(stats.solved)
 
+      # Test linesearch
+      A, b = symmetric_indefinite(FC=FC)
+      x, stats = cr(A, b, linesearch=true)
+      @test stats.status == "nonpositive curvature"
+
+      # Test Linesearch which would stop on the first call since A is negative definite
+      A, b = symmetric_indefinite_negative_curv(FC=FC)
+      x, stats = cr(A, b, linesearch=true)
+      @test stats.status == "nonpositive curvature"
+      @test stats.niter == 0
+      @test norm(x) == norm(b)
+
+
+      # Test Linesearch is true and when b^TAb=0
+      A, b = system_zero_quad(FC=FC)
+      x, stats = cr(A, b, linesearch=true)
+      @test stats.status == "x is a zero-residual solution"
+      @test norm(x) == norm(b)
+
+      # Test when b^TAb=0 and linesearch is false
+      A, b = system_zero_quad(FC=FC)
+      x, stats = cr(A,b, linesearch=false)
+      @test stats.status == "x is a zero-residual solution"
+      @test norm(x) == zero(FC)
+ 
       # test callback function
       A, b = symmetric_definite(FC=FC)
       solver = CrSolver(A, b)

--- a/test/test_cr.jl
+++ b/test/test_cr.jl
@@ -52,7 +52,8 @@
       A, b = zero_rhs(FC=FC)
       (x, stats) = cr(A, b)
       @test norm(x) == 0
-      @test stats.status == "x is a zero-residual solution"
+      @test stats.status == "x = 0 is a zero-residual solution"
+
 
       # Test with Jacobi (or diagonal) preconditioner
       A, b, M = square_preconditioned(FC=FC)
@@ -72,20 +73,23 @@
       x, stats = cr(A, b, linesearch=true)
       @test stats.status == "nonpositive curvature"
       @test stats.niter == 0
-      @test norm(x) == norm(b)
+      @test all(x .== b)
+      @test stats.solved == true
 
-
-      # Test Linesearch is true and when b^TAb=0
+      # Test when b^TAb=0 and linesearch is true
       A, b = system_zero_quad(FC=FC)
       x, stats = cr(A, b, linesearch=true)
-      @test stats.status == "x is a zero-residual solution"
-      @test norm(x) == norm(b)
+      @test stats.status == "0 is a zero-curvature direction"
+      @test all(x .== b)
+      @test stats.solved == true
 
       # Test when b^TAb=0 and linesearch is false
       A, b = system_zero_quad(FC=FC)
       x, stats = cr(A,b, linesearch=false)
-      @test stats.status == "x is a zero-residual solution"
+      @test stats.status == "0 is a zero-curvature direction"
       @test norm(x) == zero(FC)
+      @test stats.solved == true
+
  
       # test callback function
       A, b = symmetric_definite(FC=FC)

--- a/test/test_cr.jl
+++ b/test/test_cr.jl
@@ -68,7 +68,7 @@
       @test stats.status == "nonpositive curvature"
 
       # Test Linesearch which would stop on the first call since A is negative definite
-      A, b = symmetric_indefinite_negative_curv(FC=FC)
+      A, b = indefinite_system(FC=FC)
       x, stats = cr(A, b, linesearch=true)
       @test stats.status == "nonpositive curvature"
       @test stats.niter == 0

--- a/test/test_cr.jl
+++ b/test/test_cr.jl
@@ -52,7 +52,7 @@
       A, b = zero_rhs(FC=FC)
       (x, stats) = cr(A, b)
       @test norm(x) == 0
-      @test stats.status == "x = 0 is a zero-residual solution"
+      @test stats.status == "x is a zero-residual solution"
 
       # Test with Jacobi (or diagonal) preconditioner
       A, b, M = square_preconditioned(FC=FC)
@@ -68,7 +68,7 @@
       @test stats.status == "nonpositive curvature"
 
       # Test Linesearch which would stop on the first call since A is negative definite
-      A, b = indefinite_system(FC=FC)
+      A, b = symmetric_indefinite(FC=FC; shift = 5)
       x, stats = cr(A, b, linesearch=true)
       @test stats.status == "nonpositive curvature"
       @test stats.niter == 0
@@ -78,14 +78,14 @@
       # Test when b^TAb=0 and linesearch is true
       A, b = system_zero_quad(FC=FC)
       x, stats = cr(A, b, linesearch=true)
-      @test stats.status == "0 is a zero-curvature direction"
+      @test stats.status == "b is a zero-curvature direction"
       @test all(x .== b)
       @test stats.solved == true
 
       # Test when b^TAb=0 and linesearch is false
       A, b = system_zero_quad(FC=FC)
       x, stats = cr(A,b, linesearch=false)
-      @test stats.status == "0 is a zero-curvature direction"
+      @test stats.status == "b is a zero-curvature direction"
       @test norm(x) == zero(FC)
       @test stats.solved == true
 

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -21,6 +21,59 @@ function symmetric_indefinite(n :: Int=10; FC=Float64)
   return A, b
 end
 
+
+# Symmetric and indefinite system with negative curvature.
+function symmetric_indefinite_negative_curv(n::Int=10; FC=Float64, shift=5)
+  α = FC <: Complex ? FC(im) : one(FC)
+  # Build the tridiagonal matrix with 1's on the diagonal and α on the off-diagonals, and force negative curvature.
+  A = spdiagm(
+          -1 => α * ones(FC, n-1),
+           0 => ones(FC, n),
+           1 => conj(α) * ones(FC, n-1)
+      ) - shift * eye(n)
+  
+  b = A * FC[1:n;]  
+  return A, b
+end
+
+"""
+    system_zero_quad(n::Int=2; FC=Float64)
+
+Creates an n×n symmetric matrix `A` and vector `b` (with n ≥ 2) such that:
+- `A ≠ 0` and `b ≠ 0`
+- `b^T * A * b == 0`
+
+The construction embeds a 2×2 block in the upper-left corner where
+
+    A[1,1] = 1   and   A[2,2] = -1,
+
+and defines
+
+    b[1] = 1   and   b[2] = 1,
+
+with all other entries equal to zero.
+
+Example usage:
+    A, b = system_zero_quad(5, FC=Float64)
+    println("A =")
+    println(Matrix(A))
+    println("b = ", b)
+    println("b^T * A * b = ", b' * A * b)
+"""
+function system_zero_quad(n::Int=2; FC=Float64)
+    if n < 2
+        error("n must be at least 2")
+    end
+    A = zeros(FC, n, n)
+    # Define a 2×2 nontrivial block that is symmetric and indefinite.
+    A[1, 1] = one(FC)
+    A[2, 2] = -one(FC)
+    b = zeros(FC, n)
+    b[1] = one(FC)
+    b[2] = one(FC)
+    return A, b
+end
+
 # Nonsymmetric and positive definite systems.
 function nonsymmetric_definite(n :: Int=10; FC=Float64)
   if FC <: Complex

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -23,7 +23,8 @@ end
 
 
 # Symmetric and indefinite system with negative curvature.
-function symmetric_indefinite_negative_curv(n::Int=10; FC=Float64, shift=5)
+# need this to test CR with Linesearch and nonpositive curvature at the first iteration
+function indefinite_system(n::Int=10; FC=Float64, shift=5)
   α = FC <: Complex ? FC(im) : one(FC)
   # Build the tridiagonal matrix with 1's on the diagonal and α on the off-diagonals, and force negative curvature.
   A = spdiagm(

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -14,26 +14,10 @@ function symmetric_definite(n :: Int=10; FC=Float64)
 end
 
 # Symmetric and indefinite systems.
-function symmetric_indefinite(n :: Int=10; FC=Float64)
+function symmetric_indefinite(n :: Int=10; FC=Float64,  shift=0)
   α = FC <: Complex ? FC(im) : one(FC)
-  A = spdiagm(-1 => α * ones(FC, n-1), 0 => ones(FC, n), 1 => conj(α) * ones(FC, n-1))
+  A = spdiagm(-1 => α * ones(FC, n-1), 0 => ones(FC, n), 1 => conj(α) * ones(FC, n-1))- shift * eye(n)
   b = A * FC[1:n;]
-  return A, b
-end
-
-
-# Symmetric and indefinite system with negative curvature.
-# need this to test CR with Linesearch and nonpositive curvature at the first iteration
-function indefinite_system(n::Int=10; FC=Float64, shift=5)
-  α = FC <: Complex ? FC(im) : one(FC)
-  # Build the tridiagonal matrix with 1's on the diagonal and α on the off-diagonals, and force negative curvature.
-  A = spdiagm(
-          -1 => α * ones(FC, n-1),
-           0 => ones(FC, n),
-           1 => conj(α) * ones(FC, n-1)
-      ) - shift * eye(n)
-  
-  b = A * FC[1:n;]  
   return A, b
 end
 


### PR DESCRIPTION


This PR fixes an issue in the Conjugate Residual (CR) implementation (in `src/cr.jl`) where, on the first iteration (`iter == 0`), if the computed curvature is non-positive (i.e. either zero or negative), the algorithm may return without updating the iterate—even though we have  
$$b = -\nabla f(x_k) \neq 0.$$

To address this, when line search is enabled and a non-positive curvature (zero or negative) is detected at iteration 0, we now explicitly update the iterate by performing

```julia
x .= b
```

This change guarantees that the method behaves consistently by setting `x` appropriately when curvature information is either zero or negative during the first iteration.

---

**Changes Made:**

1. **First Iteration Check (iter == 0):**  
   - When either zero or negative curvature is detected (i.e. `s <= 0`), and `linesearch` is enabled, update `x` to `b` before returning.

2. **Zero Curvature Check (general case):**  
   - (Existing handling) When a zero curvature is detected later in the method (e.g. at a different check), we continue to update `x` to `b` if `linesearch` is enabled.
