### PR TITLE
[USYMLQR] Remove support for preconditioners

### DIFF
--- a/docs/src/examples/usymlqr.md
+++ b/docs/src/examples/usymlqr.md
@@ -1,6 +1,6 @@
 ```@example usymlqr
-using Krylov, LinearOperators
 using LinearAlgebra, Printf, SparseArrays
+using Krylov
 
 # Identity matrix.
 eye(n::Int) = sparse(1.0 * I, n, n)
@@ -38,15 +38,5 @@ K = [I A; A' zeros(n,n)]
 d = [0*b; c]
 r = d - K * [x; y]
 resid = norm(r)
-@printf("USYMLQR: Relative residual: %8.1e\n", resid)
-
-# [D   A] [x] = [b]
-# [Aᴴ  0] [y]   [c]
-opH = BlockDiagonalOperator(inv(D), eye(n))
-(x, y, stats) = usymlqr(A, b, c, M=inv(D))
-K = [D A; A' zeros(n,n)]
-d = [b; c]
-r = d - K * [x; y]
-resid = sqrt(dot(r, opH * r))
 @printf("USYMLQR: Relative residual: %8.1e\n", resid)
 ```

--- a/docs/src/preconditioners.md
+++ b/docs/src/preconditioners.md
@@ -111,15 +111,13 @@ Methods concerned: [`CGNE`](@ref cgne), [`CRMR`](@ref crmr), [`LNLQ`](@ref lnlq)
 
 ### Saddle-point and symmetric quasi-definite systems
 
-[`TriCG`](@ref tricg), [`TriMR`](@ref trimr) and [`USYMLQR`](@ref usymlqr) can take advantage of the structure of Hermitian systems $Kz = d$ with the 2x2 block structure
+[`TriCG`](@ref tricg) and [`TriMR`](@ref trimr) can take advantage of the structure of Hermitian systems $Kz = d$ with the 2x2 block structure
 ```math
   \begin{bmatrix} \tau E & \phantom{-}A \\ A^H & \nu F \end{bmatrix} \begin{bmatrix} x \\ y \end{bmatrix} = \begin{bmatrix} b \\ c \end{bmatrix},
 ```
 | Preconditioners | $E^{-1}$              | $E$                  | $F^{-1}$              | $F$                  |
 |:---------------:|:---------------------:|:--------------------:|:---------------------:|:--------------------:|
 | Arguments       | `M` with `ldiv=false` | `M` with `ldiv=true` | `N` with `ldiv=false` | `N` with `ldiv=true` |
-
-In the special case of [USYMLQR](@ref usymlqr), $\tau = 1$ and $\nu = 0$.
 
 !!! warning
     The preconditioners `M` and `N` must be hermitian and positive definite.
@@ -135,7 +133,7 @@ In the special case of [USYMLQR](@ref usymlqr), $\tau = 1$ and $\nu = 0$.
 | Arguments       | `C` and `E` with `ldiv=false` | `C` and `E` with `ldiv=true` | `D` and `F` with `ldiv=false` | `D` and `F` with `ldiv=true` |
 
 !!! note
-    Our implementations of [`BiLQ`](@ref bilq), [`QMR`](@ref qmr), [`BiLQR`](@ref bilqr), [`USYMLQ`](@ref usymlq), [`USYMQR`](@ref usymqr) and [`TriLQR`](@ref trilqr) don't support preconditioning.
+    Our implementations of [`BiLQ`](@ref bilq), [`QMR`](@ref qmr), [`BiLQR`](@ref bilqr), [`USYMLQ`](@ref usymlq), [`USYMQR`](@ref usymqr), [`USYMLQR`](@ref usymlqr) and [`TriLQR`](@ref trilqr) don't support preconditioning.
 
 ## Packages that provide preconditioners
 

--- a/src/krylov_workspaces.jl
+++ b/src/krylov_workspaces.jl
@@ -3239,10 +3239,10 @@ mutable struct UsymlqrWorkspace{T,FC,Sm,Sn} <: _KrylovWorkspace{T,FC,Sm,Sn}
   x          :: Sm
   y          :: Sn
   z          :: Sn
-  M⁻¹vₖ₋₁    :: Sm
-  M⁻¹vₖ      :: Sm
-  N⁻¹uₖ₋₁    :: Sn
-  N⁻¹uₖ      :: Sn
+  vₖ₋₁       :: Sm
+  vₖ         :: Sm
+  uₖ₋₁       :: Sn
+  uₖ         :: Sn
   p          :: Sn
   q          :: Sm
   d̅          :: Sm
@@ -3250,8 +3250,6 @@ mutable struct UsymlqrWorkspace{T,FC,Sm,Sn} <: _KrylovWorkspace{T,FC,Sm,Sn}
   wₖ₋₁       :: Sn
   Δx         :: Sm
   Δy         :: Sn
-  vₖ         :: Sm
-  uₖ         :: Sn
   warm_start :: Bool
   stats      :: SimpleStats{T}
 end
@@ -3266,10 +3264,10 @@ function UsymlqrWorkspace(kc::KrylovConstructor{Sm,Sn}) where {Sm,Sn}
   x       = similar(kc.vm)
   y       = similar(kc.vn)
   z       = similar(kc.vn)
-  M⁻¹vₖ₋₁ = similar(kc.vm)
-  M⁻¹vₖ   = similar(kc.vm)
-  N⁻¹uₖ₋₁ = similar(kc.vn)
-  N⁻¹uₖ   = similar(kc.vn)
+  vₖ₋₁    = similar(kc.vm)
+  vₖ      = similar(kc.vm)
+  uₖ₋₁    = similar(kc.vn)
+  uₖ      = similar(kc.vn)
   p       = similar(kc.vn)
   q       = similar(kc.vm)
   d̅       = similar(kc.vm)
@@ -3277,10 +3275,8 @@ function UsymlqrWorkspace(kc::KrylovConstructor{Sm,Sn}) where {Sm,Sn}
   wₖ₋₁    = similar(kc.vn)
   Δx      = similar(kc.vm_empty)
   Δy      = similar(kc.vn_empty)
-  vₖ      = similar(kc.vm_empty)
-  uₖ      = similar(kc.vn_empty)
   stats = SimpleStats(0, false, false, false, 0, T[], T[], T[], 0.0, 0.0, "unknown")
-  workspace = UsymlqrWorkspace{T,FC,Sm,Sn}(m, n, r, x, y, z, M⁻¹vₖ₋₁, M⁻¹vₖ, N⁻¹uₖ₋₁, N⁻¹uₖ, p, q, d̅, wₖ₋₂, wₖ₋₁, Δx, Δy, vₖ, uₖ, false, stats)
+  workspace = UsymlqrWorkspace{T,FC,Sm,Sn}(m, n, r, x, y, z, vₖ₋₁, vₖ, uₖ₋₁, uₖ, p, q, d̅, wₖ₋₂, wₖ₋₁, Δx, Δy, false, stats)
   workspace.stats.allocation_timer = start_allocation_time |> ktimer
   return workspace
 end
@@ -3293,10 +3289,10 @@ function UsymlqrWorkspace(m::Integer, n::Integer, Sm::Type, Sn::Type)
   x       = Sm(undef, m)
   y       = Sn(undef, n)
   z       = Sn(undef, n)
-  M⁻¹vₖ₋₁ = Sm(undef, m)
-  M⁻¹vₖ   = Sm(undef, m)
-  N⁻¹uₖ₋₁ = Sn(undef, n)
-  N⁻¹uₖ   = Sn(undef, n)
+  vₖ₋₁    = Sm(undef, m)
+  vₖ      = Sm(undef, m)
+  uₖ₋₁    = Sn(undef, n)
+  uₖ      = Sn(undef, n)
   p       = Sn(undef, n)
   q       = Sm(undef, m)
   d̅       = Sm(undef, m)
@@ -3304,12 +3300,10 @@ function UsymlqrWorkspace(m::Integer, n::Integer, Sm::Type, Sn::Type)
   wₖ₋₁    = Sn(undef, n)
   Δx      = Sm(undef, 0)
   Δy      = Sn(undef, 0)
-  vₖ      = Sm(undef, 0)
-  uₖ      = Sn(undef, 0)
   Sm = isconcretetype(Sm) ? Sm : typeof(x)
   Sn = isconcretetype(Sn) ? Sn : typeof(y)
   stats = SimpleStats(0, false, false, false, 0, T[], T[], T[], 0.0, 0.0, "unknown")
-  workspace = UsymlqrWorkspace{T,FC,Sm,Sn}(m, n, r, x, y, z, M⁻¹vₖ₋₁, M⁻¹vₖ, N⁻¹uₖ₋₁, N⁻¹uₖ, p, q, d̅, wₖ₋₂, wₖ₋₁, Δx, Δy, vₖ, uₖ, false, stats)
+  workspace = UsymlqrWorkspace{T,FC,Sm,Sn}(m, n, r, x, y, z, vₖ₋₁, vₖ, uₖ₋₁, uₖ, p, q, d̅, wₖ₋₂, wₖ₋₁, Δx, Δy, false, stats)
   workspace.stats.allocation_timer = start_allocation_time |> ktimer
   return workspace
 end

--- a/test/test_usymlqr.jl
+++ b/test/test_usymlqr.jl
@@ -16,7 +16,6 @@
     r = d - K * [x; y]
     resid = norm(r)
     @test resid ≤ usymlqr_tol
-    @printf("USYMLQR: Relative residual: %8.1e\n", resid)
 
     # [I   A] [x] = [b]
     # [Aᴴ  0] [y]   [0]
@@ -26,7 +25,6 @@
     r = d - K * [x; y]
     resid = norm(r)
     @test resid ≤ usymlqr_tol
-    @printf("USYMLQR: Relative residual: %8.1e\n", resid)
 
     # [I   A] [x] = [0]
     # [Aᴴ  0] [y]   [c]
@@ -36,7 +34,6 @@
     r = d - K * [x; y]
     resid = norm(r)
     @test resid ≤ usymlqr_tol
-    @printf("USYMLQR: Relative residual: %8.1e\n", resid)
   end
 
   @testset "Data Type: $FC" for FC in (Float64, ComplexF64)
@@ -76,29 +73,5 @@
     @test typeof(workspace.x) === typeof(b)
     @test typeof(workspace.y) === typeof(d)
     @test workspace.stats.solved
-
-    # (x, y, stats) = usymlqr(A, b, c, M=D⁻¹, ls=true, ln=false)
-    # K = [D A; A' zeros(n, n)]
-    # d = [b; zeros(FC, n)]
-    # r =  d - K * [x; y]
-    # resid = sqrt(dot(r, H⁻¹ * r) |> real) / sqrt(dot(d, H⁻¹ * d) |> real)
-    # @printf("USYMLQR: Relative residual: %8.1e\n", resid)
-    # @test(resid ≤ usymlqr_tol)
-
-    # (x, y, stats) = usymlqr(A, b, c, M=D⁻¹, ls=false, ln=true)
-    # K = [D A; A' zeros(n, n)]
-    # d = [zeros(FC, m); c]
-    # r =  d - K * [x; y]
-    # resid = sqrt(dot(r, H⁻¹ * r) |> real) / sqrt(dot(d, H⁻¹ * d) |> real)
-    # @printf("USYMLQR: Relative residual: %8.1e\n", resid)
-    # @test(resid ≤ usymlqr_tol)
-
-    # (x, y, stats) = usymlqr(A, b, c, M=D⁻¹)
-    # K = [D A; A' zeros(n, n)]
-    # d = [b; c]
-    # r =  d - K * [x; y]
-    # resid = sqrt(dot(r, H⁻¹ * r) |> real) / sqrt(dot(d, H⁻¹ * d) |> real)
-    # @printf("USYMLQR: Relative residual: %8.1e\n", resid)
-    # @test(resid ≤ usymlqr_tol)
   end
 end


### PR DESCRIPTION
I will open another PR with what I did with the preconditioners.
I am wondering if the recurrences in the [paper](https://epubs.siam.org/doi/10.1137/18M1194900) are correct with preconditioners.
I didn't find a way to make it work...

What is confirmed is that we can't use the `usymcg` point, it is a mistake in the paper.
I prefer to only merge what is confirmed to work well.