### PR TITLE
Fix premature termination in `minres!` due to dimensional mismatch in stopping criteria

### DIFF
--- a/src/minres.jl
+++ b/src/minres.jl
@@ -446,7 +446,7 @@ kwargs_workspace_minres = (:window,)
       # Stopping conditions based on user-provided tolerances.
       tired = iter ≥ itmax
       ill_cond_lim = (inv(Acond) ≤ ctol)
-      solved_lim = (test2 ≤ ε)
+      solved_lim = (test2 ≤ rtol + atol)
       zero_resid_lim = MisI && (test1 ≤ eps(T))
       resid_decrease_lim = (rNorm ≤ ε)
       iter ≥ window && (fwd_err = err_lbnd ≤ etol * sqrt(xENorm²))


### PR DESCRIPTION

**Summary**
This PR fixes a bug in the `minres!` loop where the solver would terminate prematurely (often on the first iteration) when solving systems with a large initial residual.

**Details**
In the stopping criteria for `minres!`, the variable `test2` is defined as `root / ANorm` (representing the dimensionless ratio $\|A^H r\| / \|A\|$). However, it was being compared against `ε`, which is a dimensionful threshold scaled by the initial residual `β₁`:

```julia
ε = atol + rtol * β₁
# ...
solved_lim = (test2 ≤ ε)

```

When used inside outer non-linear solvers (like Trust-Region or Regularized Newton methods), the initial gradient/residual `β₁` is often quite large. If `rtol * β₁ > 1.0`, `ε` becomes greater than 1. Because `test2` is inherently bounded by 1, the condition `test2 ≤ ε` evaluates to `true` instantly.

This forces MINRES to exit with `status = "found approximate minimum least-squares solution"` without actually solving the system.

**Impact**

* **Suppressed Curvature Detection:** Because the solver exited on iteration 1, it completely bypassed the Armijo-Goldstein negative curvature handlers (`cγ = cs * γbar >= 0`).
* **Outer Solver Stagnation:** In non-convex benchmarks (like the Extended Rosenbrock), handing back an unsolved step caused the outer R2N loop to reject the step, skyrocketing the regularization parameter $\sigma$ and stalling the algorithm.

**The Fix**
Decoupled the dimensionless `test2` check from the dimensionful `ε`. `test2` is now evaluated against the dimensionless tolerances directly:

```julia
solved_lim = (test2 ≤ rtol + atol)

```

This simple correction brings the behavior of `minres!` perfectly in line with `minres_qlp!` and CR, restoring its ability to reliably catch non-positive curvature directions on highly indefinite systems.