### PR TITLE
TRICG & TRIMR: support warm-start with ldiv=true

### DIFF
--- a/src/tricg.jl
+++ b/src/tricg.jl
@@ -75,7 +75,7 @@ For an in-place variant that reuses memory across solves, see [`tricg!`](@ref).
 * `y0`: a vector of length `n` that represents an initial guess of the solution `y`.
 
 Warm-starting is supported only when:
-* ldiv = true; or
+* `ldiv = true`, in which case `M` and `N` must support `mul!` as well as `ldiv!` (PDMats.jl may be helpful); or
 * `M` and `N` are either `I` or the corresponding coefficient (`τ` or `ν`) is zero.
 
 #### Keyword arguments
@@ -292,7 +292,6 @@ kwargs_tricg = (:M, :N, :ldiv, :spd, :snd, :flip, :τ, :ν, :atol, :rtol, :itmax
     # Compute ‖r₀‖² = (γ₁)² + (β₁)²
     rNorm = sqrt(γₖ^2 + βₖ^2)
     history && push!(rNorms, rNorm)
-    ε = atol + rtol * rNorm
 
     (verbose > 0) && @printf(iostream, "%5s  %7s  %7s  %7s  %5s\n", "k", "‖rₖ‖", "βₖ₊₁", "γₖ₊₁", "timer")
     kdisplay(iter, verbose) && @printf(iostream, "%5d  %7.1e  %7.1e  %7.1e  %.2fs\n", iter, rNorm, βₖ, γₖ, start_time |> ktimer)

--- a/src/trimr.jl
+++ b/src/trimr.jl
@@ -69,7 +69,9 @@ For an in-place variant that reuses memory across solves, see [`trimr!`](@ref).
 * `x0`: a vector of length `m` that represents an initial guess of the solution `x`;
 * `y0`: a vector of length `n` that represents an initial guess of the solution `y`.
 
-Warm-starting is supported only when `M` and `N` are either `I` or the corresponding coefficient (`τ` or `ν`) is zero.
+Warm-starting is supported only when:
+* `ldiv = true`, in which case `M` and `N` must support `mul!` as well as `ldiv!` (PDMats.jl may be helpful); or
+* `M` and `N` are either `I` or the corresponding coefficient (`τ` or `ν`) is zero.
 
 #### Keyword arguments
 

--- a/test/test_warm_start.jl
+++ b/test/test_warm_start.jl
@@ -130,6 +130,14 @@ function test_warm_start(FC)
     @test stats.niter <= 1
     @test_throws "x0 should have size $(length(x30))" trimr(A3x2, b3, c2, [1.0], y20)
     @test_throws "y0 should have size $(length(y20))" trimr(A3x2, b3, c2, x30, [1.0])
+
+    N = Diagonal([0.8, 1.2])
+    x30, y20, _ = trimr(A3x2, b3, c2; N, ldiv=true)
+    x3, y2, stats = trimr(A3x2, b3, c2, x30, y20; N, ldiv=true)
+    @test x3 ≈ x30 atol=1e-12
+    @test y2 ≈ y20 atol=1e-12
+    @test stats.niter <= 1
+
     workspace = TrimrWorkspace(A, b)
     krylov_solve!(workspace, A, b, b, x0, y0)
     r = [b - workspace.x - A * workspace.y; b - A' * workspace.x + workspace.y]


### PR DESCRIPTION
This addresses some potential inconsistencies in `tricg` and `trimr` in
the case `ldiv=true`:

- docs: fixes the statement about the relationship between `E`/`F` and
  `M`/`N`
- docs: describes the residual-norm in terms of `E`/`F` rather than
  `M`/`N` (only the former are unambiguous, given the problem statement)
- adds support for warm-starting when `ldiv=true` for arbitrary `M`/`N`


~NOTE: this is a WIP as `trimr` has not yet been modified. Once we settle on the `tricg` changes, I'll port the same changes to `trimr`.~