### PR TITLE
Implement Line Search with Negative Curvature Detection for MINRES Based on Liu et al. (2022)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Krylov"
 uuid = "ba0b0d4f-ebba-5204-a429-3ac8c609bfb7"
-version = "0.9.9"
+version = "0.9.10"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/block_krylov_solvers.jl
+++ b/src/block_krylov_solvers.jl
@@ -60,7 +60,7 @@ function BlockMinresSolver(m, n, p, SV, SM)
   Hₖ₋₁ = SM(undef, 2p, p)
   τₖ₋₂ = SV(undef, p)
   τₖ₋₁ = SV(undef, p)
-  stats = SimpleStats(0, false, false, T[], T[], T[], 0.0, "unknown")
+  stats = SimpleStats(0, false, false, false, T[], T[], T[], 0.0, "unknown")
   solver = BlockMinresSolver{T,FC,SV,SM}(m, n, p, ΔX, X, P, Q, C, D, Φ, Vₖ₋₁, Vₖ, wₖ₋₂, wₖ₋₁, Hₖ₋₂, Hₖ₋₁, τₖ₋₂, τₖ₋₁, false, stats)
   return solver
 end
@@ -121,7 +121,7 @@ function BlockGmresSolver(m, n, p, memory, SV, SM)
   R  = SM[SM(undef, p, p) for i = 1 : div(memory * (memory+1), 2)]
   H  = SM[SM(undef, 2p, p) for i = 1 : memory]
   τ  = SV[SV(undef, p) for i = 1 : memory]
-  stats = SimpleStats(0, false, false, T[], T[], T[], 0.0, "unknown")
+  stats = SimpleStats(0, false, false, false, T[], T[], T[], 0.0, "unknown")
   solver = BlockGmresSolver{T,FC,SV,SM}(m, n, p, ΔX, X, W, P, Q, C, D, V, Z, R, H, τ, false, stats)
   return solver
 end

--- a/src/krylov_solvers.jl
+++ b/src/krylov_solvers.jl
@@ -112,14 +112,14 @@ mutable struct MinresSolver{T,FC,S} <: KrylovSolver{T,FC,S}
   x          :: S
   r1         :: S
   r2         :: S
-  rk         :: S
+  npc_dir    :: S
   w1         :: S
   w2         :: S
   y          :: S
   v          :: S
   err_vec    :: Vector{T}
   warm_start :: Bool
-  stats      :: conStats{T}
+  stats      :: SimpleStats{T}
 end
 
 function MinresSolver(kc::KrylovConstructor; window :: Int=5)
@@ -132,14 +132,14 @@ function MinresSolver(kc::KrylovConstructor; window :: Int=5)
   x  = similar(kc.vn)
   r1 = similar(kc.vn)
   r2 = similar(kc.vn)
-  rk = similar(kc.vn_empty)
+  npc_dir = similar(kc.vn_empty)
   w1 = similar(kc.vn)
   w2 = similar(kc.vn)
   y  = similar(kc.vn)
   v  = similar(kc.vn_empty)
   err_vec = zeros(T, window)
-  stats = conStats(0, false, false, false, false, T[], T[], T[], 0.0, "unknown")
-  solver = MinresSolver{T,FC,S}(m, n, Δx, x, r1, r2, rk, w1, w2, y, v, err_vec, false, stats)
+  stats = SimpleStats(0, false, false, false, T[], T[], T[], 0.0, "unknown")
+  solver = MinresSolver{T,FC,S}(m, n, Δx, x, r1, r2, npc_dir, w1, w2, y, v, err_vec, false, stats)
   return solver
 end
 
@@ -150,14 +150,14 @@ function MinresSolver(m, n, S; window :: Int=5)
   x  = S(undef, n)
   r1 = S(undef, n)
   r2 = S(undef, n)
-  rk = S(undef, 0)
+  npc_dir = S(undef, 0)
   w1 = S(undef, n)
   w2 = S(undef, n)
   y  = S(undef, n)
   v  = S(undef, 0)
   err_vec = zeros(T, window)
-  stats = conStats(0, false, false, false, false, T[], T[], T[], 0.0, "unknown")
-  solver = MinresSolver{T,FC,S}(m, n, Δx, x, r1, r2, rk, w1, w2, y, v, err_vec, false, stats)
+  stats = SimpleStats(0, false, false, false, T[], T[], T[], 0.0, "unknown")
+  solver = MinresSolver{T,FC,S}(m, n, Δx, x, r1, r2, npc_dir, w1, w2, y, v, err_vec, false, stats)
   return solver
 end
 
@@ -209,7 +209,7 @@ function MinaresSolver(kc::KrylovConstructor)
   dₖ₋₂ = similar(kc.vn)
   dₖ₋₁ = similar(kc.vn)
   q    = similar(kc.vn)
-  stats = SimpleStats(0, false, false, T[], T[], T[], 0.0, "unknown")
+  stats = SimpleStats(0, false, false, false, T[], T[], T[], 0.0, "unknown")
   solver = MinaresSolver{T,FC,S}(m, n, Δx, vₖ, vₖ₊₁, x, wₖ₋₂, wₖ₋₁, dₖ₋₂, dₖ₋₁, q, false, stats)
   return solver
 end
@@ -226,7 +226,7 @@ function MinaresSolver(m, n, S)
   dₖ₋₂ = S(undef, n)
   dₖ₋₁ = S(undef, n)
   q    = S(undef, n)
-  stats = SimpleStats(0, false, false, T[], T[], T[], 0.0, "unknown")
+  stats = SimpleStats(0, false, false, false, T[], T[], T[], 0.0, "unknown")
   solver = MinaresSolver{T,FC,S}(m, n, Δx, vₖ, vₖ₊₁, x, wₖ₋₂, wₖ₋₁, dₖ₋₂, dₖ₋₁, q, false, stats)
   return solver
 end
@@ -273,7 +273,7 @@ function CgSolver(kc::KrylovConstructor)
   p  = similar(kc.vn)
   Ap = similar(kc.vn)
   z  = similar(kc.vn_empty)
-  stats = SimpleStats(0, false, false, T[], T[], T[], 0.0, "unknown")
+  stats = SimpleStats(0, false, false, false, T[], T[], T[], 0.0, "unknown")
   solver = CgSolver{T,FC,S}(m, n, Δx, x, r, p, Ap, z, false, stats)
   return solver
 end
@@ -287,7 +287,7 @@ function CgSolver(m, n, S)
   p  = S(undef, n)
   Ap = S(undef, n)
   z  = S(undef, 0)
-  stats = SimpleStats(0, false, false, T[], T[], T[], 0.0, "unknown")
+  stats = SimpleStats(0, false, false, false, T[], T[], T[], 0.0, "unknown")
   solver = CgSolver{T,FC,S}(m, n, Δx, x, r, p, Ap, z, false, stats)
   return solver
 end
@@ -336,7 +336,7 @@ function CrSolver(kc::KrylovConstructor)
   q  = similar(kc.vn)
   Ar = similar(kc.vn)
   Mq = similar(kc.vn_empty)
-  stats = SimpleStats(0, false, false, T[], T[], T[], 0.0, "unknown")
+  stats = SimpleStats(0, false, false, false, T[], T[], T[], 0.0, "unknown")
   solver = CrSolver{T,FC,S}(m, n, Δx, x, r, p, q, Ar, Mq, false, stats)
   return solver
 end
@@ -351,7 +351,7 @@ function CrSolver(m, n, S)
   q  = S(undef, n)
   Ar = S(undef, n)
   Mq = S(undef, 0)
-  stats = SimpleStats(0, false, false, T[], T[], T[], 0.0, "unknown")
+  stats = SimpleStats(0, false, false, false, T[], T[], T[], 0.0, "unknown")
   solver = CrSolver{T,FC,S}(m, n, Δx, x, r, p, q, Ar, Mq, false, stats)
   return solver
 end
@@ -404,7 +404,7 @@ function CarSolver(kc::KrylovConstructor)
   t  = similar(kc.vn)
   u  = similar(kc.vn)
   Mu = similar(kc.vn_empty)
-  stats = SimpleStats(0, false, false, T[], T[], T[], 0.0, "unknown")
+  stats = SimpleStats(0, false, false, false, T[], T[], T[], 0.0, "unknown")
   solver = CarSolver{T,FC,S}(m, n, Δx, x, r, p, s, q, t, u, Mu, false, stats)
   return solver
 end
@@ -421,7 +421,7 @@ function CarSolver(m, n, S)
   t  = S(undef, n)
   u  = S(undef, n)
   Mu = S(undef, 0)
-  stats = SimpleStats(0, false, false, T[], T[], T[], 0.0, "unknown")
+  stats = SimpleStats(0, false, false, false, T[], T[], T[], 0.0, "unknown")
   solver = CarSolver{T,FC,S}(m, n, Δx, x, r, p, s, q, t, u, Mu, false, stats)
   return solver
 end
@@ -693,7 +693,7 @@ function MinresQlpSolver(kc::KrylovConstructor)
   x       = similar(kc.vn)
   p       = similar(kc.vn)
   vₖ      = similar(kc.vn_empty)
-  stats = SimpleStats(0, false, false, T[], T[], T[], 0.0, "unknown")
+  stats = SimpleStats(0, false, false, false, T[], T[], T[], 0.0, "unknown")
   solver = MinresQlpSolver{T,FC,S}(m, n, Δx, wₖ₋₁, wₖ, M⁻¹vₖ₋₁, M⁻¹vₖ, x, p, vₖ, false, stats)
   return solver
 end
@@ -709,7 +709,7 @@ function MinresQlpSolver(m, n, S)
   x       = S(undef, n)
   p       = S(undef, n)
   vₖ      = S(undef, 0)
-  stats = SimpleStats(0, false, false, T[], T[], T[], 0.0, "unknown")
+  stats = SimpleStats(0, false, false, false, T[], T[], T[], 0.0, "unknown")
   solver = MinresQlpSolver{T,FC,S}(m, n, Δx, wₖ₋₁, wₖ, M⁻¹vₖ₋₁, M⁻¹vₖ, x, p, vₖ, false, stats)
   return solver
 end
@@ -767,7 +767,7 @@ function DqgmresSolver(kc::KrylovConstructor, memory = 20)
   c      = Vector{T}(undef, memory)
   s      = Vector{FC}(undef, memory)
   H      = Vector{FC}(undef, memory+1)
-  stats  = SimpleStats(0, false, false, T[], T[], T[], 0.0, "unknown")
+  stats  = SimpleStats(0, false, false, false, T[], T[], T[], 0.0, "unknown")
   solver = DqgmresSolver{T,FC,S}(m, n, Δx, x, t, z, w, P, V, c, s, H, false, stats)
   return solver
 end
@@ -786,7 +786,7 @@ function DqgmresSolver(m, n, memory, S)
   c  = Vector{T}(undef, memory)
   s  = Vector{FC}(undef, memory)
   H  = Vector{FC}(undef, memory+1)
-  stats = SimpleStats(0, false, false, T[], T[], T[], 0.0, "unknown")
+  stats = SimpleStats(0, false, false, false, T[], T[], T[], 0.0, "unknown")
   solver = DqgmresSolver{T,FC,S}(m, n, Δx, x, t, z, w, P, V, c, s, H, false, stats)
   return solver
 end
@@ -842,7 +842,7 @@ function DiomSolver(kc::KrylovConstructor, memory = 20)
   V      = S[similar(kc.vn) for i = 1 : memory]
   L      = Vector{FC}(undef, memory-1)
   H      = Vector{FC}(undef, memory)
-  stats  = SimpleStats(0, false, false, T[], T[], T[], 0.0, "unknown")
+  stats  = SimpleStats(0, false, false, false, T[], T[], T[], 0.0, "unknown")
   solver = DiomSolver{T,FC,S}(m, n, Δx, x, t, z, w, P, V, L, H, false, stats)
   return solver
 end
@@ -860,7 +860,7 @@ function DiomSolver(m, n, memory, S)
   V  = S[S(undef, n) for i = 1 : memory]
   L  = Vector{FC}(undef, memory-1)
   H  = Vector{FC}(undef, memory)
-  stats = SimpleStats(0, false, false, T[], T[], T[], 0.0, "unknown")
+  stats = SimpleStats(0, false, false, false, T[], T[], T[], 0.0, "unknown")
   solver = DiomSolver{T,FC,S}(m, n, Δx, x, t, z, w, P, V, L, H, false, stats)
   return solver
 end
@@ -913,7 +913,7 @@ function UsymlqSolver(kc::KrylovConstructor)
   vₖ₋₁ = similar(kc.vm)
   vₖ   = similar(kc.vm)
   q    = similar(kc.vm)
-  stats = SimpleStats(0, false, false, T[], T[], T[], 0.0, "unknown")
+  stats = SimpleStats(0, false, false, false, T[], T[], T[], 0.0, "unknown")
   solver = UsymlqSolver{T,FC,S}(m, n, uₖ₋₁, uₖ, p, Δx, x, d̅, vₖ₋₁, vₖ, q, false, stats)
   return solver
 end
@@ -930,7 +930,7 @@ function UsymlqSolver(m, n, S)
   vₖ₋₁ = S(undef, m)
   vₖ   = S(undef, m)
   q    = S(undef, m)
-  stats = SimpleStats(0, false, false, T[], T[], T[], 0.0, "unknown")
+  stats = SimpleStats(0, false, false, false, T[], T[], T[], 0.0, "unknown")
   solver = UsymlqSolver{T,FC,S}(m, n, uₖ₋₁, uₖ, p, Δx, x, d̅, vₖ₋₁, vₖ, q, false, stats)
   return solver
 end
@@ -985,7 +985,7 @@ function UsymqrSolver(kc::KrylovConstructor)
   uₖ₋₁ = similar(kc.vn)
   uₖ   = similar(kc.vn)
   p    = similar(kc.vn)
-  stats = SimpleStats(0, false, false, T[], T[], T[], 0.0, "unknown")
+  stats = SimpleStats(0, false, false, false, T[], T[], T[], 0.0, "unknown")
   solver = UsymqrSolver{T,FC,S}(m, n, vₖ₋₁, vₖ, q, Δx, x, wₖ₋₂, wₖ₋₁, uₖ₋₁, uₖ, p, false, stats)
   return solver
 end
@@ -1003,7 +1003,7 @@ function UsymqrSolver(m, n, S)
   uₖ₋₁ = S(undef, n)
   uₖ   = S(undef, n)
   p    = S(undef, n)
-  stats = SimpleStats(0, false, false, T[], T[], T[], 0.0, "unknown")
+  stats = SimpleStats(0, false, false, false, T[], T[], T[], 0.0, "unknown")
   solver = UsymqrSolver{T,FC,S}(m, n, vₖ₋₁, vₖ, q, Δx, x, wₖ₋₂, wₖ₋₁, uₖ₋₁, uₖ, p, false, stats)
   return solver
 end
@@ -1070,7 +1070,7 @@ function TricgSolver(kc::KrylovConstructor)
   Δy      = similar(kc.vn_empty)
   uₖ      = similar(kc.vn_empty)
   vₖ      = similar(kc.vm_empty)
-  stats = SimpleStats(0, false, false, T[], T[], T[], 0.0, "unknown")
+  stats = SimpleStats(0, false, false, false, T[], T[], T[], 0.0, "unknown")
   solver = TricgSolver{T,FC,S}(m, n, y, N⁻¹uₖ₋₁, N⁻¹uₖ, p, gy₂ₖ₋₁, gy₂ₖ, x, M⁻¹vₖ₋₁, M⁻¹vₖ, q, gx₂ₖ₋₁, gx₂ₖ, Δx, Δy, uₖ, vₖ, false, stats)
   return solver
 end
@@ -1094,7 +1094,7 @@ function TricgSolver(m, n, S)
   Δy      = S(undef, 0)
   uₖ      = S(undef, 0)
   vₖ      = S(undef, 0)
-  stats = SimpleStats(0, false, false, T[], T[], T[], 0.0, "unknown")
+  stats = SimpleStats(0, false, false, false, T[], T[], T[], 0.0, "unknown")
   solver = TricgSolver{T,FC,S}(m, n, y, N⁻¹uₖ₋₁, N⁻¹uₖ, p, gy₂ₖ₋₁, gy₂ₖ, x, M⁻¹vₖ₋₁, M⁻¹vₖ, q, gx₂ₖ₋₁, gx₂ₖ, Δx, Δy, uₖ, vₖ, false, stats)
   return solver
 end
@@ -1169,7 +1169,7 @@ function TrimrSolver(kc::KrylovConstructor)
   Δy      = similar(kc.vn_empty)
   uₖ      = similar(kc.vn_empty)
   vₖ      = similar(kc.vm_empty)
-  stats = SimpleStats(0, false, false, T[], T[], T[], 0.0, "unknown")
+  stats = SimpleStats(0, false, false, false, T[], T[], T[], 0.0, "unknown")
   solver = TrimrSolver{T,FC,S}(m, n, y, N⁻¹uₖ₋₁, N⁻¹uₖ, p, gy₂ₖ₋₃, gy₂ₖ₋₂, gy₂ₖ₋₁, gy₂ₖ, x, M⁻¹vₖ₋₁, M⁻¹vₖ, q, gx₂ₖ₋₃, gx₂ₖ₋₂, gx₂ₖ₋₁, gx₂ₖ, Δx, Δy, uₖ, vₖ, false, stats)
   return solver
 end
@@ -1197,7 +1197,7 @@ function TrimrSolver(m, n, S)
   Δy      = S(undef, 0)
   uₖ      = S(undef, 0)
   vₖ      = S(undef, 0)
-  stats = SimpleStats(0, false, false, T[], T[], T[], 0.0, "unknown")
+  stats = SimpleStats(0, false, false, false, T[], T[], T[], 0.0, "unknown")
   solver = TrimrSolver{T,FC,S}(m, n, y, N⁻¹uₖ₋₁, N⁻¹uₖ, p, gy₂ₖ₋₃, gy₂ₖ₋₂, gy₂ₖ₋₁, gy₂ₖ, x, M⁻¹vₖ₋₁, M⁻¹vₖ, q, gx₂ₖ₋₃, gx₂ₖ₋₂, gx₂ₖ₋₁, gx₂ₖ, Δx, Δy, uₖ, vₖ, false, stats)
   return solver
 end
@@ -1332,7 +1332,7 @@ function CgsSolver(kc::KrylovConstructor)
   ts = similar(kc.vn)
   yz = similar(kc.vn_empty)
   vw = similar(kc.vn_empty)
-  stats = SimpleStats(0, false, false, T[], T[], T[], 0.0, "unknown")
+  stats = SimpleStats(0, false, false, false, T[], T[], T[], 0.0, "unknown")
   solver = CgsSolver{T,FC,S}(m, n, Δx, x, r, u, p, q, ts, yz, vw, false, stats)
   return solver
 end
@@ -1349,7 +1349,7 @@ function CgsSolver(m, n, S)
   ts = S(undef, n)
   yz = S(undef, 0)
   vw = S(undef, 0)
-  stats = SimpleStats(0, false, false, T[], T[], T[], 0.0, "unknown")
+  stats = SimpleStats(0, false, false, false, T[], T[], T[], 0.0, "unknown")
   solver = CgsSolver{T,FC,S}(m, n, Δx, x, r, u, p, q, ts, yz, vw, false, stats)
   return solver
 end
@@ -1402,7 +1402,7 @@ function BicgstabSolver(kc::KrylovConstructor)
   qd = similar(kc.vn)
   yz = similar(kc.vn_empty)
   t  = similar(kc.vn_empty)
-  stats = SimpleStats(0, false, false, T[], T[], T[], 0.0, "unknown")
+  stats = SimpleStats(0, false, false, false, T[], T[], T[], 0.0, "unknown")
   solver = BicgstabSolver{T,FC,S}(m, n, Δx, x, r, p, v, s, qd, yz, t, false, stats)
   return solver
 end
@@ -1419,7 +1419,7 @@ function BicgstabSolver(m, n, S)
   qd = S(undef, n)
   yz = S(undef, 0)
   t  = S(undef, 0)
-  stats = SimpleStats(0, false, false, T[], T[], T[], 0.0, "unknown")
+  stats = SimpleStats(0, false, false, false, T[], T[], T[], 0.0, "unknown")
   solver = BicgstabSolver{T,FC,S}(m, n, Δx, x, r, p, v, s, qd, yz, t, false, stats)
   return solver
 end
@@ -1476,7 +1476,7 @@ function BilqSolver(kc::KrylovConstructor)
   d̅    = similar(kc.vn)
   t    = similar(kc.vn_empty)
   s    = similar(kc.vn_empty)
-  stats = SimpleStats(0, false, false, T[], T[], T[], 0.0, "unknown")
+  stats = SimpleStats(0, false, false, false, T[], T[], T[], 0.0, "unknown")
   solver = BilqSolver{T,FC,S}(m, n, uₖ₋₁, uₖ, q, vₖ₋₁, vₖ, p, Δx, x, d̅, t, s, false, stats)
   return solver
 end
@@ -1495,7 +1495,7 @@ function BilqSolver(m, n, S)
   d̅    = S(undef, n)
   t    = S(undef, 0)
   s    = S(undef, 0)
-  stats = SimpleStats(0, false, false, T[], T[], T[], 0.0, "unknown")
+  stats = SimpleStats(0, false, false, false, T[], T[], T[], 0.0, "unknown")
   solver = BilqSolver{T,FC,S}(m, n, uₖ₋₁, uₖ, q, vₖ₋₁, vₖ, p, Δx, x, d̅, t, s, false, stats)
   return solver
 end
@@ -1554,7 +1554,7 @@ function QmrSolver(kc::KrylovConstructor)
   wₖ₋₁ = similar(kc.vn)
   t    = similar(kc.vn_empty)
   s    = similar(kc.vn_empty)
-  stats = SimpleStats(0, false, false, T[], T[], T[], 0.0, "unknown")
+  stats = SimpleStats(0, false, false, false, T[], T[], T[], 0.0, "unknown")
   solver = QmrSolver{T,FC,S}(m, n, uₖ₋₁, uₖ, q, vₖ₋₁, vₖ, p, Δx, x, wₖ₋₂, wₖ₋₁, t, s, false, stats)
   return solver
 end
@@ -1574,7 +1574,7 @@ function QmrSolver(m, n, S)
   wₖ₋₁ = S(undef, n)
   t    = S(undef, 0)
   s    = S(undef, 0)
-  stats = SimpleStats(0, false, false, T[], T[], T[], 0.0, "unknown")
+  stats = SimpleStats(0, false, false, false, T[], T[], T[], 0.0, "unknown")
   solver = QmrSolver{T,FC,S}(m, n, uₖ₋₁, uₖ, q, vₖ₋₁, vₖ, p, Δx, x, wₖ₋₂, wₖ₋₁, t, s, false, stats)
   return solver
 end
@@ -1702,7 +1702,7 @@ function CglsSolver(kc::KrylovConstructor)
   r  = similar(kc.vm)
   q  = similar(kc.vm)
   Mr = similar(kc.vm_empty)
-  stats = SimpleStats(0, false, false, T[], T[], T[], 0.0, "unknown")
+  stats = SimpleStats(0, false, false, false, T[], T[], T[], 0.0, "unknown")
   solver = CglsSolver{T,FC,S}(m, n, x, p, s, r, q, Mr, stats)
   return solver
 end
@@ -1716,7 +1716,7 @@ function CglsSolver(m, n, S)
   r  = S(undef, m)
   q  = S(undef, m)
   Mr = S(undef, 0)
-  stats = SimpleStats(0, false, false, T[], T[], T[], 0.0, "unknown")
+  stats = SimpleStats(0, false, false, false, T[], T[], T[], 0.0, "unknown")
   solver = CglsSolver{T,FC,S}(m, n, x, p, s, r, q, Mr, stats)
   return solver
 end
@@ -1853,7 +1853,7 @@ function CrlsSolver(kc::KrylovConstructor)
   Ap = similar(kc.vm)
   s  = similar(kc.vm)
   Ms = similar(kc.vm_empty)
-  stats = SimpleStats(0, false, false, T[], T[], T[], 0.0, "unknown")
+  stats = SimpleStats(0, false, false, false, T[], T[], T[], 0.0, "unknown")
   solver = CrlsSolver{T,FC,S}(m, n, x, p, Ar, q, r, Ap, s, Ms, stats)
   return solver
 end
@@ -1869,7 +1869,7 @@ function CrlsSolver(m, n, S)
   Ap = S(undef, m)
   s  = S(undef, m)
   Ms = S(undef, 0)
-  stats = SimpleStats(0, false, false, T[], T[], T[], 0.0, "unknown")
+  stats = SimpleStats(0, false, false, false, T[], T[], T[], 0.0, "unknown")
   solver = CrlsSolver{T,FC,S}(m, n, x, p, Ar, q, r, Ap, s, Ms, stats)
   return solver
 end
@@ -1917,7 +1917,7 @@ function CgneSolver(kc::KrylovConstructor)
   q   = similar(kc.vm)
   s   = similar(kc.vm_empty)
   z   = similar(kc.vm_empty)
-  stats = SimpleStats(0, false, false, T[], T[], T[], 0.0, "unknown")
+  stats = SimpleStats(0, false, false, false, T[], T[], T[], 0.0, "unknown")
   solver = CgneSolver{T,FC,S}(m, n, x, p, Aᴴz, r, q, s, z, stats)
   return solver
 end
@@ -1932,7 +1932,7 @@ function CgneSolver(m, n, S)
   q   = S(undef, m)
   s   = S(undef, 0)
   z   = S(undef, 0)
-  stats = SimpleStats(0, false, false, T[], T[], T[], 0.0, "unknown")
+  stats = SimpleStats(0, false, false, false, T[], T[], T[], 0.0, "unknown")
   solver = CgneSolver{T,FC,S}(m, n, x, p, Aᴴz, r, q, s, z, stats)
   return solver
 end
@@ -1980,7 +1980,7 @@ function CrmrSolver(kc::KrylovConstructor)
   q   = similar(kc.vm)
   Nq  = similar(kc.vm_empty)
   s   = similar(kc.vm_empty)
-  stats = SimpleStats(0, false, false, T[], T[], T[], 0.0, "unknown")
+  stats = SimpleStats(0, false, false, false, T[], T[], T[], 0.0, "unknown")
   solver = CrmrSolver{T,FC,S}(m, n, x, p, Aᴴr, r, q, Nq, s, stats)
   return solver
 end
@@ -1995,7 +1995,7 @@ function CrmrSolver(m, n, S)
   q   = S(undef, m)
   Nq  = S(undef, 0)
   s   = S(undef, 0)
-  stats = SimpleStats(0, false, false, T[], T[], T[], 0.0, "unknown")
+  stats = SimpleStats(0, false, false, false, T[], T[], T[], 0.0, "unknown")
   solver = CrmrSolver{T,FC,S}(m, n, x, p, Aᴴr, r, q, Nq, s, stats)
   return solver
 end
@@ -2116,7 +2116,7 @@ function LsqrSolver(kc::KrylovConstructor; window :: Int=5)
   u   = similar(kc.vm_empty)
   v   = similar(kc.vn_empty)
   err_vec = zeros(T, window)
-  stats = SimpleStats(0, false, false, T[], T[], T[], 0.0, "unknown")
+  stats = SimpleStats(0, false, false, false, T[], T[], T[], 0.0, "unknown")
   solver = LsqrSolver{T,FC,S}(m, n, x, Nv, Aᴴu, w, Mu, Av, u, v, err_vec, stats)
   return solver
 end
@@ -2133,7 +2133,7 @@ function LsqrSolver(m, n, S; window :: Int=5)
   u   = S(undef, 0)
   v   = S(undef, 0)
   err_vec = zeros(T, window)
-  stats = SimpleStats(0, false, false, T[], T[], T[], 0.0, "unknown")
+  stats = SimpleStats(0, false, false, false, T[], T[], T[], 0.0, "unknown")
   solver = LsqrSolver{T,FC,S}(m, n, x, Nv, Aᴴu, w, Mu, Av, u, v, err_vec, stats)
   return solver
 end
@@ -2331,7 +2331,7 @@ function CraigSolver(kc::KrylovConstructor)
   u   = similar(kc.vm_empty)
   v   = similar(kc.vn_empty)
   w2  = similar(kc.vn_empty)
-  stats = SimpleStats(0, false, false, T[], T[], T[], 0.0, "unknown")
+  stats = SimpleStats(0, false, false, false, T[], T[], T[], 0.0, "unknown")
   solver = CraigSolver{T,FC,S}(m, n, x, Nv, Aᴴu, y, w, Mu, Av, u, v, w2, stats)
   return solver
 end
@@ -2349,7 +2349,7 @@ function CraigSolver(m, n, S)
   u   = S(undef, 0)
   v   = S(undef, 0)
   w2  = S(undef, 0)
-  stats = SimpleStats(0, false, false, T[], T[], T[], 0.0, "unknown")
+  stats = SimpleStats(0, false, false, false, T[], T[], T[], 0.0, "unknown")
   solver = CraigSolver{T,FC,S}(m, n, x, Nv, Aᴴu, y, w, Mu, Av, u, v, w2, stats)
   return solver
 end
@@ -2407,7 +2407,7 @@ function CraigmrSolver(kc::KrylovConstructor)
   u    = similar(kc.vm_empty)
   v    = similar(kc.vn_empty)
   q    = similar(kc.vn_empty)
-  stats = SimpleStats(0, false, false, T[], T[], T[], 0.0, "unknown")
+  stats = SimpleStats(0, false, false, false, T[], T[], T[], 0.0, "unknown")
   solver = CraigmrSolver{T,FC,S}(m, n, x, Nv, Aᴴu, d, y, Mu, w, wbar, Av, u, v, q, stats)
   return solver
 end
@@ -2427,7 +2427,7 @@ function CraigmrSolver(m, n, S)
   u    = S(undef, 0)
   v    = S(undef, 0)
   q    = S(undef, 0)
-  stats = SimpleStats(0, false, false, T[], T[], T[], 0.0, "unknown")
+  stats = SimpleStats(0, false, false, false, T[], T[], T[], 0.0, "unknown")
   solver = CraigmrSolver{T,FC,S}(m, n, x, Nv, Aᴴu, d, y, Mu, w, wbar, Av, u, v, q, stats)
   return solver
 end
@@ -2486,7 +2486,7 @@ function GmresSolver(kc::KrylovConstructor, memory = 20)
   s  = Vector{FC}(undef, memory)
   z  = Vector{FC}(undef, memory)
   R  = Vector{FC}(undef, div(memory * (memory+1), 2))
-  stats = SimpleStats(0, false, false, T[], T[], T[], 0.0, "unknown")
+  stats = SimpleStats(0, false, false, false, T[], T[], T[], 0.0, "unknown")
   solver = GmresSolver{T,FC,S}(m, n, Δx, x, w, p, q, V, c, s, z, R, false, 0, stats)
   return solver
 end
@@ -2505,7 +2505,7 @@ function GmresSolver(m, n, memory, S)
   s  = Vector{FC}(undef, memory)
   z  = Vector{FC}(undef, memory)
   R  = Vector{FC}(undef, div(memory * (memory+1), 2))
-  stats = SimpleStats(0, false, false, T[], T[], T[], 0.0, "unknown")
+  stats = SimpleStats(0, false, false, false, T[], T[], T[], 0.0, "unknown")
   solver = GmresSolver{T,FC,S}(m, n, Δx, x, w, p, q, V, c, s, z, R, false, 0, stats)
   return solver
 end
@@ -2564,7 +2564,7 @@ function FgmresSolver(kc::KrylovConstructor, memory = 20)
   s  = Vector{FC}(undef, memory)
   z  = Vector{FC}(undef, memory)
   R  = Vector{FC}(undef, div(memory * (memory+1), 2))
-  stats = SimpleStats(0, false, false, T[], T[], T[], 0.0, "unknown")
+  stats = SimpleStats(0, false, false, false, T[], T[], T[], 0.0, "unknown")
   solver = FgmresSolver{T,FC,S}(m, n, Δx, x, w, q, V, Z, c, s, z, R, false, 0, stats)
   return solver
 end
@@ -2583,7 +2583,7 @@ function FgmresSolver(m, n, memory, S)
   s  = Vector{FC}(undef, memory)
   z  = Vector{FC}(undef, memory)
   R  = Vector{FC}(undef, div(memory * (memory+1), 2))
-  stats = SimpleStats(0, false, false, T[], T[], T[], 0.0, "unknown")
+  stats = SimpleStats(0, false, false, false, T[], T[], T[], 0.0, "unknown")
   solver = FgmresSolver{T,FC,S}(m, n, Δx, x, w, q, V, Z, c, s, z, R, false, 0, stats)
   return solver
 end
@@ -2639,7 +2639,7 @@ function FomSolver(kc::KrylovConstructor, memory = 20)
   l  = Vector{FC}(undef, memory)
   z  = Vector{FC}(undef, memory)
   U  = Vector{FC}(undef, div(memory * (memory+1), 2))
-  stats = SimpleStats(0, false, false, T[], T[], T[], 0.0, "unknown")
+  stats = SimpleStats(0, false, false, false, T[], T[], T[], 0.0, "unknown")
   solver = FomSolver{T,FC,S}(m, n, Δx, x, w, p, q, V, l, z, U, false, stats)
   return solver
 end
@@ -2657,7 +2657,7 @@ function FomSolver(m, n, memory, S)
   l  = Vector{FC}(undef, memory)
   z  = Vector{FC}(undef, memory)
   U  = Vector{FC}(undef, div(memory * (memory+1), 2))
-  stats = SimpleStats(0, false, false, T[], T[], T[], 0.0, "unknown")
+  stats = SimpleStats(0, false, false, false, T[], T[], T[], 0.0, "unknown")
   solver = FomSolver{T,FC,S}(m, n, Δx, x, w, p, q, V, l, z, U, false, stats)
   return solver
 end
@@ -2727,7 +2727,7 @@ function GpmrSolver(kc::KrylovConstructor, memory = 20)
   gc = Vector{T}(undef, 4 * memory)
   zt = Vector{FC}(undef, 2 * memory)
   R  = Vector{FC}(undef, memory * (2 * memory + 1))
-  stats = SimpleStats(0, false, false, T[], T[], T[], 0.0, "unknown")
+  stats = SimpleStats(0, false, false, false, T[], T[], T[], 0.0, "unknown")
   solver = GpmrSolver{T,FC,S}(m, n, wA, wB, dA, dB, Δx, Δy, x, y, q, p, V, U, gs, gc, zt, R, false, stats)
   return solver
 end
@@ -2752,7 +2752,7 @@ function GpmrSolver(m, n, memory, S)
   gc = Vector{T}(undef, 4 * memory)
   zt = Vector{FC}(undef, 2 * memory)
   R  = Vector{FC}(undef, memory * (2 * memory + 1))
-  stats = SimpleStats(0, false, false, T[], T[], T[], 0.0, "unknown")
+  stats = SimpleStats(0, false, false, false, T[], T[], T[], 0.0, "unknown")
   solver = GpmrSolver{T,FC,S}(m, n, wA, wB, dA, dB, Δx, Δy, x, y, q, p, V, U, gs, gc, zt, R, false, stats)
   return solver
 end

--- a/src/krylov_solvers.jl
+++ b/src/krylov_solvers.jl
@@ -112,13 +112,14 @@ mutable struct MinresSolver{T,FC,S} <: KrylovSolver{T,FC,S}
   x          :: S
   r1         :: S
   r2         :: S
+  rk         :: S
   w1         :: S
   w2         :: S
   y          :: S
   v          :: S
   err_vec    :: Vector{T}
   warm_start :: Bool
-  stats      :: SimpleStats{T}
+  stats      :: conStats{T}
 end
 
 function MinresSolver(kc::KrylovConstructor; window :: Int=5)
@@ -131,13 +132,14 @@ function MinresSolver(kc::KrylovConstructor; window :: Int=5)
   x  = similar(kc.vn)
   r1 = similar(kc.vn)
   r2 = similar(kc.vn)
+  rk = similar(kc.vn_empty)
   w1 = similar(kc.vn)
   w2 = similar(kc.vn)
   y  = similar(kc.vn)
   v  = similar(kc.vn_empty)
   err_vec = zeros(T, window)
-  stats = SimpleStats(0, false, false, T[], T[], T[], 0.0, "unknown")
-  solver = MinresSolver{T,FC,S}(m, n, Δx, x, r1, r2, w1, w2, y, v, err_vec, false, stats)
+  stats = conStats(0, false, false, false, false, T[], T[], T[], 0.0, "unknown")
+  solver = MinresSolver{T,FC,S}(m, n, Δx, x, r1, r2, rk, w1, w2, y, v, err_vec, false, stats)
   return solver
 end
 
@@ -148,13 +150,14 @@ function MinresSolver(m, n, S; window :: Int=5)
   x  = S(undef, n)
   r1 = S(undef, n)
   r2 = S(undef, n)
+  rk = S(undef, 0)
   w1 = S(undef, n)
   w2 = S(undef, n)
   y  = S(undef, n)
   v  = S(undef, 0)
   err_vec = zeros(T, window)
-  stats = SimpleStats(0, false, false, T[], T[], T[], 0.0, "unknown")
-  solver = MinresSolver{T,FC,S}(m, n, Δx, x, r1, r2, w1, w2, y, v, err_vec, false, stats)
+  stats = conStats(0, false, false, false, false, T[], T[], T[], 0.0, "unknown")
+  solver = MinresSolver{T,FC,S}(m, n, Δx, x, r1, r2, rk, w1, w2, y, v, err_vec, false, stats)
   return solver
 end
 

--- a/src/krylov_stats.jl
+++ b/src/krylov_stats.jl
@@ -12,6 +12,7 @@ The fields are as follows:
 - `niter`: The total number of iterations completed by the solver;
 - `solved`: Indicates whether the solver successfully reached convergence (`true` if solved, `false` otherwise);
 - `inconsistent`: Flags whether the system was detected as inconsistent (i.e., when `b` is not in the range of `A`);
+- `indefinite`: Flags whether the system was detected as indefinite (i.e., when `A` is not positive definite);
 - `residuals`: A vector containing the residual norms at each iteration;
 - `Aresiduals`: A vector of `A'`-residual norms at each iteration;
 - `Acond`: An estimate of the condition number of matrix `A`.
@@ -22,6 +23,7 @@ mutable struct SimpleStats{T} <: KrylovStats{T}
   niter        :: Int
   solved       :: Bool
   inconsistent :: Bool
+  indefinite   :: Bool
   residuals    :: Vector{T}
   Aresiduals   :: Vector{T}
   Acond        :: Vector{T}
@@ -39,6 +41,7 @@ function copyto!(dest :: SimpleStats, src :: SimpleStats)
   dest.niter        = src.niter
   dest.solved       = src.solved
   dest.inconsistent = src.inconsistent
+  dest.indefinite   = src.indefinite
   dest.residuals    = copy(src.residuals)
   dest.Aresiduals   = copy(src.Aresiduals)
   dest.Acond        = copy(src.Acond)
@@ -46,58 +49,6 @@ function copyto!(dest :: SimpleStats, src :: SimpleStats)
   dest.status       = src.status
   return dest
 end
-
-"""
-Type for storing statistics returned by Conjugate Methods.
-Methods icludes:
-- CG (TODO)
-- CR (TODO)
-- MINRES
-The fields are as follows:
-- niter
-- solved
-- nonposi_curv: when a non-positive curvature is detected
-- linesearch: when a line search is performed
-- inconsistent
-- residuals
-- Aresiduals
-- Acond
-- timer
-- status
-"""
-mutable struct conStats{T} <: KrylovStats{T}
-  niter        :: Int
-  solved       :: Bool
-  nonposi_curv :: Bool
-  linesearch   :: Bool
-  inconsistent :: Bool
-  residuals    :: Vector{T}
-  Aresiduals   :: Vector{T}
-  Acond        :: Vector{T}
-  timer        :: Float64
-  status       :: String
-end
-
-function reset!(stats :: conStats)
-  empty!(stats.residuals)
-  empty!(stats.Aresiduals)
-  empty!(stats.Acond)
-end
-
-function copyto!(dest :: conStats, src :: conStats)
-  dest.niter        = src.niter
-  dest.solved       = src.solved
-  dest.nonposi_curv = src.nonposi_curv
-  dest.linesearch   = src.linesearch
-  dest.inconsistent = src.inconsistent
-  dest.residuals    = copy(src.residuals)
-  dest.Aresiduals   = copy(src.Aresiduals)
-  dest.Acond        = copy(src.Acond)
-  dest.timer        = src.timer
-  dest.status       = src.status
-  return dest
-end
-
 
 """
 Type for storing statistics returned by LSMR.

--- a/src/krylov_stats.jl
+++ b/src/krylov_stats.jl
@@ -48,6 +48,58 @@ function copyto!(dest :: SimpleStats, src :: SimpleStats)
 end
 
 """
+Type for storing statistics returned by Conjugate Methods.
+Methods icludes:
+- CG (TODO)
+- CR (TODO)
+- MINRES
+The fields are as follows:
+- niter
+- solved
+- nonposi_curv: when a non-positive curvature is detected
+- linesearch: when a line search is performed
+- inconsistent
+- residuals
+- Aresiduals
+- Acond
+- timer
+- status
+"""
+mutable struct conStats{T} <: KrylovStats{T}
+  niter        :: Int
+  solved       :: Bool
+  nonposi_curv :: Bool
+  linesearch   :: Bool
+  inconsistent :: Bool
+  residuals    :: Vector{T}
+  Aresiduals   :: Vector{T}
+  Acond        :: Vector{T}
+  timer        :: Float64
+  status       :: String
+end
+
+function reset!(stats :: conStats)
+  empty!(stats.residuals)
+  empty!(stats.Aresiduals)
+  empty!(stats.Acond)
+end
+
+function copyto!(dest :: conStats, src :: conStats)
+  dest.niter        = src.niter
+  dest.solved       = src.solved
+  dest.nonposi_curv = src.nonposi_curv
+  dest.linesearch   = src.linesearch
+  dest.inconsistent = src.inconsistent
+  dest.residuals    = copy(src.residuals)
+  dest.Aresiduals   = copy(src.Aresiduals)
+  dest.Acond        = copy(src.Acond)
+  dest.timer        = src.timer
+  dest.status       = src.status
+  return dest
+end
+
+
+"""
 Type for storing statistics returned by LSMR.
 The fields are as follows:
 - niter

--- a/src/minres.jl
+++ b/src/minres.jl
@@ -16,7 +16,7 @@
 # detection to monotonicity properties," SIAM Journal on Optimization 32, no. 4 (2022): 2636–2661):
 #
 # If linesearch is true and negative curvature is detected at iteration k > 0, the solution from iteration k-1 is returned, and `solver.npc_dir` contains the last computed residual, which is a direction of nonpositive curvature.
-# If negative curvature is detected at first iteration, the method returns the right-hand side (i.e., the negative gradient).
+# If linesearch is true and negative curvature is detected at iteration k = 0, the right-hand side is returned as solution (i.e., the negative gradient), and `solver.npc_dir` contains [WHAT?].
 #
 # C. C. Paige and M. A. Saunders, Solution of Sparse Indefinite Systems of Linear Equations,
 # SIAM Journal on Numerical Analysis, 12(4), pp. 617--629, 1975.

--- a/src/minres.jl
+++ b/src/minres.jl
@@ -323,8 +323,8 @@ kwargs_minres = (:M, :ldiv, :linesearch ,:λ, :atol, :rtol, :etol, :conlim, :itm
 
       if linesearch
         # compute the residual vector and store it in npc_dir
-        kscal!(n, sn * sn, npc_dir  )  # npc_dir  = sn * sn * npc_dir 
-        kaxpy!(n, -ϕbar * cs, v, npc_dir )   # npc_dir  = npc_dir  - ϕbar * cs * v
+        kscal!(n, sn * sn, npc_dir)  # npc_dir  = sn * sn * npc_dir 
+        kaxpy!(n, -ϕbar * cs, v, npc_dir)  # npc_dir  = npc_dir  - ϕbar * cs * v
       end
       
       # Final update of w.

--- a/src/minres.jl
+++ b/src/minres.jl
@@ -323,10 +323,8 @@ kwargs_minres = (:M, :ldiv, :linesearch ,:λ, :atol, :rtol, :etol, :conlim, :itm
 
       if linesearch
         # calculating the residual npc_dir  = sn*sn * npc_dir  - ϕbar * cs   * v
-        sn2 = sn * sn
-        kscal!(n, sn2, npc_dir  )  # npc_dir  = sn2 * npc_dir 
-        ϕ_c = -ϕbar * cs 
-        kaxpy!(n, ϕ_c, v, npc_dir )   # npc_dir  = npc_dir  + ϕ_c * v
+        kscal!(n, sn * sn, npc_dir  )  # npc_dir  = sn * sn * npc_dir 
+        kaxpy!(n, -ϕbar * cs, v, npc_dir )   # npc_dir  = npc_dir  - ϕbar * cs * v
       end
       
 

--- a/src/minres.jl
+++ b/src/minres.jl
@@ -307,7 +307,6 @@ kwargs_minres = (:M, :ldiv, :linesearch ,:λ, :atol, :rtol, :etol, :conlim, :itm
           stats.status = "nonpositive curvature"
           iter == 1 && kcopy!(n, x, b)
           solver.warm_start = false
-          # when we use the linesearch and encounter negative curvature, we return the last residual xk but user has access to npc_dir  from solver.npc_dir 
           stats.indefinite = true
           return solver
         end

--- a/src/minres.jl
+++ b/src/minres.jl
@@ -59,7 +59,6 @@ A is indefinite.
 
 MINRES produces monotonic residuals ‖r‖₂ and optimality residuals ‖Aᴴr‖₂.
 
-If linesearch is true and negative curvature is detected at iteration k > 0, the solution from iteration k-1 is returned, and `solver.npc_dir` contains the last computed residual, which is a direction of nonpositive curvature.
 If linesearch is true and negative curvature is detected at iteration k = 0, the right-hand side is returned as solution (i.e., the negative gradient), and `solver.npc_dir` contains the preconditioned initial residual.
 
 #### Input arguments

--- a/src/minres.jl
+++ b/src/minres.jl
@@ -96,7 +96,7 @@ MINRES produces monotonic residuals ‖r‖₂ and optimality residuals ‖Aᴴr
 
 * C. C. Paige and M. A. Saunders, [*Solution of Sparse Indefinite Systems of Linear Equations*](https://doi.org/10.1137/0712047), SIAM Journal on Numerical Analysis, 12(4), pp. 617--629, 1975.
 
-* Liu, Yang, and Roosta, MINRES: from negative curvature detection to monotonicity properties, SIAM Journal on Optimization, 32(4), pp. 2636--2661, 2022. 
+* Y. Liu and F. Roosta, [*MINRES: From Negative Curvature Detection to Monotonicity Properties*](https://doi.org/10.1137/21M143666X), *SIAM Journal on Optimization*, 32(4), pp. 2636–2661, 2022.
 """
 function minres end
 

--- a/src/minres.jl
+++ b/src/minres.jl
@@ -96,7 +96,7 @@ MINRES produces monotonic residuals ‖r‖₂ and optimality residuals ‖Aᴴr
 
 * C. C. Paige and M. A. Saunders, [*Solution of Sparse Indefinite Systems of Linear Equations*](https://doi.org/10.1137/0712047), SIAM Journal on Numerical Analysis, 12(4), pp. 617--629, 1975.
 
-* Y. Liu and F. Roosta, [*MINRES: From Negative Curvature Detection to Monotonicity Properties*](https://doi.org/10.1137/21M143666X), *SIAM Journal on Optimization*, 32(4), pp. 2636–2661, 2022.
+* Y. Liu and F. Roosta, [*MINRES: From Negative Curvature Detection to Monotonicity Properties*](https://doi.org/10.1137/21M143666X), SIAM Journal on Optimization, 32(4), pp. 2636--2661, 2022.
 """
 function minres end
 

--- a/src/minres.jl
+++ b/src/minres.jl
@@ -12,12 +12,12 @@
 # This implementation follows the original implementation by
 # Michael Saunders described in
 #
+# C. C. Paige and M. A. Saunders, Solution of Sparse Indefinite Systems of Linear Equations,
+# SIAM Journal on Numerical Analysis, 12(4), pp. 617--629, 1975.
+#
 # Negative curvature detection follows
 # Liu, Yang, and Roosta, MINRES: from negative curvature detection to monotonicity properties,
 # SIAM Journal on Optimization, 32(4), pp. 2636--2661, 2022.
-#
-# C. C. Paige and M. A. Saunders, Solution of Sparse Indefinite Systems of Linear Equations,
-# SIAM Journal on Numerical Analysis, 12(4), pp. 617--629, 1975.
 #
 # Dominique Orban, <dominique.orban@gerad.ca>
 # Brussels, Belgium, June 2015.
@@ -59,6 +59,7 @@ A is indefinite.
 
 MINRES produces monotonic residuals ‖r‖₂ and optimality residuals ‖Aᴴr‖₂.
 
+If `linesearch` is true and negative curvature is detected, the solution depends on the iteration: at  k > 0, the solution from k-1 is returned with `solver.npc_dir` as the last residual; at k = 0, the right-hand side is returned with `solver.npc_dir` as the preconditioned initial residual.
 
 #### Input arguments
 
@@ -97,7 +98,8 @@ If linesearch is true and nonpositive curvature is detected at iteration k = 0, 
 #### References
 
 * C. C. Paige and M. A. Saunders, [*Solution of Sparse Indefinite Systems of Linear Equations*](https://doi.org/10.1137/0712047), SIAM Journal on Numerical Analysis, 12(4), pp. 617--629, 1975.
-* Liu, Yang & Roosta, Fred. (2022). A Newton-MR algorithm with complexity guarantees for nonconvex smooth unconstrained optimization. 10.48550/arXiv.2208.07095. 
+
+* Liu, Yang, and Roosta, MINRES: from negative curvature detection to monotonicity properties, SIAM Journal on Optimization, 32(4), pp. 2636--2661, 2022. 
 """
 function minres end
 

--- a/src/minres.jl
+++ b/src/minres.jl
@@ -327,7 +327,6 @@ kwargs_minres = (:M, :ldiv, :linesearch ,:λ, :atol, :rtol, :etol, :conlim, :itm
         kaxpy!(n, -ϕbar * cs, v, npc_dir )   # npc_dir  = npc_dir  - ϕbar * cs * v
       end
       
-
       # Final update of w.
       kscal!(n, one(FC) / γ, w)
 

--- a/src/minres.jl
+++ b/src/minres.jl
@@ -198,7 +198,6 @@ kwargs_minres = (:M, :ldiv, :linesearch ,:λ, :atol, :rtol, :etol, :conlim, :itm
     rNorm =  knorm_elliptic(n, r2, r1)  # = ‖r‖
     history && push!(rNorms, rNorm)
 
-
     β₁ = kdotr(m, r1, v)
     β₁ < 0 && error("Preconditioner is not positive definite")
     if β₁ == 0

--- a/src/minres.jl
+++ b/src/minres.jl
@@ -190,8 +190,6 @@ kwargs_minres = (:M, :ldiv, :linesearch ,:λ, :atol, :rtol, :etol, :conlim, :itm
     MisI || mulorldiv!(v, M, r1, ldiv)
 
     linesearch && kcopy!(n, npc_dir , v)  # npc_dir  ← v; contain the preconditioned initial residual
-    rNorm =  knorm_elliptic(n, r2, r1)  # = ‖r‖
-    history && push!(rNorms, rNorm)
 
     β₁ = kdotr(m, r1, v)
     β₁ < 0 && error("Preconditioner is not positive definite")

--- a/src/minres.jl
+++ b/src/minres.jl
@@ -73,7 +73,7 @@ MINRES produces monotonic residuals ‖r‖₂ and optimality residuals ‖Aᴴr
 * `M`: linear operator that models a Hermitian positive-definite matrix of size `n` used for centered preconditioning;
 * `ldiv`: define whether the preconditioner uses `ldiv!` or `mul!`;
 * `window`: number of iterations used to accumulate a lower bound on the error;
-* `linesearch`: if `true`, indicate that the solution is to be used in an inexact Newton method with linesearch. If `linesearch` is true and negative curvature is detected, the solution depends on the iteration: at  k > 1, the solution from k-1 is returned with `solver.npc_dir` as the last residual; at k = 1, the right-hand side is returned with `solver.npc_dir` as the preconditioned initial residual. [Note that the MINRES solver start at iteration 1, so the first iteration is k = 1];
+* `linesearch`: if `true`, indicate that the solution is to be used in an inexact Newton method with linesearch. If `linesearch` is true and nonpositive curvature is detected, the solution depends on the iteration: at iteration k = 1, the right-hand side is returned with `solver.npc_dir` as the preconditioned initial residual; at iteration k > 1, the solution from iteration k-1 is returned with `solver.npc_dir` as the most recent residual. (Note that the MINRES solver starts at iteration 1, so the first iteration is k = 1);
 
 * `λ`: regularization parameter;
 * `atol`: absolute stopping tolerance based on the residual norm;

--- a/src/minres.jl
+++ b/src/minres.jl
@@ -15,7 +15,7 @@
 # Negative curvature handling (following Liu, Yang, and Roosta, "MINRES: from negative curvature 
 # detection to monotonicity properties," SIAM Journal on Optimization 32, no. 4 (2022): 2636–2661):
 #
-# If linesearch is true, and if negative curvature is detected at any iteration k > 0, the solution from iteration k-1 is returned, while preserving the last computed residual as a potential search direction.
+# If linesearch is true and negative curvature is detected at iteration k > 0, the solution from iteration k-1 is returned, and `solver.npc_dir` contains the last computed residual, which is a direction of nonpositive curvature.
 # If negative curvature is detected at first iteration, the method returns the right-hand side (i.e., the negative gradient).
 #
 # C. C. Paige and M. A. Saunders, Solution of Sparse Indefinite Systems of Linear Equations,

--- a/src/minres.jl
+++ b/src/minres.jl
@@ -26,7 +26,6 @@
 # Montréal, August 2015.
 #
 
-
 export minres, minres!
 
 """

--- a/src/minres.jl
+++ b/src/minres.jl
@@ -303,10 +303,9 @@ kwargs_minres = (:M, :ldiv, :linesearch ,:λ, :atol, :rtol, :etol, :conlim, :itm
           stats.inconsistent = false
           stats.timer = start_time |> ktimer
           stats.status = "nonpositive curvature"
-          iter == 1 && kcopy!(n, x, r)
+          iter == 1 && kcopy!(n, x, r1)
           solver.warm_start = false
-          # when we use the linesearch and encounter negative curvature, we return the last residual rk
-          kcopy!(n, x, rk) # x ← rk  
+          # when we use the linesearch and encounter negative curvature, we return the last residual xk but user has access to rk from solver.rk
           stats.nonposi_curv = true
           return solver
         end

--- a/src/minres.jl
+++ b/src/minres.jl
@@ -321,7 +321,7 @@ kwargs_minres = (:M, :ldiv, :linesearch ,:λ, :atol, :rtol, :etol, :conlim, :itm
       ϕbar = sn * ϕbar
 
       if linesearch
-        # calculating the residual npc_dir  = sn*sn * npc_dir  - ϕbar * cs   * v
+        # compute the residual vector and store it in npc_dir
         kscal!(n, sn * sn, npc_dir  )  # npc_dir  = sn * sn * npc_dir 
         kaxpy!(n, -ϕbar * cs, v, npc_dir )   # npc_dir  = npc_dir  - ϕbar * cs * v
       end

--- a/src/minres.jl
+++ b/src/minres.jl
@@ -299,16 +299,17 @@ kwargs_minres = (:M, :ldiv, :linesearch ,:λ, :atol, :rtol, :etol, :conlim, :itm
       ArNorm = ϕbar * root  # = ‖Aᴴrₖ₋₁‖
       history && push!(ArNorms, ArNorm)
 
-      # Check if -ve curvature encountered.
+      # Check for nonpositive curvature
       if linesearch
-        if cs * γbar ≥ 0 # or eps(T)
-          (verbose > 0) && @printf(iostream, "nonpositive curvature detected:  cs * γbar = %e\n", cs * γbar)
+        cγ = cs * γbar
+        if cγ ≥ 0
+          (verbose > 0) && @printf(iostream, "nonpositive curvature detected:  cs * γbar = %e\n", cγ)
           stats.solved = true
           stats.niter = iter
           stats.inconsistent = false
           stats.timer = start_time |> ktimer
           stats.status = "nonpositive curvature"
-          iter == 1 && kcopy!(n, x, b)  # x ← b # we start  at iteration 1
+          iter == 1 && kcopy!(n, x, r)
           solver.warm_start = false
           return solver
         end

--- a/src/minres.jl
+++ b/src/minres.jl
@@ -97,7 +97,7 @@ If negative curvature is detected at iteration `0`, the method returns the right
 * `x`: a dense vector of length `n`;
 * `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
 
-#### Reference
+#### References
 
 * C. C. Paige and M. A. Saunders, [*Solution of Sparse Indefinite Systems of Linear Equations*](https://doi.org/10.1137/0712047), SIAM Journal on Numerical Analysis, 12(4), pp. 617--629, 1975.
 

--- a/src/minres.jl
+++ b/src/minres.jl
@@ -74,7 +74,9 @@ MINRES produces monotonic residuals ‖r‖₂ and optimality residuals ‖Aᴴr
 * `M`: linear operator that models a Hermitian positive-definite matrix of size `n` used for centered preconditioning;
 * `ldiv`: define whether the preconditioner uses `ldiv!` or `mul!`;
 * `window`: number of iterations used to accumulate a lower bound on the error;
-* `linesearch`: if `true`, indicate that the solution is to be used in an inexact Newton method with linesearch. If negative curvature is detected at iteration k > 0, the solution of iteration k-1 is returned. If negative curvature is detected at iteration 0, the right-hand side is returned (i.e., the negative gradient);
+* `linesearch`: if `true`, indicate that the solution is to be used in an inexact Newton method with linesearch.
+If linesearch is true and nonpositive curvature is detected at iteration k = 0, the right-hand side is returned as solution (i.e., the negative gradient), and `solver.npc_dir` contains the preconditioned initial residual.
+If linesearch is true and nonpositive curvature is detected at iteration k = 0, the right-hand side is returned as solution (i.e., the negative gradient), and `solver.npc_dir` contains the preconditioned initial residual.
 * `λ`: regularization parameter;
 * `atol`: absolute stopping tolerance based on the residual norm;
 * `rtol`: relative stopping tolerance based on the residual norm;

--- a/src/minres.jl
+++ b/src/minres.jl
@@ -59,7 +59,6 @@ A is indefinite.
 
 MINRES produces monotonic residuals ‖r‖₂ and optimality residuals ‖Aᴴr‖₂.
 
-If linesearch is true and negative curvature is detected at iteration k = 0, the right-hand side is returned as solution (i.e., the negative gradient), and `solver.npc_dir` contains the preconditioned initial residual.
 
 #### Input arguments
 

--- a/src/minres.jl
+++ b/src/minres.jl
@@ -12,8 +12,9 @@
 # This implementation follows the original implementation by
 # Michael Saunders described in
 #
-# Negative curvature handling (following Liu, Yang, and Roosta, "MINRES: from negative curvature 
-# detection to monotonicity properties," SIAM Journal on Optimization 32, no. 4 (2022): 2636–2661):
+# Negative curvature detection follows
+# Liu, Yang, and Roosta, MINRES: from negative curvature detection to monotonicity properties,
+# SIAM Journal on Optimization, 32(4), pp. 2636--2661, 2022.
 #
 # C. C. Paige and M. A. Saunders, Solution of Sparse Indefinite Systems of Linear Equations,
 # SIAM Journal on Numerical Analysis, 12(4), pp. 617--629, 1975.

--- a/src/minres.jl
+++ b/src/minres.jl
@@ -59,8 +59,6 @@ A is indefinite.
 
 MINRES produces monotonic residuals ‖r‖₂ and optimality residuals ‖Aᴴr‖₂.
 
-If `linesearch` is true and negative curvature is detected, the solution depends on the iteration: at  k > 0, the solution from k-1 is returned with `solver.npc_dir` as the last residual; at k = 0, the right-hand side is returned with `solver.npc_dir` as the preconditioned initial residual.
-
 #### Input arguments
 
 * `A`: a linear operator that models a Hermitian matrix of dimension `n`;
@@ -75,9 +73,8 @@ If `linesearch` is true and negative curvature is detected, the solution depends
 * `M`: linear operator that models a Hermitian positive-definite matrix of size `n` used for centered preconditioning;
 * `ldiv`: define whether the preconditioner uses `ldiv!` or `mul!`;
 * `window`: number of iterations used to accumulate a lower bound on the error;
-* `linesearch`: if `true`, indicate that the solution is to be used in an inexact Newton method with linesearch.
-If linesearch is true and nonpositive curvature is detected at iteration k = 0, the right-hand side is returned as solution (i.e., the negative gradient), and `solver.npc_dir` contains the preconditioned initial residual.
-If linesearch is true and nonpositive curvature is detected at iteration k = 0, the right-hand side is returned as solution (i.e., the negative gradient), and `solver.npc_dir` contains the preconditioned initial residual.
+* `linesearch`: if `true`, indicate that the solution is to be used in an inexact Newton method with linesearch. If `linesearch` is true and negative curvature is detected, the solution depends on the iteration: at  k > 1, the solution from k-1 is returned with `solver.npc_dir` as the last residual; at k = 1, the right-hand side is returned with `solver.npc_dir` as the preconditioned initial residual. [Note that the MINRES solver start at iteration 1, so the first iteration is k = 1];
+
 * `λ`: regularization parameter;
 * `atol`: absolute stopping tolerance based on the residual norm;
 * `rtol`: relative stopping tolerance based on the residual norm;

--- a/src/minres.jl
+++ b/src/minres.jl
@@ -100,7 +100,6 @@ If negative curvature is detected at iteration `0`, the method returns the right
 #### References
 
 * C. C. Paige and M. A. Saunders, [*Solution of Sparse Indefinite Systems of Linear Equations*](https://doi.org/10.1137/0712047), SIAM Journal on Numerical Analysis, 12(4), pp. 617--629, 1975.
-
 * Liu, Yang & Roosta, Fred. (2022). A Newton-MR algorithm with complexity guarantees for nonconvex smooth unconstrained optimization. 10.48550/arXiv.2208.07095. 
 """
 function minres end

--- a/src/minres.jl
+++ b/src/minres.jl
@@ -331,7 +331,7 @@ kwargs_minres = (:M, :ldiv, :λ, :atol, :rtol, :etol, :conlim, :itmax, :timemax,
         stats.solved, stats.inconsistent = true, true
         stats.timer = start_time |> ktimer
         stats.status = "x is a minimum least-squares solution"
-        warm_start && kaxpy!(n, one(FC), Δx, x)
+        warm_start && kaxpy!(n, one(FC), Δx, x)#Linesearch
         solver.warm_start = false
         return solver
       end
@@ -345,6 +345,7 @@ kwargs_minres = (:M, :ldiv, :λ, :atol, :rtol, :etol, :conlim, :itmax, :timemax,
       # solved_mach = (ϵx ≥ β₁)
 
       # Stopping conditions based on user-provided tolerances.
+      #TODO test3 then update x to r2
       tired = iter ≥ itmax
       ill_cond_lim = (one(T) / Acond ≤ ctol)
       solved_lim = (test2 ≤ ε)

--- a/test/test_minres.jl
+++ b/test/test_minres.jl
@@ -40,7 +40,7 @@
       A, b = zero_rhs(FC=FC)
       (x, stats) = minres(A, b)
       @test norm(x) == 0
-      @test stats.status == "b is a zero-curvature directions"
+      @test stats.status == "x is a zero-residual solution"
 
       # Shifted system
       A, b = symmetric_indefinite(FC=FC)

--- a/test/test_minres.jl
+++ b/test/test_minres.jl
@@ -68,6 +68,7 @@
       resid = norm(r) / norm(b)
       @test(resid ≤ minres_tol * norm(A) * norm(x))
       @test(stats.solved)
+      @test stats.indefinite == false
 
       # Test linesearch
       A, b = symmetric_indefinite(FC=FC)
@@ -99,6 +100,16 @@
       @test stats.solved == true
       @test stats.indefinite == true
 
+
+      # Test if warm_start and linesearch are both true, it should through an error
+      A, b = symmetric_indefinite(FC=FC)
+      @test_throws MethodError minres(A, b, warm_start = true, linesearch = true)      
+      
+      # Test the constructor warm_start and linesearch when both are true, it should through an error 
+       # Test linesearch
+       A, b = symmetric_indefinite(FC=FC)
+       solver = MinresSolver(A, b)
+       @test_throws MethodError minres!(solver, A, b, linesearch=true, warm_start = true)
 
       # test callback function
       solver = MinresSolver(A, b)

--- a/test/test_minres.jl
+++ b/test/test_minres.jl
@@ -71,8 +71,16 @@
 
       # Test linesearch
       A, b = symmetric_indefinite(FC=FC)
-      x, stats = minres(A, b, linesearch=true)
+      solver = MinresSolver(A, b)
+      minres!(solver, A, b, linesearch=true)
+      x, stats, npc_dir = solver.x, solver.stats, solver.npc_dir
       @test stats.status == "nonpositive curvature"
+      @test stats.indefinite == true
+      # Verify that the returned direction indeed exhibits nonpositive curvature.
+      # For both real and complex cases, ensure to take the real part.
+      curvature = real(dot(npc_dir, A * npc_dir))
+      @test curvature <= 0
+
 
       # Test Linesearch which would stop on the first call since A is negative definite
       A, b = symmetric_indefinite(FC=FC; shift = 5)
@@ -81,6 +89,7 @@
       @test stats.niter == 1 # in Minres they add 1 to the number of iterations first step
       @test all(x .== b)
       @test stats.solved == true
+      @test stats.indefinite == true
 
       # Test when b^TAb=0 and linesearch is true
       A, b = system_zero_quad(FC=FC)
@@ -88,6 +97,7 @@
       @test stats.status == "nonpositive curvature"
       @test all(x .== b)
       @test stats.solved == true
+      @test stats.indefinite == true
 
 
       # test callback function

--- a/test/test_minres.jl
+++ b/test/test_minres.jl
@@ -84,12 +84,16 @@
 
       # Test Linesearch which would stop on the first call since A is negative definite
       A, b = symmetric_indefinite(FC=FC; shift = 5)
-      x, stats = minres(A, b, linesearch=true)
+      solver = MinresSolver(A, b)
+      minres!(solver, A, b, linesearch=true)
+      x, stats, npc_dir = solver.x, solver.stats, solver.npc_dir
       @test stats.status == "nonpositive curvature"
       @test stats.niter == 1 # in Minres they add 1 to the number of iterations first step
       @test all(x .== b)
       @test stats.solved == true
       @test stats.indefinite == true
+      curvature = real(dot(npc_dir, A * npc_dir))
+      @test curvature <= 0
 
       # Test when b^TAb=0 and linesearch is true
       A, b = system_zero_quad(FC=FC)

--- a/test/test_minres.jl
+++ b/test/test_minres.jl
@@ -69,6 +69,27 @@
       @test(resid ≤ minres_tol * norm(A) * norm(x))
       @test(stats.solved)
 
+      # Test linesearch
+      A, b = symmetric_indefinite(FC=FC)
+      x, stats = minres(A, b, linesearch=true)
+      @test stats.status == "nonpositive curvature"
+
+      # Test Linesearch which would stop on the first call since A is negative definite
+      A, b = symmetric_indefinite(FC=FC; shift = 5)
+      x, stats = minres(A, b, linesearch=true)
+      @test stats.status == "nonpositive curvature"
+      @test stats.niter == 1 # in Minres they add 1 to the number of iterations first step
+      @test all(x .== b)
+      @test stats.solved == true
+
+      # Test when b^TAb=0 and linesearch is true
+      A, b = system_zero_quad(FC=FC)
+      x, stats = minres(A, b, linesearch=true)
+      @test stats.status == "nonpositive curvature"
+      @test all(x .== b)
+      @test stats.solved == true
+
+
       # test callback function
       solver = MinresSolver(A, b)
       storage_vec = similar(b, size(A, 1))

--- a/test/test_minres.jl
+++ b/test/test_minres.jl
@@ -103,7 +103,7 @@
       @test stats.solved == true
       @test stats.indefinite == true
 
-      # Test if warm_start and linesearch are both true, it should through an error
+      # Test if warm_start and linesearch are both true, it should throw an error
       A, b = symmetric_indefinite(FC=FC)
       @test_throws MethodError minres(A, b, warm_start = true, linesearch = true)      
       

--- a/test/test_minres.jl
+++ b/test/test_minres.jl
@@ -82,7 +82,6 @@
       curvature = real(dot(npc_dir, A * npc_dir))
       @test curvature <= 0
 
-
       # Test Linesearch which would stop on the first call since A is negative definite
       A, b = symmetric_indefinite(FC=FC; shift = 5)
       x, stats = minres(A, b, linesearch=true)

--- a/test/test_minres.jl
+++ b/test/test_minres.jl
@@ -100,7 +100,6 @@
       @test stats.solved == true
       @test stats.indefinite == true
 
-
       # Test if warm_start and linesearch are both true, it should through an error
       A, b = symmetric_indefinite(FC=FC)
       @test_throws MethodError minres(A, b, warm_start = true, linesearch = true)      

--- a/test/test_minres.jl
+++ b/test/test_minres.jl
@@ -97,21 +97,18 @@
 
       # Test when b^TAb=0 and linesearch is true
       A, b = system_zero_quad(FC=FC)
-      x, stats = minres(A, b, linesearch=true)
+      solver = MinresSolver(A, b)
+      minres!(solver, A, b, linesearch=true)
+      x, stats, npc_dir = solver.x, solver.stats, solver.npc_dir
       @test stats.status == "nonpositive curvature"
       @test all(x .== b)
       @test stats.solved == true
       @test stats.indefinite == true
+      @test real(dot(npc_dir, A * npc_dir)) ≈ 0.0
 
       # Test if warm_start and linesearch are both true, it should throw an error
       A, b = symmetric_indefinite(FC=FC)
-      @test_throws MethodError minres(A, b, warm_start = true, linesearch = true)      
-      
-      # Test the constructor warm_start and linesearch when both are true, it should through an error 
-       # Test linesearch
-       A, b = symmetric_indefinite(FC=FC)
-       solver = MinresSolver(A, b)
-       @test_throws MethodError minres!(solver, A, b, linesearch=true, warm_start = true)
+      @test_throws MethodError minres(A, b, warm_start = true, linesearch = true)          
 
       # test callback function
       solver = MinresSolver(A, b)

--- a/test/test_minres.jl
+++ b/test/test_minres.jl
@@ -40,7 +40,7 @@
       A, b = zero_rhs(FC=FC)
       (x, stats) = minres(A, b)
       @test norm(x) == 0
-      @test stats.status == "x is a zero-residual solution"
+      @test stats.status == "b is a zero-curvature directions"
 
       # Shifted system
       A, b = symmetric_indefinite(FC=FC)

--- a/test/test_stats.jl
+++ b/test/test_stats.jl
@@ -1,6 +1,6 @@
 @testset "stats" begin
-  stats = Krylov.SimpleStats(0, true, true, Float64[1.0], Float64[2.0], Float64[], 1.234, "unknown")
-  stats2 = Krylov.SimpleStats(1, true, true, Float64[1.0], Float64[2.0], Float64[], 1.234, "unknown")
+  stats = Krylov.SimpleStats(0, true, true, false ,Float64[1.0], Float64[2.0], Float64[], 1.234, "unknown")
+  stats2 = Krylov.SimpleStats(1, true, true, false, Float64[1.0], Float64[2.0], Float64[], 1.234, "unknown")
   copyto!(stats2, stats)
   io = IOBuffer()
   show(io, stats)
@@ -10,6 +10,7 @@
   niter: 0
   solved: true
   inconsistent: true
+  indefinite: false
   residuals: [ 1.0e+00 ]
   Aresiduals: [ 2.0e+00 ]
   κ₂(A): []


### PR DESCRIPTION

**Description:**  
This pull request introduces a new line search routine to the MINRES algorithm, incorporating negative curvature detection as outlined in Algorithm 1 of:

>Liu, Yang & Roosta, Fred. (2022). *A Newton-MR algorithm with complexity guarantees for nonconvex smooth unconstrained optimization*. [[10.48550/arXiv.2208.07095](https://doi.org/10.48550/arXiv.2208.07095)](https://doi.org/10.48550/arXiv.2208.07095)

**Key Changes:**  
- **Negative Curvature Detection:**  
  - The implementation now detects negative curvature based on Algorithm 1 from the paper.  
  - When negative curvature is detected:
    - If the linesearch flag is enabled **and** it occurs on the first iteration, the algorithm returns `b`.
    - Otherwise, it returns the last computed `r1`.
- **Linesearch Flag:**  
  - Introduced a new flag to enable or disable the line search mechanism, allowing users to control the enhanced step size adjustments.

- **Testing & Documentation:**  
  - Updated tests and documentation to cover the new negative curvature detection and line search behavior.

