### PR TITLE
Trigger libkrylov release on tag push instead of release event

### DIFF
--- a/.github/workflows/release-libkrylov.yml
+++ b/.github/workflows/release-libkrylov.yml
@@ -1,14 +1,21 @@
 name: Release libkrylov binaries
 
-# Triggered by TagBot when it publishes a release.
+# Triggered by the version tag that TagBot pushes for each new release.
 # Builds a self-contained libkrylov bundle (library + Julia runtime) for all
-# supported platforms and uploads the archives to the existing GitHub Release.
+# supported platforms and uploads the archives to the matching GitHub Release.
+#
+# We trigger on the tag push rather than on `release: published` because TagBot
+# publishes the GitHub Release with the default GITHUB_TOKEN, and GitHub does not
+# start new workflow runs from events emitted by GITHUB_TOKEN (anti-recursion).
+# TagBot pushes the tag through the SSH DOCUMENTER_KEY instead, and deploy-key
+# pushes DO trigger workflows (this is how Documentation.yml runs on release).
 #
 # workflow_dispatch lets you re-run or test against any existing tag.
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'v*'
 
   workflow_dispatch:
     inputs:
@@ -204,5 +211,5 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          TAG=${{ github.event.release.tag_name || inputs.tag }}
+          TAG="${{ github.event.inputs.tag || github.ref_name }}"
           gh release upload "$TAG" "${{ matrix.archive }}" --clobber


### PR DESCRIPTION
I needed to trigger manually the workflow for the release `0.10.7`.