### PR TITLE
Upgrade LNLQ

### DIFF
--- a/src/bilq.jl
+++ b/src/bilq.jl
@@ -210,7 +210,7 @@ kwargs_bilq = (:c, :transfer_to_bicg, :M, :N, :ldiv, :atol, :rtol, :itmax, :time
     sₖ₋₁ = sₖ = zero(FC)           # Givens sines used for the LQ factorization of Tₖ
     kfill!(d̅, zero(FC))            # Last column of D̅ₖ = Vₖ(Qₖ)ᴴ
     ζₖ₋₁ = ζbarₖ = zero(FC)        # ζₖ₋₁ and ζbarₖ are the last components of z̅ₖ = (L̅ₖ)⁻¹β₁e₁
-    ζₖ₋₂ = ηₖ = zero(FC)           # ζₖ₋₂ and ηₖ are used to update ζₖ₋₁ and ζbarₖ
+    ηₖ₋₁ = ηₖ = ζₖ₋₂ = zero(FC)    # ηₖ₋₁, ηₖ and ζₖ₋₂ are used to update ζₖ₋₁ and ζbarₖ
     δbarₖ₋₁ = δbarₖ = zero(FC)     # Coefficients of Lₖ₋₁ and L̅ₖ modified over the course of two iterations
     norm_vₖ = bNorm / βₖ           # ‖vₖ‖ is used for residual norm estimates
 
@@ -292,7 +292,6 @@ kwargs_bilq = (:c, :transfer_to_bicg, :M, :N, :ldiv, :atol, :rtol, :itmax, :time
       # [δ₁    0  ] [  ζ₁ ] = [β₁]
       # [λ₁  δbar₂] [ζbar₂]   [0 ]
       if iter == 2
-        ηₖ₋₁ = ηₖ
         ζₖ₋₁ = ηₖ₋₁ / δₖ₋₁
         ηₖ   = -λₖ₋₁ * ζₖ₋₁
       end
@@ -301,7 +300,6 @@ kwargs_bilq = (:c, :transfer_to_bicg, :M, :N, :ldiv, :atol, :rtol, :itmax, :time
       #                     [ζbarₖ]
       if iter ≥ 3
         ζₖ₋₂ = ζₖ₋₁
-        ηₖ₋₁ = ηₖ
         ζₖ₋₁ = ηₖ₋₁ / δₖ₋₁
         ηₖ   = -ϵₖ₋₂ * ζₖ₋₂ - λₖ₋₁ * ζₖ₋₁
       end
@@ -358,9 +356,10 @@ kwargs_bilq = (:c, :transfer_to_bicg, :M, :N, :ldiv, :atol, :rtol, :itmax, :time
         rNorm_cg = abs(ρₖ) * norm_vₖ₊₁
       end
 
-      # Update sₖ₋₁, cₖ₋₁, γₖ, βₖ, δbarₖ₋₁ and norm_vₖ.
+      # Update sₖ₋₁, cₖ₋₁, ηₖ₋₁, γₖ, βₖ, δbarₖ₋₁ and norm_vₖ.
       sₖ₋₁    = sₖ
       cₖ₋₁    = cₖ
+      ηₖ₋₁    = ηₖ
       γₖ      = γₖ₊₁
       βₖ      = βₖ₊₁
       δbarₖ₋₁ = δbarₖ

--- a/src/usymlq.jl
+++ b/src/usymlq.jl
@@ -176,18 +176,18 @@ kwargs_usymlq = (:transfer_to_usymcg, :atol, :rtol, :itmax, :timemax, :verbose, 
     (verbose > 0) && @printf(iostream, "%5s  %7s  %5s\n", "k", "‖rₖ‖", "timer")
     kdisplay(iter, verbose) && @printf(iostream, "%5d  %7.1e  %.2fs\n", iter, bNorm, start_time |> ktimer)
 
-    βₖ = knorm(m, r₀)           # β₁ = ‖v₁‖ = ‖r₀‖
-    γₖ = knorm(n, c)            # γ₁ = ‖u₁‖ = ‖c‖
-    kfill!(vₖ₋₁, zero(FC))      # v₀ = 0
-    kfill!(uₖ₋₁, zero(FC))      # u₀ = 0
-    kdivcopy!(m, vₖ, r₀, βₖ)    # v₁ = (b - Ax₀) / β₁
-    kdivcopy!(n, uₖ, c, γₖ)     # u₁ = c / γ₁
-    cₖ₋₁ = cₖ = -one(T)         # Givens cosines used for the LQ factorization of Tₖ
-    sₖ₋₁ = sₖ = zero(FC)        # Givens sines used for the LQ factorization of Tₖ
-    kfill!(d̅, zero(FC))         # Last column of D̅ₖ = Uₖ(Qₖ)ᴴ
-    ζₖ₋₁ = ζbarₖ = zero(FC)     # ζₖ₋₁ and ζbarₖ are the last components of z̅ₖ = (L̅ₖ)⁻¹β₁e₁
-    ζₖ₋₂ = ηₖ = zero(FC)        # ζₖ₋₂ and ηₖ are used to update ζₖ₋₁ and ζbarₖ
-    δbarₖ₋₁ = δbarₖ = zero(FC)  # Coefficients of Lₖ₋₁ and Lₖ modified over the course of two iterations
+    βₖ = knorm(m, r₀)            # β₁ = ‖v₁‖ = ‖r₀‖
+    γₖ = knorm(n, c)             # γ₁ = ‖u₁‖ = ‖c‖
+    kfill!(vₖ₋₁, zero(FC))       # v₀ = 0
+    kfill!(uₖ₋₁, zero(FC))       # u₀ = 0
+    kdivcopy!(m, vₖ, r₀, βₖ)     # v₁ = (b - Ax₀) / β₁
+    kdivcopy!(n, uₖ, c, γₖ)      # u₁ = c / γ₁
+    cₖ₋₁ = cₖ = -one(T)          # Givens cosines used for the LQ factorization of Tₖ
+    sₖ₋₁ = sₖ = zero(FC)         # Givens sines used for the LQ factorization of Tₖ
+    kfill!(d̅, zero(FC))          # Last column of D̅ₖ = Uₖ(Qₖ)ᴴ
+    ζₖ₋₁ = ζbarₖ = zero(FC)      # ζₖ₋₁ and ζbarₖ are the last components of z̅ₖ = (L̅ₖ)⁻¹β₁e₁
+    ηₖ₋₁ = ηₖ = ζₖ₋₂ = zero(FC)  # ηₖ₋₁, ηₖ and ζₖ₋₂ are used to update ζₖ₋₁ and ζbarₖ
+    δbarₖ₋₁ = δbarₖ = zero(FC)   # Coefficients of Lₖ₋₁ and Lₖ modified over the course of two iterations
 
     # Stopping criterion.
     solved_lq = bNorm ≤ ε
@@ -258,7 +258,6 @@ kwargs_usymlq = (:transfer_to_usymcg, :atol, :rtol, :itmax, :timemax, :verbose, 
       # [δ₁    0  ] [  ζ₁ ] = [β₁]
       # [λ₁  δbar₂] [ζbar₂]   [0 ]
       if iter == 2
-        ηₖ₋₁ = ηₖ
         ζₖ₋₁ = ηₖ₋₁ / δₖ₋₁
         ηₖ   = -λₖ₋₁ * ζₖ₋₁
       end
@@ -267,7 +266,6 @@ kwargs_usymlq = (:transfer_to_usymcg, :atol, :rtol, :itmax, :timemax, :verbose, 
       #                     [ζbarₖ]
       if iter ≥ 3
         ζₖ₋₂ = ζₖ₋₁
-        ηₖ₋₁ = ηₖ
         ζₖ₋₁ = ηₖ₋₁ / δₖ₋₁
         ηₖ   = -ϵₖ₋₂ * ζₖ₋₂ - λₖ₋₁ * ζₖ₋₁
       end
@@ -321,9 +319,10 @@ kwargs_usymlq = (:transfer_to_usymcg, :atol, :rtol, :itmax, :timemax, :verbose, 
         rNorm_cg = abs(ρₖ)
       end
 
-      # Update sₖ₋₁, cₖ₋₁, γₖ, βₖ and δbarₖ₋₁.
+      # Update sₖ₋₁, cₖ₋₁, ηₖ₋₁, γₖ, βₖ and δbarₖ₋₁.
       sₖ₋₁    = sₖ
       cₖ₋₁    = cₖ
+      ηₖ₋₁    = ηₖ
       γₖ      = γₖ₊₁
       βₖ      = βₖ₊₁
       δbarₖ₋₁ = δbarₖ

--- a/test/test_craig.jl
+++ b/test/test_craig.jl
@@ -148,6 +148,14 @@ end
       @test cb_n2(workspace)
 
       @test_throws TypeError craig(A, b, callback = workspace -> "string", history = true)
+
+      # Test small least-norm problem
+      A, b = small_ln(FC=FC)
+      x, y, stats = craig(A, b)
+      r = b - A * x
+      resid = norm(r) / norm(b)
+      @test resid ≤ craig_tol
+      @test norm(x - A' * y) ≤ craig_tol * norm(x)
     end
   end
 end

--- a/test/test_craigmr.jl
+++ b/test/test_craigmr.jl
@@ -157,6 +157,14 @@ end
       @test cb_n2(workspace)
 
       @test_throws TypeError craigmr(A, b, callback = workspace -> "string", history = true)
+
+      # Test small least-norm problem
+      A, b = small_ln(FC=FC)
+      x, y, stats = craigmr(A, b)
+      r = b - A * x
+      resid = norm(r) / norm(b)
+      @test resid ≤ craigmr_tol
+      @test norm(x - A' * y) ≤ craigmr_tol * norm(x)
     end
   end
 end

--- a/test/test_lnlq.jl
+++ b/test/test_lnlq.jl
@@ -147,6 +147,14 @@ end
         @test cb_n2(workspace)
 
         @test_throws TypeError lnlq(A, b, callback = workspace -> "string", history = true)
+
+        # Test small least-norm problem
+        A, b = small_ln(FC=FC)
+        x, y, stats = lnlq(A, b)
+        r = b - A * x
+        resid = norm(r) / norm(b)
+        @test resid ≤ lnlq_tol
+        @test norm(x - A' * y) ≤ lnlq_tol * norm(x)
       end
     end
   end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -410,6 +410,12 @@ function ssy_mo_breakdown3(FC=Float64)
   return A, b, c
 end
 
+function small_ln(; FC=Float64)
+  A = FC[0 1]
+  b = FC[1]
+  return A, b
+end
+
 # Check that a KrylovStats is reset.
 function check_reset(stats :: KS) where KS <: Krylov.KrylovStats
   for field in fieldnames(KS)


### PR DESCRIPTION
close #1050 

In `lnlq`, we are always doing one more iteration at the end because we can update the solution `(x, y)` for free.
The issue is that if we have exactly an happy breakdown, we can't do one more step (for the CG point).
It is not defined and it leads to `NaN`.

I also added the same trick that `bilq` and `usymlq` to update the solution of a "triangular" system (subproblem) that depends on the coefficient `ϵbarₖ` of the factorization of `L_k`.
In `bilq` and `usymlq` this coefficient can be zero.

Because of the relation with the Lanczos process, we can probably prove that this coefficient can't be zero except if `AA'` is singular (SSPD) and `b` is not in the range of `AA'`. But LNLQ can't handle it in all cases because the problem is inconsistent...

However, even if the division by ` ϵbarₖ` is "safe", it is more stable to wait the final value ` ϵₖ` to compute `ζₖ`.