### PR TITLE
Fix Negative Curvature Status Overriding in CR.jl

### DIFF
--- a/src/cr.jl
+++ b/src/cr.jl
@@ -402,8 +402,8 @@ kwargs_cr = (:M, :ldiv, :radius, :linesearch, :γ, :atol, :rtol, :itmax, :timema
     # Termination status
     tired               && (status = "maximum number of iterations exceeded")
     on_boundary         && (status = "on trust-region boundary")
-    npcurv              && (status = "nonpositive curvature")
     solved              && (status = "solution good enough given atol and rtol")
+    npcurv              && (status = "nonpositive curvature")
     user_requested_exit && (status = "user-requested exit")
     overtimed           && (status = "time limit exceeded")
 

--- a/src/cr.jl
+++ b/src/cr.jl
@@ -335,7 +335,7 @@ kwargs_cr = (:M, :ldiv, :radius, :linesearch, :γ, :atol, :rtol, :itmax, :timema
 
       kaxpy!(n, α, p, x)
       xNorm = knorm(n, x)
-      xNorm ≈ radius && (on_boundary = true)
+      xNorm ≈ radius > 0 && (on_boundary = true)
       kaxpy!(n, -α, Mq, r)  # residual
       if MisI
         rNorm² = kdotr(n, r, r)
@@ -401,11 +401,11 @@ kwargs_cr = (:M, :ldiv, :radius, :linesearch, :γ, :atol, :rtol, :itmax, :timema
 
     # Termination status
     tired               && (status = "maximum number of iterations exceeded")
-    on_boundary         && (status = "on trust-region boundary")
     solved              && (status = "solution good enough given atol and rtol")
     user_requested_exit && (status = "user-requested exit")
     overtimed           && (status = "time limit exceeded")
     npcurv              && (status = "nonpositive curvature")
+    on_boundary         && (status = "on trust-region boundary")
 
     # Update x
     warm_start && kaxpy!(n, one(FC), Δx, x)

--- a/src/cr.jl
+++ b/src/cr.jl
@@ -403,9 +403,9 @@ kwargs_cr = (:M, :ldiv, :radius, :linesearch, :γ, :atol, :rtol, :itmax, :timema
     tired               && (status = "maximum number of iterations exceeded")
     on_boundary         && (status = "on trust-region boundary")
     solved              && (status = "solution good enough given atol and rtol")
-    npcurv              && (status = "nonpositive curvature")
     user_requested_exit && (status = "user-requested exit")
     overtimed           && (status = "time limit exceeded")
+    npcurv              && (status = "nonpositive curvature")
 
     # Update x
     warm_start && kaxpy!(n, one(FC), Δx, x)

--- a/test/test_cr.jl
+++ b/test/test_cr.jl
@@ -67,10 +67,10 @@
       x, stats = cr(A, b, linesearch=true)
       @test stats.status == "nonpositive curvature"
 
-      #test nonpositive curvature when radius > 0
+      #test on trust-region boundary when radius > 0
       A, b = symmetric_indefinite(FC=FC, shift = 5)
       x, stats = cr(A, b, radius = one(Float64))
-      @test stats.status == "nonpositive curvature"
+      @test stats.status == "on trust-region boundary"
 
       # Test Linesearch which would stop on the first call since A is negative definite
       A, b = symmetric_indefinite(FC=FC; shift = 5)

--- a/test/test_cr.jl
+++ b/test/test_cr.jl
@@ -66,11 +66,14 @@
       A, b = symmetric_indefinite(FC=FC)
       x, stats = cr(A, b, linesearch=true)
       @test stats.status == "nonpositive curvature"
+      # @test real(dot(x, A * x)) ≤ 0
 
-      #test on trust-region boundary when radius > 0
+      # Test on trust-region boundary when radius > 0
       A, b = symmetric_indefinite(FC=FC, shift = 5)
       x, stats = cr(A, b, radius = one(Float64))
       @test stats.status == "on trust-region boundary"
+      @test real(dot(x, A * x)) ≤ 0
+      @test norm(x) ≈ 1.0
 
       # Test Linesearch which would stop on the first call since A is negative definite
       A, b = symmetric_indefinite(FC=FC; shift = 5)
@@ -95,7 +98,7 @@
       @test stats.solved == true
 
  
-      # test callback function
+      # Test callback function
       A, b = symmetric_definite(FC=FC)
       solver = CrSolver(A, b)
       tol = 1.0e-1

--- a/test/test_cr.jl
+++ b/test/test_cr.jl
@@ -67,6 +67,11 @@
       x, stats = cr(A, b, linesearch=true)
       @test stats.status == "nonpositive curvature"
 
+      #test nonpositive curvature when radius > 0
+      A, b = symmetric_indefinite(FC=FC, shift = 5)
+      x, stats = cr(A, b, radius = one(Float64))
+      @test stats.status == "nonpositive curvature"
+
       # Test Linesearch which would stop on the first call since A is negative definite
       A, b = symmetric_indefinite(FC=FC; shift = 5)
       x, stats = cr(A, b, linesearch=true)


### PR DESCRIPTION

**Description:**  
This PR addresses an issue in `CR.jl` where the "nonpositive curvature" status was never set as intended. The problem arose from the current evaluation order:

```julia
solved = resid_decrease || npcurv || on_boundary
...
npcurv  && (status = "nonpositive curvature")
solved  && (status = "solution good enough given atol and rtol")
```

Because `solved` is defined as `resid_decrease || npcurv || on_boundary`, even when `npcurv` is `true`, `solved` also becomes `true`, leading to the `"solution good enough given atol and rtol"` status being assigned afterward. This inadvertently overrides the negative curvature status, meaning the `"nonpositive curvature"` status would never actually be set.

**Changes Made:**  
- **Reordered and Refactored Conditions:**  
  Modified the logic so that the negative curvature condition (`npcurv`) is checked and assigned **before** the general `solved` condition. This ensures that if negative curvature is detected, the `"nonpositive curvature"` status takes precedence.

