### PR TITLE
fix docs for CSR

### DIFF
--- a/docs/src/gpu.md
+++ b/docs/src/gpu.md
@@ -138,8 +138,8 @@ if CUDA.functional()
 
   # Solve Py = x
   function ldiv_ilu0!(P::CuSparseMatrixCSR, x, y, z)
-    ldiv!(z, UnitLowerTriangular(P), x)  # Forward substitution with L
-    ldiv!(y, UpperTriangular(P), z)      # Backward substitution with U
+    ldiv!(z, LowerTriangular(P), x)  # Forward substitution with L
+    ldiv!(y, UnitUpperTriangular(P), z)      # Backward substitution with U
     return y
   end
 


### PR DESCRIPTION
With
```
A_gpu = CuSparseMatrixCSR(sprand(T, n, n, 0.05) + I)
b_cpu = CuVector(rand(T, n))
julia> x, stats = bicgstab(A_gpu, b_gpu, M=opM)
```
we before got
```
(Float32[1.0198809, 4.0956926, 1.28241, -1.7407427, -2.9416926, -0.32771796, 0.4703165, 5.368891, -3.1246433, -1.7737565  …  0.97625387, 3.7136111, -1.0120717, 2.8906355, -1.1602651, 0.46383825, 2.538051, 1.448916, 2.4476223, -3.592498], SimpleStats
 niter: 54
 solved: false
 inconsistent: false
 indefinite: false
 residuals: []
 Aresiduals: []
 κ₂(A): []
 timer: 48.24ms
 status: breakdown αₖ == 0
)
```
but with this, get
```
(Float32[-0.4150291, 2.639933, -1.3929893, -1.1049638, -1.2597414, 0.0031488854, -1.918298, 5.812737, -1.3443595, -1.2016623  …  1.6825913, 3.0281372, -1.4967421, 3.0308955, -1.1063535, 0.2894782, 1.1083188, -0.1900546, 2.3867438, 1.4211323], SimpleStats
 niter: 66
 solved: true
 inconsistent: false
 indefinite: false
 residuals: []
 Aresiduals: []
 κ₂(A): []
 timer: 57.85ms
 status: solution good enough given atol and rtol
)
```