### PR TITLE
Initialize solved/zero_resid flags to false

### DIFF
--- a/src/minres_qlp.jl
+++ b/src/minres_qlp.jl
@@ -225,7 +225,8 @@ kwargs_minres_qlp = (:M, :ldiv, :linesearch, :λ, :atol, :rtol, :Artol, :itmax, 
 
     # Stopping criterion.
     breakdown = false
-    solved = zero_resid = zero_resid_lim = false
+    solved = false
+    zero_resid = zero_resid_lim = rNorm ≤ ε
     zero_resid_mach = false
     inconsistent = false
     ill_cond_mach = false

--- a/src/minres_qlp.jl
+++ b/src/minres_qlp.jl
@@ -225,7 +225,7 @@ kwargs_minres_qlp = (:M, :ldiv, :linesearch, :λ, :atol, :rtol, :Artol, :itmax, 
 
     # Stopping criterion.
     breakdown = false
-    solved = zero_resid = zero_resid_lim = rNorm ≤ ε
+    solved = zero_resid = zero_resid_lim = false
     zero_resid_mach = false
     inconsistent = false
     ill_cond_mach = false


### PR DESCRIPTION
Set solved, zero_resid, and zero_resid_lim to false during initialization instead of computing them from rNorm ≤ ε. This avoids marking the problem as solved at startup (and potential use of rNorm before it's set), ensuring stopping flags are only updated after the residual is computed.