### PR TITLE
Loosen type-constraints don't enforce `<:AbstractVector`

### DIFF
--- a/src/gmres.jl
+++ b/src/gmres.jl
@@ -89,9 +89,9 @@ and [`krylov_solve!`](@ref) to run the Krylov method in-place.
 function gmres! end
 
 def_args_gmres = (:(A                    ),
-                  :(b::AbstractVector{FC}))
+                  :(b::AbstractArray{FC}))
 
-def_optargs_gmres = (:(x0::AbstractVector),)
+def_optargs_gmres = (:(x0::AbstractArray{FC}),)
 
 def_kwargs_gmres = (:(; M = I                            ),
                     :(; N = I                            ),
@@ -114,7 +114,7 @@ optargs_gmres = (:x0,)
 kwargs_gmres = (:M, :N, :ldiv, :restart, :reorthogonalization, :atol, :rtol, :itmax, :timemax, :verbose, :history, :callback, :iostream)
 
 @eval begin
-  function gmres!(workspace :: GmresWorkspace{T,FC,S}, $(def_args_gmres...); $(def_kwargs_gmres...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: AbstractVector{FC}}
+  function gmres!(workspace :: GmresWorkspace{T,FC,S}, $(def_args_gmres...); $(def_kwargs_gmres...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: AbstractArray{FC}}
 
     # Timer
     start_time = time_ns()

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -228,12 +228,12 @@ for (workspace, krylov, args, def_args, optargs, def_optargs, kwargs, def_kwargs
   end
 
   ## In-place
-  @eval krylov_solve!(workspace :: $workspace{T,FC,S}, $(def_args...); $(def_kwargs...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: AbstractVector{FC}} = $(krylov!)(workspace, $(args...); $(kwargs...))
+  @eval krylov_solve!(workspace :: $workspace{T,FC,S}, $(def_args...); $(def_kwargs...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: AbstractArray{FC}} = $(krylov!)(workspace, $(args...); $(kwargs...))
 
   for krylov_ip in (:krylov_solve!, krylov!)
     @eval begin
       if !isempty($optargs)
-        function $(krylov_ip)(workspace :: $workspace{T,FC,S}, $(def_args...), $(def_optargs...); $(def_kwargs...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: AbstractVector{FC}}
+        function $(krylov_ip)(workspace :: $workspace{T,FC,S}, $(def_args...), $(def_optargs...); $(def_kwargs...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: AbstractArray{FC}}
           start_time = time_ns()
           warm_start!(workspace, $(optargs...))
           elapsed_time = start_time |> ktimer


### PR DESCRIPTION
@lcw and I just run into a case where we have a data-structure `GridArray` that for the purpose of Krylov.jl acts like a Vector and we have defined the Krylov custom workspace API for, 
but for other reasons presents as `AbstractArray{Float64, 2}`.

IIRC the last time we spoke about this, there was an argument that the reason why Krylov.jl has this type constraint is so that the block-gmres API can use Matrix as an input.
