### PR TITLE
Update Buildkite pipeline for the new JuliaGPU cluster

### DIFF
--- a/.buildkite/pipeline-julia.yml
+++ b/.buildkite/pipeline-julia.yml
@@ -1,0 +1,65 @@
+steps:
+  - label: "Apple M1 GPUs -- Metal.jl"
+    plugins:
+      - JuliaCI/julia#v1:
+          version: "1.12"
+    agents:
+      queue: "juliaecosystem"
+      os: "macos"
+      arch: "aarch64"
+    command: |
+      julia --color=yes --project -e '
+        using Pkg
+        Pkg.add("Metal")
+        Pkg.add("KernelAbstractions")
+        Pkg.instantiate()
+        include("test/gpu/metal.jl")'
+    timeout_in_minutes: 30
+
+  - label: "CPUs -- StaticArrays.jl"
+    plugins:
+      - JuliaCI/julia#v1:
+          version: "1.10"
+    agents:
+      queue: "juliaecosystem"
+      os: "linux"
+      arch: "x86_64"
+    command: |
+      julia --color=yes --project -e '
+        using Pkg
+        Pkg.add("StaticArrays")
+        Pkg.instantiate()
+        include("test/cpu/static_arrays.jl")'
+    timeout_in_minutes: 30
+
+  - label: "CPUs -- ComponentArrays.jl"
+    plugins:
+      - JuliaCI/julia#v1:
+          version: "1.10"
+    agents:
+      queue: "juliaecosystem"
+      os: "linux"
+      arch: "x86_64"
+    command: |
+      julia --color=yes --project -e '
+        using Pkg
+        Pkg.add("ComponentArrays")
+        Pkg.instantiate()
+        include("test/cpu/component_arrays.jl")'
+    timeout_in_minutes: 30
+
+  - label: "CPUs -- LinearOperators.jl"
+    plugins:
+      - JuliaCI/julia#v1:
+          version: "1.10"
+    agents:
+      queue: "juliaecosystem"
+      os: "linux"
+      arch: "x86_64"
+    command: |
+      julia --color=yes --project -e '
+        using Pkg
+        Pkg.add("LinearOperators")
+        Pkg.instantiate()
+        include("test/cpu/linear_operators.jl")'
+    timeout_in_minutes: 30

--- a/.buildkite/pipeline-julia.yml
+++ b/.buildkite/pipeline-julia.yml
@@ -1,21 +1,4 @@
 steps:
-  - label: "Apple M1 GPUs -- Metal.jl"
-    plugins:
-      - JuliaCI/julia#v1:
-          version: "1.12"
-    agents:
-      queue: "juliaecosystem"
-      os: "macos"
-      arch: "aarch64"
-    command: |
-      julia --color=yes --project -e '
-        using Pkg
-        Pkg.add("Metal")
-        Pkg.add("KernelAbstractions")
-        Pkg.instantiate()
-        include("test/gpu/metal.jl")'
-    timeout_in_minutes: 30
-
   - label: "CPUs -- StaticArrays.jl"
     plugins:
       - JuliaCI/julia#v1:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -55,3 +55,18 @@ steps:
         Pkg.instantiate()
         include("test/gpu/intel.jl")'
     timeout_in_minutes: 30
+
+  - label: "Apple M1 GPUs -- Metal.jl"
+    plugins:
+      - JuliaCI/julia#v1:
+          version: "1.12"
+    agents:
+      queue: "metal"
+    command: |
+      julia --color=yes --project -e '
+        using Pkg
+        Pkg.add("Metal")
+        Pkg.add("KernelAbstractions")
+        Pkg.instantiate()
+        include("test/gpu/metal.jl")'
+    timeout_in_minutes: 30

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,8 +4,7 @@ steps:
       - JuliaCI/julia#v1:
           version: "1.12"
     agents:
-      queue: "juliagpu"
-      cuda: "*"
+      queue: "cuda"
     command: |
       julia --color=yes --project -e '
         using Pkg
@@ -25,8 +24,7 @@ steps:
       - JuliaCI/julia#v1:
           version: "1.12"
     agents:
-      queue: "juliagpu"
-      rocm: "*"
+      queue: "rocm"
       rocmgpu: "*"
     env:
       JULIA_NUM_THREADS: 4
@@ -47,8 +45,7 @@ steps:
       - JuliaCI/julia#v1:
           version: "1.12"
     agents:
-      queue: "juliagpu"
-      intel: "*"
+      queue: "oneapi"
     command: |
       julia --color=yes --project -e '
         using Pkg
@@ -57,69 +54,4 @@ steps:
         Pkg.add("KernelAbstractions")
         Pkg.instantiate()
         include("test/gpu/intel.jl")'
-    timeout_in_minutes: 30
-
-  - label: "Apple M1 GPUs -- Metal.jl"
-    plugins:
-      - JuliaCI/julia#v1:
-          version: "1.12"
-    agents:
-      queue: "juliaecosystem"
-      os: "macos"
-      arch: "aarch64"
-    command: |
-      julia --color=yes --project -e '
-        using Pkg
-        Pkg.add("Metal")
-        Pkg.add("KernelAbstractions")
-        Pkg.instantiate()
-        include("test/gpu/metal.jl")'
-    timeout_in_minutes: 30
-
-  - label: "CPUs -- StaticArrays.jl"
-    plugins:
-      - JuliaCI/julia#v1:
-          version: "1.10"
-    agents:
-      queue: "juliaecosystem"
-      os: "linux"
-      arch: "x86_64"
-    command: |
-      julia --color=yes --project -e '
-        using Pkg
-        Pkg.add("StaticArrays")
-        Pkg.instantiate()
-        include("test/cpu/static_arrays.jl")'
-    timeout_in_minutes: 30
-
-  - label: "CPUs -- ComponentArrays.jl"
-    plugins:
-      - JuliaCI/julia#v1:
-          version: "1.10"
-    agents:
-      queue: "juliaecosystem"
-      os: "linux"
-      arch: "x86_64"
-    command: |
-      julia --color=yes --project -e '
-        using Pkg
-        Pkg.add("ComponentArrays")
-        Pkg.instantiate()
-        include("test/cpu/component_arrays.jl")'
-    timeout_in_minutes: 30
-
-  - label: "CPUs -- LinearOperators.jl"
-    plugins:
-      - JuliaCI/julia#v1:
-          version: "1.10"
-    agents:
-      queue: "juliaecosystem"
-      os: "linux"
-      arch: "x86_64"
-    command: |
-      julia --color=yes --project -e '
-        using Pkg
-        Pkg.add("LinearOperators")
-        Pkg.instantiate()
-        include("test/cpu/linear_operators.jl")'
     timeout_in_minutes: 30


### PR DESCRIPTION
The JuliaGPU Buildkite agents have moved to a dedicated cluster, where the single `juliagpu` queue has been split into per-backend queues. Steps now select agents using `queue: "cuda"`, `queue: "rocm"` or `queue: "oneapi"` instead of `queue: "juliagpu"` combined with a `cuda`/`rocm`/`intel` tag.

This change only affects agent selection; the steps themselves are unchanged.

Since queues are now scoped to a cluster, a single pipeline can no longer mix JuliaGPU and `juliaecosystem` jobs: `pipeline.yml` now contains only the GPU jobs, while the `juliaecosystem` steps have moved unmodified to `pipeline-julia.yml`, to be uploaded by a separate pipeline in the ecosystem cluster once that is back online.

🤖 Generated with [Claude Code](https://claude.com/claude-code)