### PR TITLE
Support for any floating-point data type in block Krylov methods

### DIFF
--- a/src/block_gmres.jl
+++ b/src/block_gmres.jl
@@ -263,7 +263,7 @@ kwargs_workspace_block_gmres = (:memory,)
         for i = 1 : inner_iter-1
           D1 .= R[nr+i]
           D2 .= R[nr+i+1]
-          kormqr!('L', trans, H[i], τ[i], D, buffer)
+          kunmqr!('L', trans, H[i], τ[i], D, buffer)
           R[nr+i] .= D1
           R[nr+i+1] .= D2
         end
@@ -276,7 +276,7 @@ kwargs_workspace_block_gmres = (:memory,)
         # Update Zₖ = (Qₖ)ᴴΓE₁ = (Λ₁, ..., Λₖ, Λbarₖ₊₁)
         D1 .= Z[inner_iter]
         D2 .= zero(FC)
-        kormqr!('L', trans, H[inner_iter], τ[inner_iter], D, buffer)
+        kunmqr!('L', trans, H[inner_iter], τ[inner_iter], D, buffer)
         Z[inner_iter] .= D1
 
         # Update residual norm estimate.

--- a/src/block_krylov_utils.jl
+++ b/src/block_krylov_utils.jl
@@ -194,7 +194,7 @@ function householder!(Q::AbstractMatrix{FC}, R::AbstractMatrix{FC}, τ::Abstract
   kfill!(R, zero(FC))
   kgeqrf!(Q, τ)
   copy_triangle(Q, R, k)
-  !compact && korgqr!(Q, τ)
+  !compact && kungqr!(Q, τ)
   return Q, R
 end
 
@@ -203,11 +203,11 @@ function householder!(Q::AbstractMatrix{FC}, R::AbstractMatrix{FC}, τ::Abstract
   kfill!(R, zero(FC))
   kgeqrf!(Q, τ, buffer)
   copy_triangle(Q, R, k)
-  !compact && korgqr!(Q, τ, buffer)
+  !compact && kungqr!(Q, τ, buffer)
   return Q, R
 end
 
-for (Xgeqrf, Xorgqr, Xormqr, T) in ((:sgeqrf_, :sorgqr_, :sormqr_, :Float32   ),
+for (Xgeqrf, Xungqr, Xunmqr, T) in ((:sgeqrf_, :sorgqr_, :sormqr_, :Float32   ),
                                     (:dgeqrf_, :dorgqr_, :dormqr_, :Float64   ),
                                     (:cgeqrf_, :cungqr_, :cunmqr_, :ComplexF32),
                                     (:zgeqrf_, :zungqr_, :zunmqr_, :ComplexF64))
@@ -235,57 +235,57 @@ for (Xgeqrf, Xorgqr, Xormqr, T) in ((:sgeqrf_, :sorgqr_, :sormqr_, :Float32   ),
             return nothing
         end
 
-        function $Xorgqr(m, n, k, a, lda, tau, work, lwork, info)
-            return ccall((@blasfunc($Xorgqr), libblastrampoline), Cvoid,
+        function $Xungqr(m, n, k, a, lda, tau, work, lwork, info)
+            return ccall((@blasfunc($Xungqr), libblastrampoline), Cvoid,
                          (Ref{BlasInt}, Ref{BlasInt}, Ref{BlasInt}, Ptr{$T},
                           Ref{BlasInt}, Ptr{$T}, Ptr{$T}, Ref{BlasInt}, Ref{BlasInt}),
                           m, n, k, a, lda, tau, work, lwork, info)
         end
 
-        function korgqr_buffer!(A::Matrix{$T}, tau::Vector{$T})
+        function kungqr_buffer!(A::Matrix{$T}, tau::Vector{$T})
             m, n = size(A)
             k = length(tau)
             work = Ref{$T}(0)
             lda = max(1, stride(A, 2))
-            $Xorgqr(m, n, k, A, lda, tau, work, -1, 0)
+            $Xungqr(m, n, k, A, lda, tau, work, -1, 0)
             return work[] |> BlasInt
         end
 
-        function korgqr!(A::Matrix{$T}, tau::Vector{$T}, work::Vector{$T})
-            symb = @blasfunc($Xorgqr)
+        function kungqr!(A::Matrix{$T}, tau::Vector{$T}, work::Vector{$T})
+            symb = @blasfunc($Xungqr)
             m, n = size(A)
             k = length(tau)
             lwork = length(work)
             lda = max(1, stride(A, 2))
-            $Xorgqr(m, n, k, A, lda, tau, work, lwork, 0)
+            $Xungqr(m, n, k, A, lda, tau, work, lwork, 0)
             return nothing
         end
 
-        function $Xormqr(side, trans, m, n, k, a, lda, tau, c, ldc, work, lwork, info)
-            return ccall((@blasfunc($Xormqr), libblastrampoline), Cvoid,
+        function $Xunmqr(side, trans, m, n, k, a, lda, tau, c, ldc, work, lwork, info)
+            return ccall((@blasfunc($Xunmqr), libblastrampoline), Cvoid,
                          (Ref{UInt8}, Ref{UInt8}, Ref{BlasInt}, Ref{BlasInt}, Ref{BlasInt}, Ptr{$T},
                           Ref{BlasInt}, Ptr{$T}, Ptr{$T}, Ref{BlasInt}, Ptr{$T}, Ref{BlasInt},
                           Ref{BlasInt}, Clong, Clong),
                           side, trans, m, n, k, a, lda, tau, c, ldc, work, lwork, info, 1, 1)
         end
 
-        function kormqr_buffer!(side::Char, trans::Char, A::Matrix{$T}, tau::Vector{$T}, C::Matrix{$T})
+        function kunmqr_buffer!(side::Char, trans::Char, A::Matrix{$T}, tau::Vector{$T}, C::Matrix{$T})
             m, n = size(A)
             k = length(tau)
             work = Ref{$T}(0)
             lda = max(1, stride(A, 2))
             ldc = max(1, stride(C, 2))
-            $Xormqr(side, trans, m, n, k, A, lda, tau, C, ldc, work, -1, 0)
+            $Xunmqr(side, trans, m, n, k, A, lda, tau, C, ldc, work, -1, 0)
             return work[] |> BlasInt
         end
 
-        function kormqr!(side::Char, trans::Char, A::Matrix{$T}, tau::Vector{$T}, C::Matrix{$T}, work::Vector{$T})
+        function kunmqr!(side::Char, trans::Char, A::Matrix{$T}, tau::Vector{$T}, C::Matrix{$T}, work::Vector{$T})
             m, n = size(A)
             k = length(tau)
             lwork = length(work)
             lda = max(1, stride(A, 2))
             ldc = max(1, stride(C, 2))
-            $Xormqr(side, trans, m, n, k, A, lda, tau, C, ldc, work, lwork, 0)
+            $Xunmqr(side, trans, m, n, k, A, lda, tau, C, ldc, work, lwork, 0)
             return nothing
         end
     end
@@ -294,11 +294,11 @@ end
 kgeqrf!(A :: AbstractMatrix{T}, tau :: AbstractVector{T}) where T <: BLAS.BlasFloat = LAPACK.geqrf!(A, tau)
 kgeqrf!(A :: AbstractMatrix{T}, tau :: AbstractVector{T}, buffer:: AbstractVector{T}) where T <: BLAS.BlasFloat = LAPACK.geqrf!(A, tau)
 
-korgqr!(A :: AbstractMatrix{T}, tau :: AbstractVector{T}) where T <: BLAS.BlasFloat = LAPACK.orgqr!(A, tau)
-korgqr!(A :: AbstractMatrix{T}, tau :: AbstractVector{T}, buffer:: AbstractVector{T}) where T <: BLAS.BlasFloat = LAPACK.orgqr!(A, tau)
+kungqr!(A :: AbstractMatrix{T}, tau :: AbstractVector{T}) where T <: BLAS.BlasFloat = LAPACK.orgqr!(A, tau)
+kungqr!(A :: AbstractMatrix{T}, tau :: AbstractVector{T}, buffer:: AbstractVector{T}) where T <: BLAS.BlasFloat = LAPACK.orgqr!(A, tau)
 
-kormqr!(side :: Char, trans :: Char, A :: AbstractMatrix{T}, tau :: AbstractVector{T}, C :: AbstractMatrix{T}) where T <: BLAS.BlasFloat = LAPACK.ormqr!(side, trans, A, tau, C)
-kormqr!(side :: Char, trans :: Char, A :: AbstractMatrix{T}, tau :: AbstractVector{T}, C :: AbstractMatrix{T}, buffer:: AbstractVector{T}) where T <: BLAS.BlasFloat = LAPACK.ormqr!(side, trans, A, tau, C)
+kunmqr!(side :: Char, trans :: Char, A :: AbstractMatrix{T}, tau :: AbstractVector{T}, C :: AbstractMatrix{T}) where T <: BLAS.BlasFloat = LAPACK.ormqr!(side, trans, A, tau, C)
+kunmqr!(side :: Char, trans :: Char, A :: AbstractMatrix{T}, tau :: AbstractVector{T}, C :: AbstractMatrix{T}, buffer:: AbstractVector{T}) where T <: BLAS.BlasFloat = LAPACK.ormqr!(side, trans, A, tau, C)
 
 # """
 #     β, τ = larfg!(α, x)
@@ -322,13 +322,13 @@ function larfg!(α::FC, x::AbstractVector{FC}) where FC <: FloatOrComplex
 end
 
 # """
-#     A = geqrf!(A, tau)
+#     A = geqr2!(A, tau)
 #
 # Reduced QR factorization via Householder reflections.
 # On output the upper triangle of `A` holds `R`, and the reflectors are stored
 # below the diagonal together with the scalars `τ`.
 # """
-function geqrf!(A::AbstractMatrix{FC}, tau::AbstractVector{FC}) where FC <: FloatOrComplex
+function geqr2!(A::AbstractMatrix{FC}, tau::AbstractVector{FC}) where FC <: FloatOrComplex
   m, n = size(A)
   k = min(m, n)
   for i = 1:k
@@ -351,13 +351,14 @@ function geqrf!(A::AbstractMatrix{FC}, tau::AbstractVector{FC}) where FC <: Floa
 end
 
 # """
-#     A = orgqr!(A, tau)
+#     A = ung2r!(A, tau)
 #
 # Form the orthonormal factor `Q` from the reflectors produced by [`geqrf!`](@ref), overwriting `A`.
 # """
-function orgqr!(A::AbstractMatrix{FC}, tau::AbstractVector{FC}) where FC <: FloatOrComplex
+function ung2r!(A::AbstractMatrix{FC}, tau::AbstractVector{FC}) where FC <: FloatOrComplex
   m, n = size(A)
   k = length(tau)
+  k ≤ min(m,n) || error("The dimension of A (($m,$n)) and the length of tau ($k) are inconsistent.")
   for j = k+1:n
     for l = 1:m
       A[l,j] = zero(FC)
@@ -388,12 +389,12 @@ function orgqr!(A::AbstractMatrix{FC}, tau::AbstractVector{FC}) where FC <: Floa
 end
 
 # """
-#     C = ormqr!(side, trans, A, tau, C)
+#     C = unm2r!(side, trans, A, tau, C)
 #
 # Apply Q or Qᴴ (stored as reflectors in `A` with scalars `τ`) to the matrix `C`
 # from the left ('L') or the right ('R'), using the reflectors computed by [`geqrf!`](@ref).
 # """
-function ormqr!(side::Char, trans::Char, A::AbstractMatrix{FC}, tau::AbstractVector{FC}, C::AbstractMatrix{FC}) where FC <: FloatOrComplex
+function unm2r!(side::Char, trans::Char, A::AbstractMatrix{FC}, tau::AbstractVector{FC}, C::AbstractMatrix{FC}) where FC <: FloatOrComplex
   m, n = size(C)
   k = length(tau)
   notran = (trans == 'N')
@@ -439,15 +440,16 @@ function ormqr!(side::Char, trans::Char, A::AbstractMatrix{FC}, tau::AbstractVec
   return C
 end
 
-kgeqrf!(A :: AbstractMatrix{FC}, tau :: AbstractVector{FC}) where FC <: FloatOrComplex = geqrf!(A, tau)
-kgeqrf!(A :: AbstractMatrix{FC}, tau :: AbstractVector{FC}, buffer :: AbstractVector{FC}) where FC <: FloatOrComplex = geqrf!(A, tau)
+kgeqrf!(A :: AbstractMatrix{FC}, tau :: AbstractVector{FC}) where FC <: FloatOrComplex = geqr2!(A, tau)
+kungqr!(A :: AbstractMatrix{FC}, tau :: AbstractVector{FC}) where FC <: FloatOrComplex = ung2r!(A, tau)
+kunmqr!(side :: Char, trans :: Char, A :: AbstractMatrix{FC}, tau :: AbstractVector{FC}, C :: AbstractMatrix{FC}) where FC <: FloatOrComplex = unm2r!(side, trans, A, tau, C)
 
-korgqr!(A :: AbstractMatrix{FC}, tau :: AbstractVector{FC}) where FC <: FloatOrComplex = orgqr!(A, tau)
-korgqr!(A :: AbstractMatrix{FC}, tau :: AbstractVector{FC}, buffer :: AbstractVector{FC}) where FC <: FloatOrComplex = orgqr!(A, tau)
-
-kormqr!(side :: Char, trans :: Char, A :: AbstractMatrix{FC}, tau :: AbstractVector{FC}, C :: AbstractMatrix{FC}) where FC <: FloatOrComplex = ormqr!(side, trans, A, tau, C)
-kormqr!(side :: Char, trans :: Char, A :: AbstractMatrix{FC}, tau :: AbstractVector{FC}, C :: AbstractMatrix{FC}, buffer :: AbstractVector{FC}) where FC <: FloatOrComplex = ormqr!(side, trans, A, tau, C)
+# Fallback methods for the buffered API.
+# The extra `buffer` argument is currently ignored because only the unblocked algorithms (`geqr2!`, `ung2r!`, `unm2r!`) are implemented.
+kgeqrf!(A :: AbstractMatrix{FC}, tau :: AbstractVector{FC}, buffer :: AbstractVector{FC}) where FC <: FloatOrComplex = geqr2!(A, tau)
+kungqr!(A :: AbstractMatrix{FC}, tau :: AbstractVector{FC}, buffer :: AbstractVector{FC}) where FC <: FloatOrComplex = ung2r!(A, tau)
+kunmqr!(side :: Char, trans :: Char, A :: AbstractMatrix{FC}, tau :: AbstractVector{FC}, C :: AbstractMatrix{FC}, buffer :: AbstractVector{FC}) where FC <: FloatOrComplex = unm2r!(side, trans, A, tau, C)
 
 kgeqrf_buffer!(A :: AbstractMatrix{FC}, tau :: AbstractVector{FC}) where FC <: FloatOrComplex = 0
-korgqr_buffer!(A :: AbstractMatrix{FC}, tau :: AbstractVector{FC}) where FC <: FloatOrComplex = 0
-kormqr_buffer!(side :: Char, trans :: Char, A :: AbstractMatrix{FC}, tau :: AbstractVector{FC}, C :: AbstractMatrix{FC}) where FC <: FloatOrComplex = 0
+kungqr_buffer!(A :: AbstractMatrix{FC}, tau :: AbstractVector{FC}) where FC <: FloatOrComplex = 0
+kunmqr_buffer!(side :: Char, trans :: Char, A :: AbstractMatrix{FC}, tau :: AbstractVector{FC}, C :: AbstractMatrix{FC}) where FC <: FloatOrComplex = 0

--- a/src/block_krylov_utils.jl
+++ b/src/block_krylov_utils.jl
@@ -299,3 +299,155 @@ korgqr!(A :: AbstractMatrix{T}, tau :: AbstractVector{T}, buffer:: AbstractVecto
 
 kormqr!(side :: Char, trans :: Char, A :: AbstractMatrix{T}, tau :: AbstractVector{T}, C :: AbstractMatrix{T}) where T <: BLAS.BlasFloat = LAPACK.ormqr!(side, trans, A, tau, C)
 kormqr!(side :: Char, trans :: Char, A :: AbstractMatrix{T}, tau :: AbstractVector{T}, C :: AbstractMatrix{T}, buffer:: AbstractVector{T}) where T <: BLAS.BlasFloat = LAPACK.ormqr!(side, trans, A, tau, C)
+
+# """
+#     β, τ = larfg!(α, x)
+#
+# Generate an elementary Householder reflector `H = I - τ vvᴴ` such that
+# `Hᴴ * [α; x] = [β; 0]` (LAPACK convention; `H` is not hermitian in the complex
+# case), where `v = [1; y]` and `β` is the (signed) Euclidean norm of `[α; x]`.
+# On output `x` is overwritten by the tail `y` of `v`.
+# """
+function larfg!(α::FC, x::AbstractVector{FC}) where FC <: FloatOrComplex
+  T = real(FC)
+  n = length(x)
+  xnorm = knorm(n, x)
+  if xnorm == zero(T) && imag(α) == zero(T)
+    return real(α), zero(FC)
+  end
+  β = -copysign(hypot(abs(α), xnorm), real(α))
+  τ = (β - α) / β
+  kdiv!(n, x, α - β)
+  return β, τ
+end
+
+# """
+#     A = geqrf!(A, tau)
+#
+# Reduced QR factorization via Householder reflections.
+# On output the upper triangle of `A` holds `R`, and the reflectors are stored
+# below the diagonal together with the scalars `τ`.
+# """
+function geqrf!(A::AbstractMatrix{FC}, tau::AbstractVector{FC}) where FC <: FloatOrComplex
+  m, n = size(A)
+  k = min(m, n)
+  for i = 1:k
+    x = view(A, i+1:m, i)
+    βi, τi = larfg!(A[i,i], x)
+    tau[i] = τi
+    if i < n && τi != zero(FC)
+      A[i,i] = one(FC)
+      v = view(A, i:m, i)
+      p = m - i + 1
+      for j = i+1:n
+        c = view(A, i:m, j)
+        s = kdot(p, v, c)
+        kaxpy!(p, -conj(τi) * s, v, c)
+      end
+    end
+    A[i,i] = βi
+  end
+  return A
+end
+
+# """
+#     A = orgqr!(A, tau)
+#
+# Form the orthonormal factor `Q` from the reflectors produced by [`geqrf!`](@ref), overwriting `A`.
+# """
+function orgqr!(A::AbstractMatrix{FC}, tau::AbstractVector{FC}) where FC <: FloatOrComplex
+  m, n = size(A)
+  k = length(tau)
+  for j = k+1:n
+    for l = 1:m
+      A[l,j] = zero(FC)
+    end
+    A[j,j] = one(FC)
+  end
+  for i = k:-1:1
+    τi = tau[i]
+    if i < n && τi != zero(FC)
+      A[i,i] = one(FC)
+      v = view(A, i:m, i)
+      p = m - i + 1
+      for j = i+1:n
+        c = view(A, i:m, j)
+        s = kdot(p, v, c)
+        kaxpy!(p, -τi * s, v, c)
+      end
+    end
+    for l = i+1:m
+      A[l,i] = -τi * A[l,i]
+    end
+    A[i,i] = one(FC) - τi
+    for l = 1:i-1
+      A[l,i] = zero(FC)
+    end
+  end
+  return A
+end
+
+# """
+#     C = ormqr!(side, trans, A, tau, C)
+#
+# Apply Q or Qᴴ (stored as reflectors in `A` with scalars `τ`) to the matrix `C`
+# from the left ('L') or the right ('R'), using the reflectors computed by [`geqrf!`](@ref).
+# """
+function ormqr!(side::Char, trans::Char, A::AbstractMatrix{FC}, tau::AbstractVector{FC}, C::AbstractMatrix{FC}) where FC <: FloatOrComplex
+  m, n = size(C)
+  k = length(tau)
+  notran = (trans == 'N')
+  if side == 'L'
+    rng = notran ? (k:-1:1) : (1:k)
+    for i in rng
+      τi = notran ? tau[i] : conj(tau[i])
+      τi == zero(FC) && continue
+      Aii = A[i,i]
+      A[i,i] = one(FC)
+      v = view(A, i:m, i)
+      p = m - i + 1
+      for j = 1:n
+        c = view(C, i:m, j)
+        s = kdot(p, v, c)
+        kaxpy!(p, -τi * s, v, c)
+      end
+      A[i,i] = Aii
+    end
+  else  # side == 'R'
+    rng = notran ? (1:k) : (k:-1:1)
+    for i in rng
+      τi = notran ? tau[i] : conj(tau[i])
+      τi == zero(FC) && continue
+      Aii = A[i,i]
+      A[i,i] = one(FC)
+      v = view(A, i:n, i)
+      q = n - i + 1
+      for a = 1:m
+        r = view(C, a, i:n)
+        s = zero(FC)
+        for t = 1:q
+          s += r[t] * v[t]
+        end
+        d = τi * s
+        for t = 1:q
+          r[t] -= d * conj(v[t])
+        end
+      end
+      A[i,i] = Aii
+    end
+  end
+  return C
+end
+
+kgeqrf!(A :: AbstractMatrix{FC}, tau :: AbstractVector{FC}) where FC <: FloatOrComplex = geqrf!(A, tau)
+kgeqrf!(A :: AbstractMatrix{FC}, tau :: AbstractVector{FC}, buffer :: AbstractVector{FC}) where FC <: FloatOrComplex = geqrf!(A, tau)
+
+korgqr!(A :: AbstractMatrix{FC}, tau :: AbstractVector{FC}) where FC <: FloatOrComplex = orgqr!(A, tau)
+korgqr!(A :: AbstractMatrix{FC}, tau :: AbstractVector{FC}, buffer :: AbstractVector{FC}) where FC <: FloatOrComplex = orgqr!(A, tau)
+
+kormqr!(side :: Char, trans :: Char, A :: AbstractMatrix{FC}, tau :: AbstractVector{FC}, C :: AbstractMatrix{FC}) where FC <: FloatOrComplex = ormqr!(side, trans, A, tau, C)
+kormqr!(side :: Char, trans :: Char, A :: AbstractMatrix{FC}, tau :: AbstractVector{FC}, C :: AbstractMatrix{FC}, buffer :: AbstractVector{FC}) where FC <: FloatOrComplex = ormqr!(side, trans, A, tau, C)
+
+kgeqrf_buffer!(A :: AbstractMatrix{FC}, tau :: AbstractVector{FC}) where FC <: FloatOrComplex = 0
+korgqr_buffer!(A :: AbstractMatrix{FC}, tau :: AbstractVector{FC}) where FC <: FloatOrComplex = 0
+kormqr_buffer!(side :: Char, trans :: Char, A :: AbstractMatrix{FC}, tau :: AbstractVector{FC}, C :: AbstractMatrix{FC}) where FC <: FloatOrComplex = 0

--- a/src/block_krylov_workspaces.jl
+++ b/src/block_krylov_workspaces.jl
@@ -80,9 +80,9 @@ function BlockMinresWorkspace(m::Integer, n::Integer, p::Integer, SV::Type, SM::
   SV = isconcretetype(SV) ? SV : typeof(τₖ₋₁)
   SM = isconcretetype(SM) ? SM : typeof(X)
   stats = SimpleStats(0, false, false, false, 0, T[], T[], T[], 0.0, 0.0, "unknown")
-  size_buffer = C isa Matrix ? max(kgeqrf_buffer!(Vₖ, τₖ₋₁), kgeqrf_buffer!(Hₖ₋₁, τₖ₋₁),
-                                   korgqr_buffer!(Vₖ, τₖ₋₁), korgqr_buffer!(Hₖ₋₁, τₖ₋₁),
-                                   kormqr_buffer!('L', FC <: AbstractFloat ? 'T' : 'C', Hₖ₋₁, τₖ₋₁, D)) : 0
+  size_buffer = max(kgeqrf_buffer!(Vₖ, τₖ₋₁), kgeqrf_buffer!(Hₖ₋₁, τₖ₋₁),
+                    kungqr_buffer!(Vₖ, τₖ₋₁), kungqr_buffer!(Hₖ₋₁, τₖ₋₁),
+                    kunmqr_buffer!('L', FC <: AbstractFloat ? 'T' : 'C', Hₖ₋₁, τₖ₋₁, D))
   buffer = SV(undef, size_buffer)
   workspace = BlockMinresWorkspace{T,FC,SV,SM}(m, n, p, ΔX, X, P, Q, C, D, Φ, Ψₖ, Ωₖ, Ψₖ₊₁, Πₖ₋₂, Γbarₖ₋₁, Γₖ₋₁, Λbarₖ, Λₖ,
                                                Vₖ₋₁, Vₖ, wₖ₋₂, wₖ₋₁, wₖ, Hₖ₋₂, Hₖ₋₁, τₖ₋₂, τₖ₋₁, buffer, false, stats)
@@ -152,9 +152,9 @@ function BlockGmresWorkspace(m::Integer, n::Integer, p::Integer, SV::Type, SM::T
   τ  = SV[SV(undef, p) for i = 1 : memory]
   SV = isconcretetype(SV) ? SV : typeof(τ)
   SM = isconcretetype(SM) ? SM : typeof(X)
-  size_buffer = C isa Matrix ? max(kgeqrf_buffer!(V[1], τ[1]), kgeqrf_buffer!(H[1], τ[1]),
-                                   korgqr_buffer!(V[1], τ[1]), korgqr_buffer!(H[1], τ[1]),
-                                   kormqr_buffer!('L', FC <: AbstractFloat ? 'T' : 'C', H[1], τ[1], D)) : 0
+  size_buffer = max(kgeqrf_buffer!(V[1], τ[1]), kgeqrf_buffer!(H[1], τ[1]),
+                    kungqr_buffer!(V[1], τ[1]), kungqr_buffer!(H[1], τ[1]),
+                    kunmqr_buffer!('L', FC <: AbstractFloat ? 'T' : 'C', H[1], τ[1], D))
   buffer = SV(undef, size_buffer)
   stats = SimpleStats(0, false, false, false, 0, T[], T[], T[], 0.0, 0.0, "unknown")
   workspace = BlockGmresWorkspace{T,FC,SV,SM}(m, n, p, ΔX, X, W, P, Q, C, D, V, Z, R, H, τ, buffer, false, stats)

--- a/src/block_minres.jl
+++ b/src/block_minres.jl
@@ -206,7 +206,7 @@ kwargs_block_minres = (:M, :ldiv, :atol, :rtol, :itmax, :timemax, :verbose, :his
       if iter ≥ 3
         D1 .= zero(T)
         D2 .= Ψₖ'
-        kormqr!('L', trans, Hₖ₋₂, τₖ₋₂, D, buffer)
+        kunmqr!('L', trans, Hₖ₋₂, τₖ₋₂, D, buffer)
         Πₖ₋₂ .= D1
         Γbarₖ₋₁ .= D2
       end
@@ -216,7 +216,7 @@ kwargs_block_minres = (:M, :ldiv, :atol, :rtol, :itmax, :timemax, :verbose, :his
         (iter == 2) && (Γbarₖ₋₁ .= Ψₖ')
         D1 .= Γbarₖ₋₁
         D2 .= Ωₖ
-        kormqr!('L', trans, Hₖ₋₁, τₖ₋₁, D, buffer)
+        kunmqr!('L', trans, Hₖ₋₁, τₖ₋₁, D, buffer)
         Γₖ₋₁ .= D1
         Λbarₖ .= D2
       end
@@ -236,7 +236,7 @@ kwargs_block_minres = (:M, :ldiv, :atol, :rtol, :itmax, :timemax, :verbose, :his
       # Update Zₖ = (Qₖ)ᴴΨ₁E₁ = (Φ₁, ..., Φₖ, Φbarₖ₊₁)
       D1 .= Φbarₖ
       D2 .= zero(FC)
-      kormqr!('L', trans, Hₖ, τₖ, D, buffer)
+      kunmqr!('L', trans, Hₖ, τₖ, D, buffer)
       Φₖ .= D1
 
       # Compute the directions Wₖ, the last columns of Wₖ = Vₖ(Rₖ)⁻¹ ⟷ (Rₖ)ᵀ(Wₖ)ᵀ = (Vₖ)ᵀ

--- a/test/test_aux.jl
+++ b/test/test_aux.jl
@@ -191,4 +191,95 @@
       Krylov.kref!(n, x, y, c, s)
     end
   end
+
+  @testset "reduced QR (larfg! / geqrf! / orgqr! / ormqr!)" begin
+    @testset "accuracy $FC" for FC in (Float32, Float64, ComplexF32, ComplexF64, BigFloat, Complex{BigFloat})
+      T = real(FC)
+      tol = sqrt(eps(T))
+      for (m, k) in ((10, 4), (6, 6))
+        A = rand(FC, m, k)
+
+        # larfg!: Hᴴ [α; x] = [β; 0] with v = [1; tail]  (LAPACK convention)
+        α = A[1,1]
+        x = A[2:m, 1]
+        xold = copy(x)
+        β, τ = Krylov.larfg!(α, x)
+        v = vcat(one(FC), x)
+        u = vcat(α, xold)
+        Hᴴu = u - conj(τ) * v * (v' * u)
+        @test abs(β) ≈ norm(u) atol=tol
+        @test Hᴴu[1] ≈ β atol=tol
+        @test norm(Hᴴu[2:end]) ≤ tol
+
+        # geqrf! + orgqr!: reduced QR factorization
+        QR = copy(A)
+        tau = zeros(FC, k)
+        Krylov.geqrf!(QR, tau)
+        R = triu(QR[1:k, 1:k])
+        Krylov.orgqr!(QR, tau)
+        Q = QR[:, 1:k]
+        @test istriu(R)
+        @test norm(Q' * Q - I) ≤ tol
+        @test norm(Q * R - A) ≤ tol
+
+        Aref = copy(A)
+        tauref = zeros(FC, k)
+        Krylov.geqrf!(Aref, tauref)
+        Qfull = zeros(FC, m, m)
+        Qfull[:, 1:k] .= Aref
+        Krylov.orgqr!(Qfull, tauref)
+        nc = 5
+        for trans in (FC <: Complex ? ('N', 'C') : ('N', 'T', 'C'))
+          op = trans == 'N' ? Qfull : Qfull'
+          C = rand(FC, m, nc)
+          @test norm(Krylov.ormqr!('L', trans, copy(Aref), tauref, copy(C)) - op * C) ≤ tol
+          D = rand(FC, nc, m)
+          @test norm(Krylov.ormqr!('R', trans, copy(Aref), tauref, copy(D)) - D * op) ≤ tol
+        end
+      end
+    end
+
+    @testset "matches LAPACK $FC" for FC in (Float32, Float64, ComplexF32, ComplexF64)
+      m, k = 9, 4
+      A = rand(FC, m, k)
+      Qg = copy(A); tg = zeros(FC, k); Krylov.geqrf!(Qg, tg);  Krylov.orgqr!(Qg, tg)   # pure Julia
+      Ql = copy(A); tl = zeros(FC, k); Krylov.kgeqrf!(Ql, tl); Krylov.korgqr!(Ql, tl)  # LAPACK
+      # Q is defined up to a phase, so compare the (phase-invariant) projectors
+      @test Qg[:, 1:k] * Qg[:, 1:k]' ≈ Ql[:, 1:k] * Ql[:, 1:k]'
+    end
+
+    @testset "no allocations $FC" for FC in (Float16, ComplexF16)
+      m, k, nc = 12, 4, 5
+
+      A = rand(FC, m, k); tau = zeros(FC, k)
+      Krylov.geqrf!(copy(A), copy(tau))
+      Ag = copy(A)
+      taug = copy(tau)
+      @test (@allocated Krylov.geqrf!(Ag, taug)) == 0
+
+      Af = copy(A)
+      tf = zeros(FC, k)
+      Krylov.geqrf!(Af, tf)
+      Krylov.orgqr!(copy(Af), tf)
+      Ao = copy(Af)
+      @test (@allocated Krylov.orgqr!(Ao, tf)) == 0
+
+      CL = rand(FC, m, nc)   # left  operand
+      CR = rand(FC, nc, m)   # right operand
+      Krylov.ormqr!('L', 'N', Af, tf, copy(CL))
+      for trans in (FC <: Complex ? ('N', 'C') : ('N', 'T', 'C'))
+        DL = copy(CL)
+        @test (@allocated Krylov.ormqr!('L', trans, Af, tf, DL)) == 0
+        DR = copy(CR)
+        @test (@allocated Krylov.ormqr!('R', trans, Af, tf, DR)) == 0
+      end
+
+      if VERSION ≥ v"1.12"
+        α = rand(FC); x = rand(FC, m-1)
+        Krylov.larfg!(α, copy(x))
+        xl = copy(x)
+        @test (@allocated Krylov.larfg!(α, xl)) == 0
+      end
+    end
+  end
 end

--- a/test/test_aux.jl
+++ b/test/test_aux.jl
@@ -193,9 +193,9 @@
   end
 
   @testset "reduced QR (larfg! / geqrf! / orgqr! / ormqr!)" begin
-    @testset "accuracy $FC" for FC in (Float32, Float64, ComplexF32, ComplexF64, BigFloat, Complex{BigFloat})
+    @testset "accuracy $FC" for FC in (Float32, Float64, ComplexF32, ComplexF64, Complex{BigFloat}, BigFloat)
       T = real(FC)
-      tol = sqrt(eps(T))
+      tol = 100 * eps(T)
       for (m, k) in ((10, 4), (6, 6))
         A = rand(FC, m, k)
 
@@ -214,27 +214,27 @@
         # geqrf! + orgqr!: reduced QR factorization
         QR = copy(A)
         tau = zeros(FC, k)
-        Krylov.geqrf!(QR, tau)
+        Krylov.geqr2!(QR, tau)
         R = triu(QR[1:k, 1:k])
-        Krylov.orgqr!(QR, tau)
+        Krylov.ung2r!(QR, tau)
         Q = QR[:, 1:k]
         @test istriu(R)
         @test norm(Q' * Q - I) ≤ tol
-        @test norm(Q * R - A) ≤ tol
+        @test norm(Q * R - A) ≤ tol * norm(A)
 
         Aref = copy(A)
         tauref = zeros(FC, k)
-        Krylov.geqrf!(Aref, tauref)
+        Krylov.geqr2!(Aref, tauref)
         Qfull = zeros(FC, m, m)
         Qfull[:, 1:k] .= Aref
-        Krylov.orgqr!(Qfull, tauref)
+        Krylov.ung2r!(Qfull, tauref)
         nc = 5
         for trans in (FC <: Complex ? ('N', 'C') : ('N', 'T', 'C'))
           op = trans == 'N' ? Qfull : Qfull'
           C = rand(FC, m, nc)
-          @test norm(Krylov.ormqr!('L', trans, copy(Aref), tauref, copy(C)) - op * C) ≤ tol
+          @test norm(Krylov.unm2r!('L', trans, copy(Aref), tauref, copy(C)) - op * C) ≤ tol
           D = rand(FC, nc, m)
-          @test norm(Krylov.ormqr!('R', trans, copy(Aref), tauref, copy(D)) - D * op) ≤ tol
+          @test norm(Krylov.unm2r!('R', trans, copy(Aref), tauref, copy(D)) - D * op) ≤ tol
         end
       end
     end
@@ -242,8 +242,8 @@
     @testset "matches LAPACK $FC" for FC in (Float32, Float64, ComplexF32, ComplexF64)
       m, k = 9, 4
       A = rand(FC, m, k)
-      Qg = copy(A); tg = zeros(FC, k); Krylov.geqrf!(Qg, tg);  Krylov.orgqr!(Qg, tg)   # pure Julia
-      Ql = copy(A); tl = zeros(FC, k); Krylov.kgeqrf!(Ql, tl); Krylov.korgqr!(Ql, tl)  # LAPACK
+      Qg = copy(A); tg = zeros(FC, k); Krylov.geqr2!(Qg, tg);  Krylov.ung2r!(Qg, tg)   # pure Julia
+      Ql = copy(A); tl = zeros(FC, k); Krylov.kgeqrf!(Ql, tl); Krylov.kungqr!(Ql, tl)  # LAPACK
       # Q is defined up to a phase, so compare the (phase-invariant) projectors
       @test Qg[:, 1:k] * Qg[:, 1:k]' ≈ Ql[:, 1:k] * Ql[:, 1:k]'
     end
@@ -252,26 +252,26 @@
       m, k, nc = 12, 4, 5
 
       A = rand(FC, m, k); tau = zeros(FC, k)
-      Krylov.geqrf!(copy(A), copy(tau))
+      Krylov.geqr2!(copy(A), copy(tau))
       Ag = copy(A)
       taug = copy(tau)
-      @test (@allocated Krylov.geqrf!(Ag, taug)) == 0
+      @test (@allocated Krylov.geqr2!(Ag, taug)) == 0
 
       Af = copy(A)
       tf = zeros(FC, k)
-      Krylov.geqrf!(Af, tf)
-      Krylov.orgqr!(copy(Af), tf)
+      Krylov.geqr2!(Af, tf)
+      Krylov.ung2r!(copy(Af), tf)
       Ao = copy(Af)
-      @test (@allocated Krylov.orgqr!(Ao, tf)) == 0
+      @test (@allocated Krylov.ung2r!(Ao, tf)) == 0
 
-      CL = rand(FC, m, nc)   # left  operand
+      CL = rand(FC, m, nc)   # left operand
       CR = rand(FC, nc, m)   # right operand
-      Krylov.ormqr!('L', 'N', Af, tf, copy(CL))
+      Krylov.unm2r!('L', 'N', Af, tf, copy(CL))
       for trans in (FC <: Complex ? ('N', 'C') : ('N', 'T', 'C'))
         DL = copy(CL)
-        @test (@allocated Krylov.ormqr!('L', trans, Af, tf, DL)) == 0
+        @test (@allocated Krylov.unm2r!('L', trans, Af, tf, DL)) == 0
         DR = copy(CR)
-        @test (@allocated Krylov.ormqr!('R', trans, Af, tf, DR)) == 0
+        @test (@allocated Krylov.unm2r!('R', trans, Af, tf, DR)) == 0
       end
 
       if VERSION ≥ v"1.12"


### PR DESCRIPTION
Add a generic Julia implementation for `larfg`, `geqrf`, `orgqr` and `ormqr` (LAPACK routines).
It allows support for any precision with the block Krylov solvers implemented in `Krylov.jl` (block-MINRES / block-GMRES).

@langou It could be relevant for you if we want one day we use what you presented at Saint-Girons.