### PR TITLE
Allow vm and vn to be of different types

### DIFF
--- a/src/cgls.jl
+++ b/src/cgls.jl
@@ -126,7 +126,7 @@ args_cgls = (:A, :b)
 kwargs_cgls = (:M, :ldiv, :radius, :λ, :atol, :rtol, :itmax, :timemax, :verbose, :history, :callback, :iostream)
 
 @eval begin
-  function cgls!(workspace :: CglsWorkspace{T,FC,S}, $(def_args_cgls...); $(def_kwargs_cgls...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: AbstractVector{FC}}
+  function cgls!(workspace :: CglsWorkspace{T,FC,Sm,Sn}, $(def_args_cgls...); $(def_kwargs_cgls...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, Sm <: AbstractVector{FC}, Sn <: AbstractVector{FC}}
 
     # Timer
     start_time = time_ns()
@@ -142,13 +142,13 @@ kwargs_cgls = (:M, :ldiv, :radius, :λ, :atol, :rtol, :itmax, :timemax, :verbose
 
     # Check type consistency
     eltype(A) == FC || @warn "eltype(A) ≠ $FC. This could lead to errors or additional allocations in operator-vector products."
-    ktypeof(b) == S || error("ktypeof(b) must be equal to $S")
+    ktypeof(b) == Sm || error("ktypeof(b) must be equal to $Sm")
 
     # Compute the adjoint of A
     Aᴴ = A'
 
     # Set up workspace.
-    allocate_if(!MisI, workspace, :Mr, S, workspace.r)  # The length of Mr is m
+    allocate_if(!MisI, workspace, :Mr, Sm, workspace.r)  # The length of Mr is m
     x, p, s, r, q, stats = workspace.x, workspace.p, workspace.s, workspace.r, workspace.q, workspace.stats
     rNorms, ArNorms = stats.residuals, stats.Aresiduals
     reset!(stats)

--- a/src/gpmr.jl
+++ b/src/gpmr.jl
@@ -157,7 +157,7 @@ optargs_gpmr = (:x0, :y0)
 kwargs_gpmr = (:C, :D, :E, :F, :ldiv, :gsp, :λ, :μ, :reorthogonalization, :atol, :rtol, :itmax, :timemax, :verbose, :history, :callback, :iostream)
 
 @eval begin
-  function gpmr!(workspace :: GpmrWorkspace{T,FC,S}, $(def_args_gpmr...); $(def_kwargs_gpmr...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: AbstractVector{FC}}
+  function gpmr!(workspace :: GpmrWorkspace{T,FC,Sm,Sn}, $(def_args_gpmr...); $(def_kwargs_gpmr...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, Sm <: AbstractVector{FC}, Sn <: AbstractVector{FC}}
 
     # Timer
     start_time = time_ns()
@@ -181,8 +181,8 @@ kwargs_gpmr = (:C, :D, :E, :F, :ldiv, :gsp, :λ, :μ, :reorthogonalization, :ato
     # Check type consistency
     eltype(A) == FC || @warn "eltype(A) ≠ $FC. This could lead to errors or additional allocations in operator-vector products."
     eltype(B) == FC || @warn "eltype(B) ≠ $FC. This could lead to errors or additional allocations in operator-vector products."
-    ktypeof(b) == S || error("ktypeof(b) must be equal to $S")
-    ktypeof(c) == S || error("ktypeof(c) must be equal to $S")
+    ktypeof(b) == Sm || error("ktypeof(b) must be equal to $Sm")
+    ktypeof(c) == Sn || error("ktypeof(c) must be equal to $Sn")
 
     # Determine λ and μ associated to generalized saddle point systems.
     gsp && (λ = one(FC) ; μ = zero(FC))
@@ -192,10 +192,10 @@ kwargs_gpmr = (:C, :D, :E, :F, :ldiv, :gsp, :λ, :μ, :reorthogonalization, :ato
     warm_start && (μ ≠ 0) && !FisI && error("Warm-start with right preconditioners is not supported.")
 
     # Set up workspace.
-    allocate_if(!CisI, workspace, :q , S, workspace.x)  # The length of q is m
-    allocate_if(!DisI, workspace, :p , S, workspace.y)  # The length of p is n
-    allocate_if(!EisI, workspace, :wB, S, workspace.x)  # The length of wB is m
-    allocate_if(!FisI, workspace, :wA, S, workspace.y)  # The length of wA is n
+    allocate_if(!CisI, workspace, :q , Sm, workspace.x)  # The length of q is m
+    allocate_if(!DisI, workspace, :p , Sn, workspace.y)  # The length of p is n
+    allocate_if(!EisI, workspace, :wB, Sm, workspace.x)  # The length of wB is m
+    allocate_if(!FisI, workspace, :wA, Sn, workspace.y)  # The length of wA is n
     wA, wB, dA, dB, Δx, Δy = workspace.wA, workspace.wB, workspace.dA, workspace.dB, workspace.Δx, workspace.Δy
     x, y, V, U, gs, gc = workspace.x, workspace.y, workspace.V, workspace.U, workspace.gs, workspace.gc
     zt, R, stats = workspace.zt, workspace.R, workspace.stats

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -138,7 +138,7 @@ for (workspace, krylov, args, def_args, optargs, def_optargs, kwargs, def_kwargs
 
       krylov_solve(::Val{Symbol($krylov)}, $(def_args...); $(def_kwargs...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}} = $(krylov)($(args...); $(kwargs...))
     end
-  elseif krylov in (:diom, :dqgmres, :fom, :gmres, :fgmres, :gpmr)
+  elseif krylov in (:diom, :dqgmres, :fom, :gmres, :fgmres)
     @eval begin
       function $(krylov)($(def_args...); memory::Int = 20, $(def_kwargs...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
         start_time = time_ns()
@@ -156,6 +156,35 @@ for (workspace, krylov, args, def_args, optargs, def_optargs, kwargs, def_kwargs
         function $(krylov)($(def_args...), $(def_optargs...); memory::Int = 20, $(def_kwargs...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
           start_time = time_ns()
           workspace = $workspace(A, b; memory)
+          warm_start!(workspace, $(optargs...))
+          elapsed_time = start_time |> ktimer
+          timemax -= elapsed_time
+          $(krylov!)(workspace, $(args...); $(kwargs...))
+          workspace.stats.timer += elapsed_time
+          return results(workspace)
+        end
+
+        krylov_solve(::Val{Symbol($krylov)}, $(def_args...), $(def_optargs...); memory::Int = 20, $(def_kwargs...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}} = $(krylov)($(args...), $(optargs...); memory, $(kwargs...))
+      end
+    end
+  elseif krylov == :gpmr
+    @eval begin
+      function $(krylov)($(def_args...); memory::Int = 20, $(def_kwargs...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+        start_time = time_ns()
+        workspace = $workspace(KrylovConstructor(b, c, similar(b, 0), similar(c, 0)); memory)
+        elapsed_time = start_time |> ktimer
+        timemax -= elapsed_time
+        $(krylov!)(workspace, $(args...); $(kwargs...))
+        workspace.stats.timer += elapsed_time
+        return results(workspace)
+      end
+
+      krylov_solve(::Val{Symbol($krylov)}, $(def_args...); memory::Int = 20, $(def_kwargs...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}} = $(krylov)($(args...); memory, $(kwargs...))
+
+      if !isempty($optargs)
+        function $(krylov)($(def_args...), $(def_optargs...); memory::Int = 20, $(def_kwargs...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+          start_time = time_ns()
+          workspace = $workspace(KrylovConstructor(b, c, similar(b, 0), similar(c, 0)); memory)
           warm_start!(workspace, $(optargs...))
           elapsed_time = start_time |> ktimer
           timemax -= elapsed_time
@@ -194,6 +223,35 @@ for (workspace, krylov, args, def_args, optargs, def_optargs, kwargs, def_kwargs
         end
 
         krylov_solve(::Val{Symbol($krylov)}, $(def_args...), $(def_optargs...); window::Int = 5, $(def_kwargs...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}} = $(krylov)($(args...), $(optargs...); window, $(kwargs...))
+      end
+    end
+  elseif krylov in (:tricg, :trimr)
+    @eval begin
+      function $(krylov)($(def_args...); $(def_kwargs...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+        start_time = time_ns()
+        workspace = $workspace(KrylovConstructor(b, c, similar(b, 0), similar(c, 0)))
+        elapsed_time = start_time |> ktimer
+        timemax -= elapsed_time
+        $(krylov!)(workspace, $(args...); $(kwargs...))
+        workspace.stats.timer += elapsed_time
+        return results(workspace)
+      end
+
+      krylov_solve(::Val{Symbol($krylov)}, $(def_args...); $(def_kwargs...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}} = $(krylov)($(args...); $(kwargs...))
+
+      if !isempty($optargs)
+        function $(krylov)($(def_args...), $(def_optargs...); $(def_kwargs...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}}
+          start_time = time_ns()
+          workspace = $workspace(KrylovConstructor(b, c, similar(b, 0), similar(c, 0)))
+          warm_start!(workspace, $(optargs...))
+          elapsed_time = start_time |> ktimer
+          timemax -= elapsed_time
+          $(krylov!)(workspace, $(args...); $(kwargs...))
+          workspace.stats.timer += elapsed_time
+          return results(workspace)
+        end
+
+        krylov_solve(::Val{Symbol($krylov)}, $(def_args...), $(def_optargs...); $(def_kwargs...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}} = $(krylov)($(args...), $(optargs...); $(kwargs...))
       end
     end
   else

--- a/src/krylov_show.jl
+++ b/src/krylov_show.jl
@@ -63,13 +63,13 @@ end
 
 Statistics of `workspace` are displayed if `show_stats` is set to true.
 """
-function show(io :: IO, workspace :: Union{KrylovWorkspace{T,FC,S}, BlockKrylovWorkspace{T,FC,S}}; show_stats :: Bool=true) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: AbstractVector{FC}}
+function show(io :: IO, workspace :: Union{KrylovWorkspaceNext{T,FC,S}, BlockKrylovWorkspace{T,FC,S}}; show_stats :: Bool=true) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: AbstractVector{FC}}
   type_workspace = typeof(workspace)
   name_workspace = string(type_workspace.name.name)
   name_stats = string(typeof(workspace.stats).name.name)
   nbytes = sizeof(workspace)
   storage = format_bytes(nbytes)
-  architecture = S <: Vector ? "CPU" : "GPU"
+  architecture = S <: Vector ? "CPU" : "GPU"   # FIXME cannot assume that all non-Vector types are GPU types
   l1 = max(length(name_workspace), length(string(FC)) + 11)  # length("Precision: ") = 11
   nchar = type_workspace <: Union{CgLanczosShiftWorkspace, FomWorkspace, DiomWorkspace, DqgmresWorkspace, GmresWorkspace, FgmresWorkspace, GpmrWorkspace, BlockGmresWorkspace} ? 8 : 0  # length("Vector{}") = 8
   l2 = max(ndigits(workspace.m) + 7, length(architecture) + 14, length(string(S)) + nchar)  # length("nrows: ") = 7 and length("Architecture: ") = 14

--- a/src/lsqr.jl
+++ b/src/lsqr.jl
@@ -164,7 +164,7 @@ args_lsqr = (:A, :b)
 kwargs_lsqr = (:M, :N, :ldiv, :sqd, :λ, :radius, :etol, :axtol, :btol, :conlim, :atol, :rtol, :itmax, :timemax, :verbose, :history, :callback, :iostream)
 
 @eval begin
-  function lsqr!(workspace :: LsqrWorkspace{T,FC,S}, $(def_args_lsqr...); $(def_kwargs_lsqr...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: AbstractVector{FC}}
+  function lsqr!(workspace :: LsqrWorkspace{T,FC,Sm,Sn}, $(def_args_lsqr...); $(def_kwargs_lsqr...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, Sm <: AbstractVector{FC}, Sn <: AbstractVector{FC}}
 
     # Timer
     start_time = time_ns()
@@ -185,14 +185,14 @@ kwargs_lsqr = (:M, :N, :ldiv, :sqd, :λ, :radius, :etol, :axtol, :btol, :conlim,
 
     # Check type consistency
     eltype(A) == FC || @warn "eltype(A) ≠ $FC. This could lead to errors or additional allocations in operator-vector products."
-    ktypeof(b) == S || error("ktypeof(b) must be equal to $S")
+    ktypeof(b) == Sm || error("ktypeof(b) must be equal to $Sm")
 
     # Compute the adjoint of A
     Aᴴ = A'
 
     # Set up workspace.
-    allocate_if(!MisI, workspace, :u, S, workspace.Av)  # The length of u is m
-    allocate_if(!NisI, workspace, :v, S, workspace.x)   # The length of v is n
+    allocate_if(!MisI, workspace, :u, Sm, workspace.Av)  # The length of u is m
+    allocate_if(!NisI, workspace, :v, Sn, workspace.x)   # The length of v is n
     x, Nv, Aᴴu, w = workspace.x, workspace.Nv, workspace.Aᴴu, workspace.w
     Mu, Av, err_vec, stats = workspace.Mu, workspace.Av, workspace.err_vec, workspace.stats
     rNorms, ArNorms = stats.residuals, stats.Aresiduals

--- a/src/tricg.jl
+++ b/src/tricg.jl
@@ -146,7 +146,7 @@ optargs_tricg = (:x0, :y0)
 kwargs_tricg = (:M, :N, :ldiv, :spd, :snd, :flip, :τ, :ν, :atol, :rtol, :itmax, :timemax, :verbose, :history, :callback, :iostream)
 
 @eval begin
-  function tricg!(workspace :: TricgWorkspace{T,FC,S}, $(def_args_tricg...); $(def_kwargs_tricg...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: AbstractVector{FC}}
+  function tricg!(workspace :: TricgWorkspace{T,FC,Sm,Sn}, $(def_args_tricg...); $(def_kwargs_tricg...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, Sm <: AbstractVector{FC}, Sn <: AbstractVector{FC}}
 
     # Timer
     start_time = time_ns()
@@ -169,8 +169,8 @@ kwargs_tricg = (:M, :N, :ldiv, :spd, :snd, :flip, :τ, :ν, :atol, :rtol, :itmax
 
     # Check type consistency
     eltype(A) == FC || @warn "eltype(A) ≠ $FC. This could lead to errors or additional allocations in operator-vector products."
-    ktypeof(b) == S || error("ktypeof(b) must be equal to $S")
-    ktypeof(c) == S || error("ktypeof(c) must be equal to $S")
+    ktypeof(b) == Sm || error("ktypeof(b) must be equal to $Sm")
+    ktypeof(c) == Sn || error("ktypeof(c) must be equal to $Sn")
 
     # Determine τ and ν associated to SQD, SPD or SND systems.
     flip && (τ = -one(T) ; ν =  one(T))
@@ -185,8 +185,8 @@ kwargs_tricg = (:M, :N, :ldiv, :spd, :snd, :flip, :τ, :ν, :atol, :rtol, :itmax
     Aᴴ = A'
 
     # Set up workspace.
-    allocate_if(!MisI, workspace, :vₖ, S, workspace.x)  # The length of vₖ is m
-    allocate_if(!NisI, workspace, :uₖ, S, workspace.y)  # The length of uₖ is n
+    allocate_if(!MisI, workspace, :vₖ, Sm, workspace.x)  # The length of vₖ is m
+    allocate_if(!NisI, workspace, :uₖ, Sn, workspace.y)  # The length of uₖ is n
     Δy, yₖ, N⁻¹uₖ₋₁, N⁻¹uₖ, p = workspace.Δy, workspace.y, workspace.N⁻¹uₖ₋₁, workspace.N⁻¹uₖ, workspace.p
     Δx, xₖ, M⁻¹vₖ₋₁, M⁻¹vₖ, q = workspace.Δx, workspace.x, workspace.M⁻¹vₖ₋₁, workspace.M⁻¹vₖ, workspace.q
     gy₂ₖ₋₁, gy₂ₖ, gx₂ₖ₋₁, gx₂ₖ = workspace.gy₂ₖ₋₁, workspace.gy₂ₖ, workspace.gx₂ₖ₋₁, workspace.gx₂ₖ

--- a/src/trimr.jl
+++ b/src/trimr.jl
@@ -147,7 +147,7 @@ optargs_trimr = (:x0, :y0)
 kwargs_trimr = (:M, :N, :ldiv, :spd, :snd, :flip, :sp, :τ, :ν, :atol, :rtol, :itmax, :timemax, :verbose, :history, :callback, :iostream)
 
 @eval begin
-  function trimr!(workspace :: TrimrWorkspace{T,FC,S}, $(def_args_trimr...); $(def_kwargs_trimr...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: AbstractVector{FC}}
+  function trimr!(workspace :: TrimrWorkspace{T,FC,Sm,Sn}, $(def_args_trimr...); $(def_kwargs_trimr...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, Sm <: AbstractVector{FC}, Sn <: AbstractVector{FC}}
 
     # Timer
     start_time = time_ns()
@@ -173,8 +173,8 @@ kwargs_trimr = (:M, :N, :ldiv, :spd, :snd, :flip, :sp, :τ, :ν, :atol, :rtol, :
 
     # Check type consistency
     eltype(A) == FC || @warn "eltype(A) ≠ $FC. This could lead to errors or additional allocations in operator-vector products."
-    ktypeof(b) == S || error("ktypeof(b) must be equal to $S")
-    ktypeof(c) == S || error("ktypeof(c) must be equal to $S")
+    ktypeof(b) == Sm || error("ktypeof(b) must be equal to $Sm")
+    ktypeof(c) == Sn || error("ktypeof(c) must be equal to $Sn")
 
     # Determine τ and ν associated to SQD, SPD or SND systems.
     flip && (τ = -one(T) ; ν =  one(T))
@@ -190,8 +190,8 @@ kwargs_trimr = (:M, :N, :ldiv, :spd, :snd, :flip, :sp, :τ, :ν, :atol, :rtol, :
     Aᴴ = A'
 
     # Set up workspace.
-    allocate_if(!MisI, workspace, :vₖ, S, workspace.x)  # The length of vₖ is m
-    allocate_if(!NisI, workspace, :uₖ, S, workspace.y)  # The length of uₖ is n
+    allocate_if(!MisI, workspace, :vₖ, Sm, workspace.x)  # The length of vₖ is m
+    allocate_if(!NisI, workspace, :uₖ, Sn, workspace.y)  # The length of uₖ is n
     Δy, yₖ, N⁻¹uₖ₋₁, N⁻¹uₖ, p = workspace.Δy, workspace.y, workspace.N⁻¹uₖ₋₁, workspace.N⁻¹uₖ, workspace.p
     Δx, xₖ, M⁻¹vₖ₋₁, M⁻¹vₖ, q = workspace.Δx, workspace.x, workspace.M⁻¹vₖ₋₁, workspace.M⁻¹vₖ, workspace.q
     gy₂ₖ₋₃, gy₂ₖ₋₂, gy₂ₖ₋₁, gy₂ₖ = workspace.gy₂ₖ₋₃, workspace.gy₂ₖ₋₂, workspace.gy₂ₖ₋₁, workspace.gy₂ₖ

--- a/test/test_cgls.jl
+++ b/test/test_cgls.jl
@@ -47,6 +47,15 @@
         (x, stats) = cgls(A, b, M=D⁻¹, λ=1.0)
       end
 
+      # Test different types for input and output
+      A, b, c, D = small_sp(false, FC=FC)
+      workspace = CglsWorkspace(KrylovConstructor(TestVector(b), c))
+      cgls!(workspace, A, TestVector(b), M=inv(D), λ=1.0)
+      @test typeof(workspace.x) === typeof(c)
+      workspace = CglsWorkspace(KrylovConstructor(b, TestVector(c)))
+      cgls!(workspace, A, b, M=inv(D), λ=1.0)
+      @test typeof(workspace.x) === typeof(TestVector(c))
+
       # test callback function
       A, b, M = saddle_point(FC=FC)
       M⁻¹ = inv(M)

--- a/test/test_gpmr.jl
+++ b/test/test_gpmr.jl
@@ -301,8 +301,20 @@
         (x, y, stats) = gpmr(A, A', b, c, C=M⁻¹, D=N⁻¹)
       end
 
+      # Test different types for b and c
+      A, b, _ = saddle_point(FC=FC)
+      (x, y, stats) = gpmr(A, A', b, -b)
+      c = TestVector(-b)
+      workspace = GpmrWorkspace(KrylovConstructor(b, c))
+      @test typeof(workspace.x) === typeof(b)
+      @test typeof(workspace.y) === typeof(c)
+      gpmr!(workspace, A, A', b, c)
+      xt, yt = workspace.x, workspace.y
+      @test typeof(xt) === typeof(b)
+      @test typeof(yt) === typeof(c)
+
       # test callback function
-      # Not testing with an interesting callback because workspace.x and workspace.y are not updated 
+      # Not testing with an interesting callback because workspace.x and workspace.y are not updated
       # until the end of the algorithm (TODO: be able to evaluate workspace.x and workspace.y ?)
       A, b, c = square_adjoint(FC=FC)
       workspace = GpmrWorkspace(A, b; memory = 20)

--- a/test/test_interface.jl
+++ b/test/test_interface.jl
@@ -296,6 +296,14 @@ function test_krylov_workspaces(FC; krylov_constructor::Bool=false, use_val::Boo
           @test solution(workspace, 1) === workspace.x
           @test solution(workspace, 2) === workspace.y
           @test solution_count(workspace) == 2
+
+          if method == :gpmr
+            x, y, stats = use_val ? @inferred(krylov_solve(Val(method), Ao, Au, TestVector(b), c)) : krylov_solve(method, Ao, Au, TestVector(b), c)
+            @test typeof(x) === typeof(TestVector(b))
+          else
+            x, y, stats = use_val ? @inferred(krylov_solve(Val(method), Au, TestVector(c), b)) : krylov_solve(method, Au, TestVector(c), b)
+            @test typeof(x) === typeof(TestVector(c))
+          end
         end
 
         if method ∈ (:usymlq, :usymqr)

--- a/test/test_lsqr.jl
+++ b/test/test_lsqr.jl
@@ -88,6 +88,15 @@
         (x, stats) = lsqr(A, b, M=M⁻¹, N=N⁻¹, sqd=true)
       end
 
+      # Test different types for input and output
+      A, b, c, D = small_sp(false, FC=FC)
+      workspace = LsqrWorkspace(KrylovConstructor(TestVector(b), c))
+      lsqr!(workspace, A, TestVector(b), M=inv(D), λ=1.0)
+      @test typeof(workspace.x) === typeof(c)
+      workspace = LsqrWorkspace(KrylovConstructor(b, TestVector(c)))
+      lsqr!(workspace, A, b, M=inv(D), λ=1.0)
+      @test typeof(workspace.x) === typeof(TestVector(c))
+
       # test callback function
       A, b, M = saddle_point(FC=FC)
       M⁻¹ = inv(M)

--- a/test/test_tricg.jl
+++ b/test/test_tricg.jl
@@ -166,6 +166,18 @@
         @test sqrt(dot(r, inv(H) * r)) / sqrt(dot([b; c], inv(H) * [b; c])) ≤ tricg_tol
       end
 
+      # Test different types for b and c
+      A, b, _ = saddle_point(FC=FC)
+      (x, y, stats) = tricg(A, b, -b)
+      c = TestVector(-b)
+      workspace = TricgWorkspace(KrylovConstructor(b, c))
+      @test typeof(workspace.x) === typeof(b)
+      @test typeof(workspace.y) === typeof(c)
+      tricg!(workspace, A, b, c)
+      xt, yt = workspace.x, workspace.y
+      @test typeof(xt) === typeof(b)
+      @test typeof(yt) === typeof(c)
+
       for transpose ∈ (false, true)
         A, b, c = ssy_mo_breakdown(transpose)
 

--- a/test/test_trimr.jl
+++ b/test/test_trimr.jl
@@ -206,6 +206,18 @@
         @test sqrt(dot(r, inv(H) * r)) / sqrt(dot([b; c], inv(H) * [b; c])) ≤ trimr_tol
       end
 
+      # Test different types for b and c
+      A, b, _ = saddle_point(FC=FC)
+      (x, y, stats) = trimr(A, b, -b)
+      c = TestVector(-b)
+      workspace = TrimrWorkspace(KrylovConstructor(b, c))
+      @test typeof(workspace.x) === typeof(b)
+      @test typeof(workspace.y) === typeof(c)
+      trimr!(workspace, A, b, c)
+      xt, yt = workspace.x, workspace.y
+      @test typeof(xt) === typeof(b)
+      @test typeof(yt) === typeof(c)
+
       for transpose ∈ (false, true)
         A, b, c = ssy_mo_breakdown(transpose)
 

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -5,6 +5,15 @@ include("gen_lsq.jl")
 include("check_min_norm.jl")
 include("callback_utils.jl")
 
+struct TestVector{T} <: AbstractVector{T}
+    data::Vector{T}
+end
+TestVector{T}(::UndefInitializer, n::Integer) where {T} = TestVector{T}(Vector{T}(undef, n))
+Base.size(v::TestVector) = size(v.data)
+Base.getindex(v::TestVector, i::Int) = v.data[i]
+Base.setindex!(v::TestVector, val, i::Int) = (v.data[i] = val)
+Base.similar(v::TestVector, ::Type{S}, dims::Dims) where {S} = TestVector{S}(similar(v.data, S, dims))
+
 # Symmetric and positive definite systems.
 function symmetric_definite(n :: Int=10; FC=Float64)
   α = FC <: Complex ? FC(im) : one(FC)


### PR DESCRIPTION
~This is a proof-of-concept that in a~ For problems `Ax=b`, this allows the vector space
of `x` (`vn`) to be different from the vector space of `b` (`vm`); also for some bipartite problems

    [A B; C D] [x; y] = [b; c]

it allows `x` and `y` to be of different types.

This PR implements the actual change ~only for CGLS~ for CGLS, LSQR, TRICG, TRIMR, and GPMR.
Extending to other solvers is left as an exercise for the reader.

Fixes #1037