### PR TITLE
Reset stats when reusing Krylov solver workspaces

### DIFF
--- a/src/cg.jl
+++ b/src/cg.jl
@@ -270,7 +270,7 @@ kwargs_cg = (:M, :ldiv, :radius, :linesearch, :atol, :rtol, :itmax, :timemax, :v
 
     # Termination status
     solved && on_boundary             && (status = "on trust-region boundary")
-    solved && stats.indefinite        && (status = "nonpositive curvature detected")
+    solved && stats.indefinite        && (status = "nonpositive curvature")
     solved && (status == "unknown")   && (status = "solution good enough given atol and rtol")
     zero_curvature                    && (status = "zero curvature detected")
     tired                             && (status = "maximum number of iterations exceeded")

--- a/src/krylov_stats.jl
+++ b/src/krylov_stats.jl
@@ -37,6 +37,8 @@ function reset!(stats :: SimpleStats)
   empty!(stats.residuals)
   empty!(stats.Aresiduals)
   empty!(stats.Acond)
+  stats.indefinite = false
+  stats.npcCount = 0
 end
 
 function copyto!(dest :: SimpleStats, src :: SimpleStats)

--- a/test/test_minres.jl
+++ b/test/test_minres.jl
@@ -70,6 +70,43 @@
       @test(stats.solved)
       @test stats.indefinite == false
 
+      # Test: Ensure stats are reset when reusing workspace
+      # (pᵀAp < 0)
+      A = FC[
+        10.0 0.0 0.0 0.0;
+        0.0 8.0 0.0 0.0;
+        0.0 0.0 5.0 0.0;
+        0.0 0.0 0.0 -1.0
+      ]
+      b = FC[1.0, 1.0, 1.0, 0.1]
+      
+      # Initialize workspace and solve
+      solver = MinresWorkspace(A, b)
+      minres!(solver, A, b; linesearch=true)
+      
+      # Verify the "npc" state was recorded
+      @test solver.stats.npcCount == 2
+      @test solver.stats.indefinite == true
+      @test solver.stats.status == "nonpositive curvature"
+
+      # Reuse the SAME solver on a Positive Definite System
+
+      A = FC[
+        10.0 0.0 0.0 0.0;
+        0.0 8.0 0.0 0.0;
+        0.0 0.0 5.0 0.0;
+        0.0 0.0 0.0 1.0
+      ]
+      b = FC[1.0, 1.0, 1.0, 1.0]
+
+      # Run the solver again on the same workspace
+      minres!(solver, A, b; linesearch=true)
+
+      # Verify the RESET works
+      @test solver.stats.npcCount == 0
+      @test solver.stats.indefinite == false
+      @test solver.stats.solved == true
+
       # Test linesearch
       A, b = symmetric_indefinite(FC=FC)
       workspace = MinresWorkspace(A, b)


### PR DESCRIPTION
Adds explicit resetting of 'indefinite' and 'npcCount' fields in SimpleStats to ensure solver statistics are cleared when reusing workspaces. Updates tests for CG, CR, MINRES, and MINRES-QLP to verify correct stats reset behavior between runs on indefinite and positive definite systems. Also standardizes the 'nonpositive curvature' status message.