### PR TITLE
Trim SparseArrays from the published libkrylov bundle

### DIFF
--- a/.github/workflows/release-libkrylov.yml
+++ b/.github/workflows/release-libkrylov.yml
@@ -125,6 +125,20 @@ jobs:
           '
 
       # -----------------------------------------------------------------------
+      # Trim SparseArrays from the build.
+      # The C interface only exposes solvers, never the Krylov processes, so the
+      # only thing pulling SparseArrays (and therefore SuiteSparse) is dead code
+      # for this bundle. This patch drops the dependency, disables the two
+      # *_processes.jl files and the SparseVector ktypeof methods, so the build
+      # no longer dlopen's SuiteSparse and the bundle stays small.
+      # -----------------------------------------------------------------------
+      - name: Strip SparseArrays from the build
+        shell: bash
+        run: |
+          julia --startup-file=no interfaces/scripts/trim_sparsearrays.jl
+          git diff --stat
+
+      # -----------------------------------------------------------------------
       # Instantiate the Krylov.jl project
       # -----------------------------------------------------------------------
       - name: Instantiate Julia project
@@ -167,24 +181,6 @@ jobs:
           mkdir -p interfaces/build/include
           cp interfaces/include/krylov.h interfaces/build/include/
           cp interfaces/include/krylov.f90 interfaces/build/include/
-
-      # -----------------------------------------------------------------------
-      # Bundle the SuiteSparse libraries.
-      # juliac --bundle does not trace libraries that Julia dlopen's at startup
-      # (SparseArrays -> SuiteSparse_jll: libbtf, libcholmod, libumfpack, ...).
-      # They must be copied next to the embedded runtime so the published bundle
-      # is genuinely self-contained on machines without Julia.
-      # -----------------------------------------------------------------------
-      - name: Bundle SuiteSparse libraries
-        shell: bash
-        run: |
-          JBIN="$(julia --startup-file=no -e 'print(Sys.BINDIR)')"
-          if [ "$RUNNER_OS" = "Windows" ]; then JLIB="$JBIN"; else JLIB="$JBIN/../lib/julia"; fi
-          DEST="$(dirname "$(find interfaces/build -name 'libjulia-internal*' | head -1)")"
-          echo "Copying SuiteSparse libraries from $JLIB to $DEST"
-          for name in amd btf camd ccolamd cholmod colamd klu ldl rbio spqr suitesparseconfig umfpack; do
-            cp -a "$JLIB"/lib"$name".* "$DEST"/ 2>/dev/null || true
-          done
 
       # -----------------------------------------------------------------------
       # Package bundle

--- a/.github/workflows/test-libkrylov.yml
+++ b/.github/workflows/test-libkrylov.yml
@@ -89,6 +89,18 @@ jobs:
           echo "$JULIAC_BIN" >> "$GITHUB_PATH"
 
       # -----------------------------------------------------------------------
+      # Trim SparseArrays from the build, exactly like the release workflow, so
+      # the library exercised by the tests matches the one we ship. The C
+      # interface only exposes solvers, never the Krylov processes, so this drops
+      # SparseArrays (and therefore SuiteSparse) as dead weight.
+      # -----------------------------------------------------------------------
+      - name: Strip SparseArrays from the build
+        shell: bash
+        run: |
+          julia --startup-file=no interfaces/scripts/trim_sparsearrays.jl
+          git diff --stat
+
+      # -----------------------------------------------------------------------
       # Instantiate the Krylov.jl project
       # -----------------------------------------------------------------------
       - name: Instantiate Julia project
@@ -119,24 +131,6 @@ jobs:
       - name: Generate krylov.h
         shell: bash
         run: julia --startup-file=no --project=. interfaces/scripts/generate_header.jl
-
-      # -----------------------------------------------------------------------
-      # Bundle the SuiteSparse libraries.
-      # juliac --bundle does not trace libraries that Julia dlopen's at startup
-      # (SparseArrays -> SuiteSparse_jll: libbtf, libcholmod, libumfpack, ...).
-      # They must be copied next to the embedded runtime so the bundle runs on a
-      # machine without Julia.
-      # -----------------------------------------------------------------------
-      - name: Bundle SuiteSparse libraries
-        shell: bash
-        run: |
-          JBIN="$(julia --startup-file=no -e 'print(Sys.BINDIR)')"
-          if [ "$RUNNER_OS" = "Windows" ]; then JLIB="$JBIN"; else JLIB="$JBIN/../lib/julia"; fi
-          DEST="$(dirname "$(find interfaces/build -name 'libjulia-internal*' | head -1)")"
-          echo "Copying SuiteSparse libraries from $JLIB to $DEST"
-          for name in amd btf camd ccolamd cholmod colamd klu ldl rbio spqr suitesparseconfig umfpack; do
-            cp -a "$JLIB"/lib"$name".* "$DEST"/ 2>/dev/null || true
-          done
 
       # -----------------------------------------------------------------------
       # Verify the bundle is self-contained: run an example with ONLY the bundle

--- a/interfaces/scripts/trim_sparsearrays.jl
+++ b/interfaces/scripts/trim_sparsearrays.jl
@@ -1,0 +1,61 @@
+# Strip SparseArrays (and therefore SuiteSparse) from the libkrylov build.
+#
+# The C/Fortran interface only exposes the Krylov solvers, never the processes
+# (hermitian_lanczos, golub_kahan, ...), so SparseArrays is dead weight here.
+# This script edits the working tree in place before the bundle is built:
+#
+#   * Project.toml      : drop the SparseArrays dep and compat entry
+#   * src/Krylov.jl     : drop `using SparseArrays`, disable the *_processes.jl
+#   * src/krylov_utils.jl : remove the two SparseVector ktypeof methods
+#
+# Every edit is anchored on a stable string/signature rather than on line
+# numbers or surrounding context, so it survives code moving around. If an
+# anchor is ever missing the script errors out loudly instead of silently
+# leaving SparseArrays in the build.
+
+const ROOT = normpath(joinpath(@__DIR__, "..", ".."))
+
+"Apply `f` to the file, asserting that it actually changed the content."
+function edit(f, relpath)
+    path = joinpath(ROOT, relpath)
+    old = read(path, String)
+    new = f(old)
+    new == old && error("trim_sparsearrays: no change in $relpath — an anchor is missing, refusing to build with SparseArrays still in.")
+    write(path, new)
+    println("  patched $relpath")
+end
+
+println("Trimming SparseArrays from the build...")
+
+# --- Project.toml: remove the dep uuid line and the compat line ---------------
+edit("Project.toml") do s
+    replace(s, r"^SparseArrays = .*\n"m => "")
+end
+
+# --- src/Krylov.jl: drop the using and disable the two process files ----------
+edit("src/Krylov.jl") do s
+    s = replace(s, "using LinearAlgebra, SparseArrays, Printf" =>
+                   "using LinearAlgebra, Printf")
+    s = replace(s, "include(\"krylov_processes.jl\")" =>
+                   "# include(\"krylov_processes.jl\")        # disabled: pulls SparseArrays -> SuiteSparse")
+    s = replace(s, "include(\"block_krylov_processes.jl\")" =>
+                   "# include(\"block_krylov_processes.jl\")  # disabled: pulls SparseArrays -> SuiteSparse")
+    return s
+end
+
+# --- src/krylov_utils.jl: remove the two SparseVector ktypeof methods ---------
+# Anchored on the method signatures; `.*?\r?\nend\r?\n` matches the (brace-free)
+# body up to the first closing `end`, regardless of where the methods sit in the
+# file. `\r?` keeps it working on Windows checkouts that use CRLF line endings.
+edit("src/krylov_utils.jl") do s
+    s = replace(s, r"function ktypeof\(v::S\) where S <: SparseVector.*?\r?\nend\r?\n"s => "")
+    s = replace(s, r"function ktypeof\(v::S\) where S <: AbstractSparseVector.*?\r?\nend\r?\n"s => "")
+    return s
+end
+
+println("Done.")
+println()
+println("NOTE: this edited the working tree in place (Project.toml, src/Krylov.jl,")
+println("      src/krylov_utils.jl). In CI the checkout is throwaway. For a LOCAL")
+println("      build, restore your sources once the bundle is built with:")
+println("          git restore Project.toml src/Krylov.jl src/krylov_utils.jl")


### PR DESCRIPTION
The C / Fortran interface only exposes the Krylov solvers, never the processes (hermitian_lanczos, golub_kahan, ...).
The sole reason the bundle pulled the whole SuiteSparse stack (libcholmod, libumfpack, ...) was `using SparseArrays` in Krylov.jl, whose `__init__` dlopen's SuiteSparse_jll at startup.
It is a dead weight for the precompiled artifacts,
