### PR TITLE
Eliminate redundant vector zeroing and redundant norm evaluations in Krylov.jl

### DIFF
--- a/src/diom.jl
+++ b/src/diom.jl
@@ -181,13 +181,7 @@ kwargs_workspace_diom = (:memory,)
     (verbose > 0) && @printf(iostream, "%5s  %7s  %5s\n", "k", "‖rₖ‖", "timer")
     kdisplay(iter, verbose) && @printf(iostream, "%5d  %7.1e  %.2fs\n", iter, rNorm, start_time |> ktimer)
 
-    mem = length(V)  # Memory
-    for i = 1 : mem
-      kfill!(V[i], zero(FC))  # Orthogonal basis of Kₖ(MAN, Mr₀).
-    end
-    for i = 1 : mem-1
-      kfill!(P[i], zero(FC))  # Directions Pₖ = NVₖ(Uₖ)⁻¹.
-    end
+    # Set up workspace.
     kfill!(H, zero(FC))  # Last column of the band hessenberg matrix Hₖ = LₖUₖ.
     # Each column has at most mem + 1 nonzero elements.
     # hᵢ.ₖ is stored as H[k-i+1], i ≤ k. hₖ₊₁.ₖ is not stored in H.

--- a/src/diom.jl
+++ b/src/diom.jl
@@ -266,6 +266,11 @@ kwargs_workspace_diom = (:memory,)
       # Compute the direction pₖ, the last column of Pₖ = NVₖ(Uₖ)⁻¹.
       # u₁.ₖp₁ + ... + uₖ.ₖpₖ = Nvₖ             if k ≤ mem
       # uₖ₋ₘₑₘ₊₁.ₖpₖ₋ₘₑₘ₊₁ + ... + uₖ.ₖpₖ = Nvₖ if k ≥ mem + 1
+      if iter < mem
+        # pₐᵤₓ ← Nvₖ
+        # The copy overwrites P[ppos], so the workspace does not need to be zero-initialized.
+        kcopy!(n, P[ppos], z)
+      end
       for i = max(1,iter-mem+1) : iter-1
         ipos = mod(i-1, mem-1) + 1  # Position corresponding to pᵢ in the circular stack P.
         diag = iter - i + 1
@@ -277,8 +282,10 @@ kwargs_workspace_diom = (:memory,)
           kaxpy!(n, -H[diag], P[ipos], P[ppos])
         end
       end
-      # pₐᵤₓ ← pₐᵤₓ + Nvₖ
-      kaxpy!(n, one(FC), z, P[ppos])
+      if iter ≥ mem
+        # pₐᵤₓ ← pₐᵤₓ + Nvₖ
+        kaxpy!(n, one(FC), z, P[ppos])
+      end
       # pₖ = pₐᵤₓ / uₖ.ₖ
       kdiv!(n, P[ppos], H[1])
 

--- a/src/diom.jl
+++ b/src/diom.jl
@@ -182,6 +182,7 @@ kwargs_workspace_diom = (:memory,)
     kdisplay(iter, verbose) && @printf(iostream, "%5d  %7.1e  %.2fs\n", iter, rNorm, start_time |> ktimer)
 
     # Set up workspace.
+    mem = length(V)  # Memory
     kfill!(H, zero(FC))  # Last column of the band hessenberg matrix Hₖ = LₖUₖ.
     # Each column has at most mem + 1 nonzero elements.
     # hᵢ.ₖ is stored as H[k-i+1], i ≤ k. hₖ₊₁.ₖ is not stored in H.

--- a/src/dqgmres.jl
+++ b/src/dqgmres.jl
@@ -267,6 +267,11 @@ kwargs_workspace_dqgmres = (:memory,)
       γₖ   =      c[pos]  * γₖ
 
       # Compute the direction pₖ, the last column of Pₖ = NVₖ(Rₖ)⁻¹.
+      if iter ≤ mem
+        # pₐᵤₓ ← Nvₖ
+        # The copy overwrites P[pos], so the workspace does not need to be zero-initialized.
+        kcopy!(n, P[pos], z)
+      end
       for i = max(1,iter-mem) : iter-1
         ipos = mod(i-1, mem) + 1  # Position corresponding to pᵢ in the circular stack P.
         diag = iter - i + 1
@@ -278,8 +283,10 @@ kwargs_workspace_dqgmres = (:memory,)
           kaxpy!(n, -H[diag], P[ipos], P[pos])
         end
       end
-      # pₐᵤₓ ← pₐᵤₓ + Nvₖ
-      kaxpy!(n, one(FC), z, P[pos])
+      if iter > mem
+        # pₐᵤₓ ← pₐᵤₓ + Nvₖ
+        kaxpy!(n, one(FC), z, P[pos])
+      end
       # pₖ = pₐᵤₓ / hₖ.ₖ
       kdiv!(n, P[pos], H[1])
 

--- a/src/dqgmres.jl
+++ b/src/dqgmres.jl
@@ -182,6 +182,7 @@ kwargs_workspace_dqgmres = (:memory,)
     kdisplay(iter, verbose) && @printf(iostream, "%5d  %7.1e  %.2fs\n", iter, rNorm, start_time |> ktimer)
 
     # Set up workspace.
+    mem = length(V)  # Memory.
     kfill!(c, zero(T))   # Last mem Givens cosines used for the factorization QₖRₖ = Hₖ.
     kfill!(s, zero(FC))  # Last mem Givens sines used for the factorization QₖRₖ = Hₖ.
     kfill!(H, zero(FC))  # Last column of the band hessenberg matrix Hₖ.

--- a/src/dqgmres.jl
+++ b/src/dqgmres.jl
@@ -182,11 +182,6 @@ kwargs_workspace_dqgmres = (:memory,)
     kdisplay(iter, verbose) && @printf(iostream, "%5d  %7.1e  %.2fs\n", iter, rNorm, start_time |> ktimer)
 
     # Set up workspace.
-    mem = length(V)  # Memory.
-    for i = 1 : mem
-      kfill!(V[i], zero(FC))  # Orthogonal basis of Kₖ(MAN, Mr₀).
-      kfill!(P[i], zero(FC))  # Directions for x : Pₖ = NVₖ(Rₖ)⁻¹.
-    end
     kfill!(c, zero(T))   # Last mem Givens cosines used for the factorization QₖRₖ = Hₖ.
     kfill!(s, zero(FC))  # Last mem Givens sines used for the factorization QₖRₖ = Hₖ.
     kfill!(H, zero(FC))  # Last column of the band hessenberg matrix Hₖ.

--- a/src/fgmres.jl
+++ b/src/fgmres.jl
@@ -213,10 +213,6 @@ kwargs_workspace_fgmres = (:memory,)
 
       # Initialize workspace.
       nr = 0  # Number of coefficients stored in Rₖ.
-      for i = 1 : mem
-        kfill!(V[i], zero(FC))  # Orthogonal basis of {Mr₀, MANₖr₀, ..., (MANₖ)ᵏ⁻¹r₀}.
-        kfill!(Z[i], zero(FC))  # Zₖ = [N₁v₁, ..., Nₖvₖ]
-      end
       kfill!(s, zero(FC))  # Givens sines used for the factorization QₖRₖ = Hₖ₊₁.ₖ.
       kfill!(c, zero(T))   # Givens cosines used for the factorization QₖRₖ = Hₖ₊₁.ₖ.
       kfill!(R, zero(FC))  # Upper triangular matrix Rₖ.
@@ -228,11 +224,11 @@ kwargs_workspace_fgmres = (:memory,)
           kmul!(w, A, x)
           kaxpby!(n, one(FC), b, -one(FC), w)
           MisI || mulorldiv!(r₀, M, w, ldiv)
+          β = knorm(n, r₀)
         end
       end
 
       # Initial ζ₁ and v₁
-      β = knorm(n, r₀)
       z[1] = β
       kdivcopy!(n, V[1], r₀, rNorm)  # v₁ = r₀ / ‖r₀‖
 

--- a/src/fom.jl
+++ b/src/fom.jl
@@ -207,9 +207,6 @@ kwargs_workspace_fom = (:memory,)
 
       # Initialize workspace.
       nr = 0  # Number of coefficients stored in Uₖ.
-      for i = 1 : mem
-        kfill!(V[i], zero(FC))  # Orthogonal basis of Kₖ(MAN, Mr₀).
-      end
       kfill!(l, zero(FC))  # Lower unit triangular matrix Lₖ.
       kfill!(U, zero(FC))  # Upper triangular matrix Uₖ.
       kfill!(z, zero(FC))  # Solution of Lₖzₖ = βe₁.
@@ -220,11 +217,11 @@ kwargs_workspace_fom = (:memory,)
           kmul!(w, A, x)
           kaxpby!(n, one(FC), b, -one(FC), w)
           MisI || mulorldiv!(r₀, M, w, ldiv)
+          β = knorm(n, r₀)
         end
       end
 
       # Initial ζ₁ and v₁
-      β = knorm(n, r₀)
       z[1] = β
       kdivcopy!(n, V[1], r₀, rNorm)  # v₁ = r₀ / ‖r₀‖
 

--- a/src/fom.jl
+++ b/src/fom.jl
@@ -229,7 +229,7 @@ kwargs_workspace_fom = (:memory,)
       inner_iter = 0
       inner_tired = false
 
-      while !(solved || inner_tired || breakdown)
+      while !(solved || inner_tired || breakdown || user_requested_exit || overtimed)
 
         # Update iteration index
         inner_iter = inner_iter + 1

--- a/src/gmres.jl
+++ b/src/gmres.jl
@@ -208,9 +208,6 @@ kwargs_workspace_gmres = (:memory,)
 
       # Initialize workspace.
       nr = 0  # Number of coefficients stored in Rₖ.
-      for i = 1 : mem
-        kfill!(V[i], zero(FC))  # Orthogonal basis of Kₖ(MAN, Mr₀).
-      end
       kfill!(s, zero(FC))  # Givens sines used for the factorization QₖRₖ = Hₖ₊₁.ₖ.
       kfill!(c, zero(T))   # Givens cosines used for the factorization QₖRₖ = Hₖ₊₁.ₖ.
       kfill!(R, zero(FC))  # Upper triangular matrix Rₖ.
@@ -222,11 +219,11 @@ kwargs_workspace_gmres = (:memory,)
           kmul!(w, A, x)
           kaxpby!(n, one(FC), b, -one(FC), w)
           MisI || mulorldiv!(r₀, M, w, ldiv)
+          β = knorm(n, r₀)
         end
       end
 
       # Initial ζ₁ and v₁
-      β = knorm(n, r₀)
       z[1] = β
       kdivcopy!(n, V[1], r₀, rNorm)  # v₁ = r₀ / ‖r₀‖
 

--- a/src/gpmr.jl
+++ b/src/gpmr.jl
@@ -221,10 +221,6 @@ kwargs_workspace_gpmr = (:memory,)
     nr = 0           # Number of coefficients stored in Rₖ
     mem = length(V)  # Memory
     ωₖ = zero(FC)    # Auxiliary variable to store fₖₖ
-    for i = 1 : mem
-      kfill!(V[i], zero(FC))
-      kfill!(U[i], zero(FC))
-    end
     kfill!(gs, zero(FC))  # Givens sines used for the factorization QₖRₖ = Sₖ₊₁.ₖ.
     kfill!(gc, zero(T))   # Givens cosines used for the factorization QₖRₖ = Sₖ₊₁.ₖ.
     kfill!(R , zero(FC))  # Upper triangular matrix Rₖ.


### PR DESCRIPTION
Accelerates GPU performance of Krylov solver

**Changes**:
- Removed redundant `kfill!(V[i], zero(FC))` pre-allocation loops in `src/gmres.jl`, `src/fgmres.jl`, `src/dqgmres.jl`, `src/diom.jl`,  `src/fom.jl`, and  `src/gpmr.jl`. The basis vectors $V_1$ and $V_{k+1}$ are overwritten directly in-place by `kdivcopy!` during Arnoldi iterations, so pre-zeroing all $mem$ vectors at the start of each solve launched  20-40 unnecessary GPU kernels (incurring substantial latency in our atmosphere modeling test cases in ClimaAtmos.jl).
- Removed redundant residual norm recomputation (`β = knorm(n, r₀)`) at the start of passes in `gmres.jl`, `fgmres.jl`, and `fom.jl` when `npass == 1`.
- Fixed a pre-existing runaway-loop bug in FOM's timemax/callback handling, which the V zeroing was accidentally masking 