### PR TITLE
feature: trust region support in DIOM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ benchmark/tune.json
 benchmark/commit.md
 benchmark/main.md
 benchmark/judgement.md
+.DS_Store

--- a/src/cg.jl
+++ b/src/cg.jl
@@ -71,7 +71,7 @@ For an in-place variant that reuses memory across solves, see [`cg!`](@ref).
 #### Output arguments
 
 * `x`: a dense vector of length `n`;
-* `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
+* `stats`: statistics collected on the run in a [`DiomCgStats`](@ref) structure.
 
 #### Reference
 
@@ -144,6 +144,7 @@ kwargs_cg = (:M, :ldiv, :radius, :linesearch, :atol, :rtol, :itmax, :timemax, :v
     Δx, x, r, p, Ap, stats = workspace.Δx, workspace.x, workspace.r, workspace.p, workspace.Ap, workspace.stats
     warm_start = workspace.warm_start
     rNorms = stats.residuals
+    qxs = stats.qvals
     reset!(stats)
     z = MisI ? r : workspace.z
     if linesearch || (radius > 0)
@@ -153,16 +154,21 @@ kwargs_cg = (:M, :ldiv, :radius, :linesearch, :atol, :rtol, :itmax, :timemax, :v
     kfill!(x, zero(FC))
     if warm_start
       mul!(r, A, Δx)
+      (radius > 0) && (qx = kdot(n, Δx, r) / 2 - kdot(n, b, Δx))    # q(x₀) = ½ΔxᵀAΔx - bᵀΔx
       kaxpby!(n, one(FC), b, -one(FC), r)
     else
       kcopy!(n, r, b)  # r ← b
+      (radius > 0) && (qx = zero(T))                 # q(0) = 0
     end
     MisI || mulorldiv!(z, M, r, ldiv)
     kcopy!(n, p, z)  # p ← z
     γ = kdotr(n, r, z)
     γ ≥ 0 || error("The linear operator `A` or the preconditioner `M` is not symmetric positive definite.")
     rNorm = sqrt(γ)
-    history && push!(rNorms, rNorm)
+    if history
+      push!(rNorms, rNorm)
+      (radius > 0) && push!(qxs, qx)
+    end
     if γ == 0
       stats.niter = 0
       stats.solved, stats.inconsistent = true, false
@@ -242,7 +248,12 @@ kwargs_cg = (:M, :ldiv, :radius, :linesearch, :atol, :rtol, :itmax, :timemax, :v
       γ_next = kdotr(n, r, z)
       γ_next ≥ 0 || error("The linear operator `A` or the preconditioner `M` is not symmetric positive definite.")
       rNorm = sqrt(γ_next)
-      history && push!(rNorms, rNorm)
+      (radius > 0) && (qx +=  α^2 * pAp / 2 - α * γ)   # q(x) = q(x) + α²pᵀAp/2 - αbᵀp = q(x) + α²pᵀAp/2 - αγ
+
+      if history
+        push!(rNorms, rNorm)
+        (radius > 0) && push!(qxs, qx)
+      end
 
       # Stopping conditions that do not depend on user input.
       # This is to guard against tolerances that are unreasonably small.

--- a/src/diom.jl
+++ b/src/diom.jl
@@ -55,7 +55,13 @@ For an in-place variant that reuses memory across solves, see [`diom!`](@ref).
 * `memory`: the number of most recent vectors of the Krylov basis against which to orthogonalize a new vector;
 * `M`: linear operator that models a nonsingular matrix of size `n` used for left preconditioning;
 * `N`: linear operator that models a nonsingular matrix of size `n` used for right preconditioning;
+
+  **Note on preconditioners:**  
+  - When `radius > 0`, we assumes that `A = A*`. In this case, following CG implementation, `N` should be Hermitian and `M = N``.  
+
 * `ldiv`: define whether the preconditioners use `ldiv!` or `mul!`;
+* `radius`: add the trust-region constraint ‖x‖ ≤ `radius` if `radius > 0`. Only useful for computing a step in a trust-region optimization method when A is Hermitian.
+  If 'radius' > 0, and nonpositive curvature is detected along the current search direction, we take the step to the trust-region boundary,
 * `reorthogonalization`: reorthogonalize the new vectors of the Krylov basis against the `memory` most recent vectors;
 * `atol`: absolute stopping tolerance based on the residual norm;
 * `rtol`: relative stopping tolerance based on the residual norm;
@@ -69,7 +75,7 @@ For an in-place variant that reuses memory across solves, see [`diom!`](@ref).
 #### Output arguments
 
 * `x`: a dense vector of length `n`;
-* `stats`: statistics collected on the run in a [`SimpleStats`](@ref) structure.
+* `stats`: statistics collected on the run in a [`DiomCgStats`](@ref) structure.
 
 #### Reference
 
@@ -101,6 +107,7 @@ def_optargs_diom = (:(x0::AbstractVector),)
 def_kwargs_diom = (:(; M = I                            ),
                    :(; N = I                            ),
                    :(; ldiv::Bool = false               ),
+                   :(; radius::T = zero(T)              ),
                    :(; reorthogonalization::Bool = false),
                    :(; atol::T = √eps(T)                ),
                    :(; rtol::T = √eps(T)                ),
@@ -115,7 +122,7 @@ def_kwargs_diom = extract_parameters.(def_kwargs_diom)
 
 args_diom = (:A, :b)
 optargs_diom = (:x0,)
-kwargs_diom = (:M, :N, :ldiv, :reorthogonalization, :atol, :rtol, :itmax, :timemax, :verbose, :history, :callback, :iostream)
+kwargs_diom = (:M, :N, :ldiv, :radius, :reorthogonalization, :atol, :rtol, :itmax, :timemax, :verbose, :history, :callback, :iostream)
 
 @eval begin
   function diom!(workspace :: DiomWorkspace{T,FC,S}, $(def_args_diom...); $(def_kwargs_diom...)) where {T <: AbstractFloat, FC <: FloatOrComplex{T}, S <: AbstractVector{FC}}
@@ -133,7 +140,8 @@ kwargs_diom = (:M, :N, :ldiv, :reorthogonalization, :atol, :rtol, :itmax, :timem
     # Check M = Iₙ and N = Iₙ
     MisI = (M === I)
     NisI = (N === I)
-
+    # Check M = N
+    MisN = (M === N)
     # Check type consistency
     eltype(A) == FC || @warn "eltype(A) ≠ $FC. This could lead to errors or additional allocations in operator-vector products."
     ktypeof(b) == S || error("ktypeof(b) must be equal to $S")
@@ -141,25 +149,34 @@ kwargs_diom = (:M, :N, :ldiv, :reorthogonalization, :atol, :rtol, :itmax, :timem
     # Set up workspace.
     allocate_if(!MisI, workspace, :w, S, workspace.x)  # The length of w is n
     allocate_if(!NisI, workspace, :z, S, workspace.x)  # The length of z is n
+    
     Δx, x, t, P, V = workspace.Δx, workspace.x, workspace.t, workspace.P, workspace.V
     L, H, stats = workspace.L, workspace.H, workspace.stats
     warm_start = workspace.warm_start
     rNorms = stats.residuals
+    qxs = stats.qvals
     reset!(stats)
     w  = MisI ? t : workspace.w
     r₀ = MisI ? t : workspace.w
+    
 
-    # Initial solution x₀ and residual r₀.
-    kfill!(x, zero(FC))  # x₀
+    # Initial solution x₀, residual r₀ and q(x₀).
+    kfill!(x, zero(FC))  # x₀ ← 0
     if warm_start
-      mul!(t, A, Δx)
+      mul!(t, A, Δx) 
+      (radius > 0) &&  (qx = kdot(n, Δx, t) / 2 - kdot(n, b, Δx))    # q(x₀) = ½ΔxᵀAΔx - bᵀΔx
       kaxpby!(n, one(FC), b, -one(FC), t)
     else
       kcopy!(n, t, b)  # t ← b
+      (radius > 0) && (qx = zero(T))  # Quadratic model value at x₀ = 0
     end
     MisI || mulorldiv!(r₀, M, t, ldiv)  # M(b - Ax₀)
     rNorm = knorm(n, r₀)                # β = ‖r₀‖₂
-    history && push!(rNorms, rNorm)
+    ukk = zero(FC)                      # uₖ.ₖ is used if we hit the trust-region boundary
+    if history
+      push!(rNorms, rNorm)
+      (radius > 0) && push!(qxs, qx)
+    end
     if rNorm == 0
       stats.niter = 0
       stats.solved, stats.inconsistent = true, false
@@ -184,6 +201,7 @@ kwargs_diom = (:M, :N, :ldiv, :reorthogonalization, :atol, :rtol, :itmax, :timem
     for i = 1 : mem-1
       kfill!(P[i], zero(FC))  # Directions Pₖ = NVₖ(Uₖ)⁻¹.
     end
+    
     kfill!(H, zero(FC))  # Last column of the band hessenberg matrix Hₖ = LₖUₖ.
     # Each column has at most mem + 1 nonzero elements.
     # hᵢ.ₖ is stored as H[k-i+1], i ≤ k. hₖ₊₁.ₖ is not stored in H.
@@ -197,12 +215,13 @@ kwargs_diom = (:M, :N, :ldiv, :reorthogonalization, :atol, :rtol, :itmax, :timem
 
     # Stopping criterion.
     solved = rNorm ≤ ε
+    on_boundary = false
     tired = iter ≥ itmax
     status = "unknown"
     user_requested_exit = false
     overtimed = false
 
-    while !(solved || tired || user_requested_exit || overtimed)
+    while !(solved || tired || user_requested_exit || overtimed || on_boundary)
 
       # Update iteration index.
       iter = iter + 1
@@ -280,6 +299,35 @@ kwargs_diom = (:M, :N, :ldiv, :reorthogonalization, :atol, :rtol, :itmax, :timem
       end
       # pₐᵤₓ ← pₐᵤₓ + Nvₖ
       kaxpy!(n, one(FC), z, P[ppos])
+
+      # Compute step size to boundary if applicable.
+      if radius == 0
+         σ = 1/H[1]  
+      elseif NisI && MisI
+         # pcg =  ξₖ * pₐᵤₓ
+         kscal!(n, ξ, P[ppos])
+         σ = maximum(to_boundary(n, x,  P[ppos], z, radius))
+      elseif MisN
+         σ = maximum(to_boundary(n, x,  P[ppos], z, radius, M=M, ldiv=!ldiv)) 
+      else
+         error("Must use split preconditioning with M = N when radius > 0")
+      end
+
+      # Move along p from x to the boundary if either
+      # the next step leads outside the trust region or
+      # we have nonpositive curvature.
+      if radius > 0
+        indefinite = real(H[1]) ≤ 0
+        stats.indefinite = indefinite
+        σinv = 1 / σ
+        on_boundary = indefinite || (real(H[1]) < σinv)
+        if on_boundary
+          ukk = H[1]
+          H[1] = σinv
+        end
+        # pₐᵤₓ = pcg / ξₖ
+        kdiv!(n, P[ppos], ξ)
+      end
       # pₖ = pₐᵤₓ / uₖ.ₖ
       kdiv!(n, P[ppos], H[1])
 
@@ -288,9 +336,17 @@ kwargs_diom = (:M, :N, :ldiv, :reorthogonalization, :atol, :rtol, :itmax, :timem
       kaxpy!(n, ξ, P[ppos], x)
 
       # Compute residual norm.
-      # ‖ M(b - Axₖ) ‖₂ = hₖ₊₁.ₖ * |ξₖ / uₖ.ₖ|
-      rNorm = Haux * abs(ξ / H[1])
-      history && push!(rNorms, rNorm)
+      if !on_boundary
+        rNorm = Haux * abs(ξ / H[1]) # ‖ M(b - Axₖ) ‖₂ = hₖ₊₁.ₖ * |ξₖ / uₖ.ₖ| 
+        (radius > 0) &&  (qx -= abs(ξ)^2 / abs(H[1]) / 2)   # q(xₖ) = q(xₖ₋₁) -0.5*ξₖ²/uₖ.ₖ         
+      else 
+        rNorm = sqrt(abs(rNorm - abs(ξ) * ukk * σ)^2 + abs(Haux * ξ * σ)^2) # ‖ M(b - Axₖ) ‖₂ if we hit the boundary
+        qx += (real(σ)^2 / 2) * real(ξ)^2 * real(ukk) - σ * real(ξ)^2   # q(xₖ) if we hit the boundary
+      end
+      if history
+        push!(rNorms, rNorm)
+        (radius > 0) && push!(qxs, qx)
+      end
 
       # Stopping conditions that do not depend on user input.
       # This is to guard against tolerances that are unreasonably small.
@@ -308,6 +364,7 @@ kwargs_diom = (:M, :N, :ldiv, :reorthogonalization, :atol, :rtol, :itmax, :timem
     (verbose > 0) && @printf(iostream, "\n")
 
     # Termination status
+    on_boundary         && (status = "on trust-region boundary")
     tired               && (status = "maximum number of iterations exceeded")
     solved              && (status = "solution good enough given atol and rtol")
     user_requested_exit && (status = "user-requested exit")

--- a/src/krylov_stats.jl
+++ b/src/krylov_stats.jl
@@ -6,6 +6,57 @@ import Base.copyto!
 abstract type KrylovStats{T} end
 
 """
+Type for storing statistics returned by diom.
+
+The fields are as follows:
+- `niter`: The total number of iterations completed by the solver;
+- `solved`: Indicates whether the solver successfully reached convergence (`true` if solved, `false` otherwise);
+- `inconsistent`: Flags whether the system was detected as inconsistent (i.e., when `b` is not in the range of `A`);
+- `indefinite`: Flags whether the system was detected as indefinite (i.e., when `A` is not positive definite);
+- `npcCount`: The number of nonpositive curvature directions encountered during the solve;
+- `residuals`: A vector containing the residual norms at each iteration;
+- `Aresiduals`: A vector of `A'`-residual norms at each iteration;
+- `qvals`: A vector of quadratic model values at each iteration;
+- `Acond`: An estimate of the condition number of matrix `A`.
+- `timer`: The elapsed time (in seconds) taken by the solver to complete all iterations;
+- `status`: A string indicating the outcome of the solve, providing additional details beyond `solved`.
+"""
+mutable struct DiomCgStats{T} <: KrylovStats{T}
+  niter        :: Int
+  solved       :: Bool
+  inconsistent :: Bool
+  indefinite   :: Bool
+  npcCount     :: Int
+  residuals    :: Vector{T}
+  Aresiduals   :: Vector{T}
+  qvals       :: Vector{T}   
+  Acond        :: Vector{T}
+  timer        :: Float64
+  status       :: String
+end
+
+function reset!(stats :: DiomCgStats)
+  empty!(stats.residuals)
+  empty!(stats.Aresiduals)
+  empty!(stats.qvals)
+  empty!(stats.Acond)
+end
+
+function copyto!(dest :: DiomCgStats, src :: DiomCgStats)
+  dest.niter        = src.niter
+  dest.solved       = src.solved
+  dest.inconsistent = src.inconsistent
+  dest.indefinite   = src.indefinite
+  dest.npcCount     = src.npcCount
+  dest.residuals    = copy(src.residuals)
+  dest.Aresiduals   = copy(src.Aresiduals)
+  dest.qvals       = copy(src.qvals)
+  dest.Acond        = copy(src.Acond)
+  dest.timer        = src.timer
+  dest.status       = src.status
+  return dest
+end
+"""
 Type for storing statistics returned by the majority of (block) Krylov solvers.
 
 The fields are as follows:

--- a/src/krylov_workspaces.jl
+++ b/src/krylov_workspaces.jl
@@ -211,7 +211,7 @@ mutable struct CgWorkspace{T,FC,S} <: KrylovWorkspace{T,FC,S}
   Ap         :: S
   z          :: S
   warm_start :: Bool
-  stats      :: SimpleStats{T}
+  stats      :: DiomCgStats{T}
 end
 
 function CgWorkspace(kc::KrylovConstructor)
@@ -227,7 +227,7 @@ function CgWorkspace(kc::KrylovConstructor)
   p  = similar(kc.vn)
   Ap = similar(kc.vn)
   z  = similar(kc.vn_empty)
-  stats = SimpleStats(0, false, false, false, 0, T[], T[], T[], 0.0, "unknown")
+  stats = DiomCgStats(0, false, false, false, 0, T[], T[], T[], T[], 0.0, "unknown")
   workspace = CgWorkspace{T,FC,S}(m, n, Δx, x, r, npc_dir, p, Ap, z, false, stats)
   return workspace
 end
@@ -243,7 +243,7 @@ function CgWorkspace(m::Integer, n::Integer, S::Type)
   Ap = S(undef, n)
   z  = S(undef, 0)
   S = isconcretetype(S) ? S : typeof(x)
-  stats = SimpleStats(0, false, false, false, 0, T[], T[], T[], 0.0, "unknown")
+  stats = DiomCgStats(0, false, false, false, 0, T[], T[], T[], T[], 0.0, "unknown")
   workspace = CgWorkspace{T,FC,S}(m, n, Δx, x, r, npc_dir, p, Ap, z, false, stats)
   return workspace
 end
@@ -776,7 +776,7 @@ mutable struct DiomWorkspace{T,FC,S} <: KrylovWorkspace{T,FC,S}
   L          :: Vector{FC}
   H          :: Vector{FC}
   warm_start :: Bool
-  stats      :: SimpleStats{T}
+  stats      :: DiomCgStats{T}
 end
 
 function DiomWorkspace(kc::KrylovConstructor; memory::Integer = 20)
@@ -795,7 +795,7 @@ function DiomWorkspace(kc::KrylovConstructor; memory::Integer = 20)
   V      = S[similar(kc.vn) for i = 1 : memory]
   L      = Vector{FC}(undef, memory-1)
   H      = Vector{FC}(undef, memory)
-  stats  = SimpleStats(0, false, false, false, 0, T[], T[], T[], 0.0, "unknown")
+  stats  = DiomCgStats(0, false, false, false, 0, T[], T[], T[], T[], 0.0, "unknown")
   workspace = DiomWorkspace{T,FC,S}(m, n, Δx, x, t, z, w, P, V, L, H, false, stats)
   return workspace
 end
@@ -814,7 +814,7 @@ function DiomWorkspace(m::Integer, n::Integer, S::Type; memory::Integer = 20)
   L  = Vector{FC}(undef, memory-1)
   H  = Vector{FC}(undef, memory)
   S = isconcretetype(S) ? S : typeof(x)
-  stats = SimpleStats(0, false, false, false, 0, T[], T[], T[], 0.0, "unknown")
+  stats = DiomCgStats(0, false, false, false, 0, T[], T[], T[], T[], 0.0, "unknown")
   workspace = DiomWorkspace{T,FC,S}(m, n, Δx, x, t, z, w, P, V, L, H, false, stats)
   return workspace
 end

--- a/test/test_cg.jl
+++ b/test/test_cg.jl
@@ -1,6 +1,5 @@
 @testset "cg" begin
   cg_tol = 1.0e-6
-
   for FC in (Float64, ComplexF64)
     @testset "Data Type: $FC" begin
 
@@ -94,6 +93,53 @@
       @test stats.status == "nonpositive curvature detected"
       @test stats.indefinite == true
       @test real(dot(npc_dir, A * npc_dir)) <= 0.01 
+
+      # test quadratic function values are computed correctly
+      A = FC[10.0 0.0 0.0 0.0;
+        0.0 8.0 0.0 0.0;
+        0.0 0.0 5.0 0.0;
+        0.0 0.0 0.0 1.0
+      ]
+      b = FC[1.0, 1.0, 1.0, 0.1]
+      solver = CgWorkspace(A, b)
+      cg!(solver, A, b; radius = 10 * real(one(FC)), history = true)
+      x, stats, qxs = solver.x, solver.stats, solver.stats.qvals
+      @test length(qxs) == stats.niter + 1
+      @test abs(qxs[end] - (-dot(b, x) + dot(x, A * x)/2)) ≤ 1.0e-10
+      @test abs(qxs[1]) ≤ 1.0e-10  # q(0) = 0
+      # test that q is decreasing
+      @test all(diff(qxs) .<= 1.0e-10)
+
+      # test quadratic function with trust-region
+      A = FC[
+        10.0 0.0 0.0 0.0;
+        0.0 8.0 0.0 0.0;
+        0.0 0.0 5.0 0.0;
+        0.0 0.0 0.0 -1.0
+      ]
+      b = FC[1.0, 1.0, 1.0, 0.1]
+      solver = CgWorkspace(A, b)
+      cg!(solver, A, b; radius = 0.5 * real(one(FC)), history = true)
+      x, stats, = solver.x, solver.stats
+      q = -dot(b, x) + dot(x, A * x)/2
+      qxs = stats.qvals
+      @test abs(q - qxs[end]) ≤ 1.0e-10
+
+      # test quadratic function with warm start
+      A = FC[
+        10.0 0.0 0.0 0.0;
+        0.0 8.0 0.0 0.0;
+        0.0 0.0 5.0 0.0;
+        0.0 0.0 0.0 -1.0
+      ]
+      b = FC[1.0, 1.0, 1.0, 0.1]
+      x0 = FC[0.5, 0.5, 0.5, 0.05]
+      solver = CgWorkspace(A, b)
+      cg!(solver, A, b, x0; radius = 10 * real(one(FC)), history = true)
+      x, stats, = solver.x, solver.stats
+      q = -dot(b, x0) + dot(x0, A * x0)/2
+      qxs = stats.qvals
+      @test abs(q - qxs[1]) ≤ 1.0e-10
 
       # Test singular and consistent system
       A, b = singular_consistent(FC=FC)

--- a/test/test_diom.jl
+++ b/test/test_diom.jl
@@ -1,6 +1,5 @@
 @testset "diom" begin
   diom_tol = 1.0e-6
-
   for FC in (Float64, ComplexF64)
     @testset "Data Type: $FC" begin
 
@@ -98,6 +97,95 @@
       @test workspace.stats.status == "user-requested exit"
       @test cb_n2(workspace)
 
+      # trust region tests, same as in test_cg
+      # Test radius > 0  and b^TAb=0
+      A, b = zero_rhs(FC=FC)
+      solver = DiomWorkspace(A, b)
+      diom!(solver, A, b,radius = 10 * real(one(FC)))
+      x, stats = solver.x, solver.stats
+      @test stats.status == "x is a zero-residual solution"
+      @test norm(x) == zero(FC)
+      @test stats.niter == 0
+
+      # Test radius > 0 and pᵀAp < 0
+      A = FC[
+        10.0 0.0 0.0 0.0;
+        0.0 8.0 0.0 0.0;
+        0.0 0.0 5.0 0.0;
+        0.0 0.0 0.0 -1.0
+      ]
+      b = FC[1.0, 1.0, 1.0, 0.1]
+      solver = DiomWorkspace(A, b)
+      diom!(solver, A, b; radius = 10 * real(one(FC)))
+      x, stats, = solver.x, solver.stats
+      @test stats.indefinite == true
+      
+      # Test residual of the solution with trust region
+      A = FC[
+        10.0 0.0 0.0 0.0;
+        0.0 8.0 0.0 0.0;
+        0.0 0.0 5.0 0.0;
+        0.0 0.0 0.0 -1.0
+      ]
+      b = FC[1.0, 1.0, 1.0, 0.1]
+      solver = DiomWorkspace(A, b)
+      diom!(solver, A, b; radius = 0.5 * real(one(FC)), history = true)
+      x, stats, = solver.x, solver.stats
+      r = b - A * x
+      normr = norm(r)
+      @test isapprox(normr, stats.residuals[end], atol=1.0e-8)
+      @test stats.status == "on trust-region boundary"
+
+      # test quadratic function values are computed correctly
+      A = FC[10.0 0.0 0.0 0.0;
+        0.0 8.0 0.0 0.0;
+        0.0 0.0 5.0 0.0;
+        0.0 0.0 0.0 1.0
+      ]
+      b = FC[1.0, 1.0, 1.0, 0.1]
+      solver = DiomWorkspace(A, b)
+      diom!(solver, A, b; radius = 10 * real(one(FC)), history = true)
+      x, stats, = solver.x, solver.stats
+      qxs = stats.qvals
+      q = -dot(b, x) + dot(x, A * x)/2
+      @test length(qxs) == stats.niter + 1
+      @test abs(qxs[end] - q) ≤ 1.0e-10
+      @test abs(qxs[1]) ≤ 1.0e-10  # q(0) = 0
+      # test that q is decreasing
+      @test all(diff(qxs) .<= 1.0e-10)
+
+      # test quadratic function with trust-region
+      A = FC[
+        10.0 0.0 0.0 0.0;
+        0.0 8.0 0.0 0.0;
+        0.0 0.0 5.0 0.0;
+        0.0 0.0 0.0 -1.0
+      ]
+      b = FC[1.0, 1.0, 1.0, 0.1]
+      solver = DiomWorkspace(A, b)
+      diom!(solver, A, b; radius = 0.5 * real(one(FC)), history = true)
+      x, stats, = solver.x, solver.stats
+      q = -dot(b, x) + dot(x, A * x)/2
+      qxs = stats.qvals
+      @test abs(q - qxs[end]) ≤ 1.0e-10
+      @test stats.status == "on trust-region boundary"
+
+      # test quadratic function with warm start
+      A = FC[
+        10.0 0.0 0.0 0.0;
+        0.0 8.0 0.0 0.0;
+        0.0 0.0 5.0 0.0;
+        0.0 0.0 0.0 -1.0
+      ]
+      b = FC[1.0, 1.0, 1.0, 0.1]
+      x0 = FC[0.5, 0.5, 0.5, 0.05]
+      solver = DiomWorkspace(A, b)
+      diom!(solver, A, b, x0; radius = 10 * real(one(FC)), history = true)
+      x, stats, = solver.x, solver.stats
+      q = -dot(b, x0) + dot(x0, A * x0)/2
+      qxs = stats.qvals
+      @test abs(q - qxs[1]) ≤ 1.0e-10
+    
       @test_throws TypeError diom(A, b, callback = workspace -> "string", history = true)
     end
   end


### PR DESCRIPTION
When applied to Hermitian A, DIOM coincides with CG in exact arithmetic. However, in finite precision, DIOM acts as a form of regularization that can significantly improve upon CG's robustness in the presence of ill conditioning.

This commit introduces the trust-region constraint management in DIOM so it can be used as a drop-in replacement of CG in a trust-region solver such as trunk.

Summary:

- Add shared DiomCgStats struct for CG/DIOM to store quadratic objective
- Add quadratic objective computation in DIOM and CG if radius > 0  (O(1)/iteration)
- Compute residual at trust-region boundary for diom
- Add unit tests for quadratic problem with and without trust region.