### PR TITLE
Remove machine-precision stopping conditions

### DIFF
--- a/src/bicgstab.jl
+++ b/src/bicgstab.jl
@@ -240,14 +240,10 @@ kwargs_bicgstab = (:c, :M, :N, :ldiv, :atol, :rtol, :itmax, :timemax, :verbose, 
       rNorm = knorm(n, r)
       history && push!(rNorms, rNorm)
 
-      # Stopping conditions that do not depend on user input.
-      # This is to guard against tolerances that are unreasonably small.
-      resid_decrease_mach = (rNorm + one(T) ≤ one(T))
-
       # Update stopping criterion.
       user_requested_exit = callback(workspace) :: Bool
       resid_decrease_lim = rNorm ≤ ε
-      solved = resid_decrease_lim || resid_decrease_mach
+      solved = resid_decrease_lim
       tired = iter ≥ itmax
       breakdown = (α == 0 || isnan(α))
       timer = time_ns() - start_time

--- a/src/bilqr.jl
+++ b/src/bilqr.jl
@@ -205,10 +205,10 @@ kwargs_bilqr = (:transfer_to_bicg, :atol, :rtol, :itmax, :timemax, :verbose, :hi
 
     # Stopping criterion.
     solved_lq = bNorm == 0
-    solved_lq_tol = solved_lq_mach = false
-    solved_cg = solved_cg_tol = solved_cg_mach = false
+    solved_lq_tol = false
+    solved_cg = solved_cg_tol = false
     solved_primal = solved_lq || solved_cg
-    solved_qr_tol = solved_qr_mach = false
+    solved_qr_tol = false
     solved_dual = cNorm == 0
     tired = iter ≥ itmax
     breakdown = false
@@ -339,11 +339,9 @@ kwargs_bilqr = (:transfer_to_bicg, :atol, :rtol, :itmax, :timemax, :verbose, :hi
 
         # Update primal stopping criterion
         solved_lq_tol = rNorm_lq ≤ εL
-        solved_lq_mach = rNorm_lq + 1 ≤ 1
-        solved_lq = solved_lq_tol || solved_lq_mach
+        solved_lq = solved_lq_tol
         solved_cg_tol = transfer_to_bicg && (abs(δbarₖ) > eps(T)) && (rNorm_cg ≤ εL)
-        solved_cg_mach = transfer_to_bicg && (abs(δbarₖ) > eps(T)) && (rNorm_cg + 1 ≤ 1)
-        solved_cg = solved_cg_tol || solved_cg_mach
+        solved_cg = solved_cg_tol
         solved_primal = solved_lq || solved_cg
       end
 
@@ -403,8 +401,7 @@ kwargs_bilqr = (:transfer_to_bicg, :atol, :rtol, :itmax, :timemax, :verbose, :hi
 
         # Update dual stopping criterion
         solved_qr_tol = sNorm ≤ εQ
-        solved_qr_mach = sNorm + 1 ≤ 1
-        solved_dual = solved_qr_tol || solved_qr_mach
+        solved_dual = solved_qr_tol
       end
 
       # Compute vₖ₊₁ and uₖ₊₁.
@@ -456,15 +453,6 @@ kwargs_bilqr = (:transfer_to_bicg, :atol, :rtol, :itmax, :timemax, :verbose, :hi
     !solved_primal && solved_qr_tol  && (status = "Only the dual solution t is good enough given atol and rtol")
     solved_lq_tol  && solved_qr_tol  && (status = "Both primal and dual solutions (xᴸ, t) are good enough given atol and rtol")
     solved_cg_tol  && solved_qr_tol  && (status = "Both primal and dual solutions (xᶜ, t) are good enough given atol and rtol")
-    solved_lq_mach && !solved_dual   && (status = "Only found approximate zero-residual primal solution xᴸ")
-    solved_cg_mach && !solved_dual   && (status = "Only found approximate zero-residual primal solution xᶜ")
-    !solved_primal && solved_qr_mach && (status = "Only found approximate zero-residual dual solution t")
-    solved_lq_mach && solved_qr_mach && (status = "Found approximate zero-residual primal and dual solutions (xᴸ, t)")
-    solved_cg_mach && solved_qr_mach && (status = "Found approximate zero-residual primal and dual solutions (xᶜ, t)")
-    solved_lq_mach && solved_qr_tol  && (status = "Found approximate zero-residual primal solutions xᴸ and a dual solution t good enough given atol and rtol")
-    solved_cg_mach && solved_qr_tol  && (status = "Found approximate zero-residual primal solutions xᶜ and a dual solution t good enough given atol and rtol")
-    solved_lq_tol  && solved_qr_mach && (status = "Found a primal solution xᴸ good enough given atol and rtol and an approximate zero-residual dual solutions t")
-    solved_cg_tol  && solved_qr_mach && (status = "Found a primal solution xᶜ good enough given atol and rtol and an approximate zero-residual dual solutions t")
     user_requested_exit              && (status = "user-requested exit")
     overtimed                        && (status = "time limit exceeded")
 

--- a/src/car.jl
+++ b/src/car.jl
@@ -205,11 +205,8 @@ kwargs_car = (:M, :ldiv, :atol, :rtol, :itmax, :timemax, :verbose, :history, :ca
       rNorm = knorm(n, r)
       history && push!(rNorms, rNorm)
 
-      # Stopping conditions that do not depend on user input.
-      # This is to guard against tolerances that are unreasonably small.
-      resid_decrease_mach = (rNorm + one(T) ≤ one(T))
       resid_decrease_lim = rNorm ≤ ε
-      solved = resid_decrease_lim || resid_decrease_mach
+      solved = resid_decrease_lim
 
       if !solved
         kmul!(t, A, s)                # tₖ₊₁ = A * sₖ₊₁

--- a/src/cg.jl
+++ b/src/cg.jl
@@ -244,12 +244,8 @@ kwargs_cg = (:M, :ldiv, :radius, :linesearch, :atol, :rtol, :itmax, :timemax, :v
       rNorm = sqrt(γ_next)
       history && push!(rNorms, rNorm)
 
-      # Stopping conditions that do not depend on user input.
-      # This is to guard against tolerances that are unreasonably small.
-      resid_decrease_mach = (rNorm + one(T) ≤ one(T))
-
       resid_decrease_lim = rNorm ≤ ε
-      resid_decrease = resid_decrease_lim || resid_decrease_mach
+      resid_decrease = resid_decrease_lim
       solved = resid_decrease || on_boundary
 
       if !solved

--- a/src/cg_lanczos.jl
+++ b/src/cg_lanczos.jl
@@ -228,13 +228,9 @@ kwargs_cg_lanczos = (:M, :ldiv, :check_curvature, :atol, :rtol, :itmax, :timemax
       iter = iter + 1
       kdisplay(iter, verbose) && @printf(iostream, "%5d  %7.1e  %.2fs\n", iter, rNorm, start_time |> ktimer)
 
-      # Stopping conditions that do not depend on user input.
-      # This is to guard against tolerances that are unreasonably small.
-      resid_decrease_mach = (rNorm + one(T) ≤ one(T))
-      
       user_requested_exit = callback(workspace) :: Bool
       resid_decrease_lim = rNorm ≤ ε
-      solved = resid_decrease_lim || resid_decrease_mach
+      solved = resid_decrease_lim
       tired = iter ≥ itmax
       timer = time_ns() - start_time
       overtimed = timer > timemax_ns

--- a/src/cgne.jl
+++ b/src/cgne.jl
@@ -221,13 +221,9 @@ kwargs_cgne = (:N, :ldiv, :λ, :atol, :rtol, :itmax, :timemax, :verbose, :histor
       iter = iter + 1
       kdisplay(iter, verbose) && @printf(iostream, "%5d  %8.2e  %.2fs\n", iter, rNorm, start_time |> ktimer)
 
-      # Stopping conditions that do not depend on user input.
-      # This is to guard against tolerances that are unreasonably small.
-      resid_decrease_mach = (rNorm + one(T) ≤ one(T))
-
       user_requested_exit = callback(workspace) :: Bool
       resid_decrease_lim = rNorm ≤ ɛ_c
-      solved = resid_decrease_lim || resid_decrease_mach
+      solved = resid_decrease_lim
       inconsistent = (rNorm > 100 * ɛ_c) && (pNorm ≤ ɛ_i)
       tired = iter ≥ itmax
       timer = time_ns() - start_time

--- a/src/cgs.jl
+++ b/src/cgs.jl
@@ -244,14 +244,10 @@ kwargs_cgs = (:c, :M, :N, :ldiv, :atol, :rtol, :itmax, :timemax, :verbose, :hist
       rNorm = knorm(n, r)
       history && push!(rNorms, rNorm)
 
-      # Stopping conditions that do not depend on user input.
-      # This is to guard against tolerances that are unreasonably small.
-      resid_decrease_mach = (rNorm + one(T) ≤ one(T))
-
       # Update stopping criterion.
       user_requested_exit = callback(workspace) :: Bool
       resid_decrease_lim = rNorm ≤ ε
-      solved = resid_decrease_lim || resid_decrease_mach
+      solved = resid_decrease_lim
       tired = iter ≥ itmax
       breakdown = (α == 0 || isnan(α))
       timer = time_ns() - start_time

--- a/src/cr.jl
+++ b/src/cr.jl
@@ -412,13 +412,9 @@ kwargs_cr = (:M, :ldiv, :radius, :linesearch, :γ, :atol, :rtol, :itmax, :timema
         @printf(iostream, "%5d  %8.1e  %8.1e  %8.1e  %.2fs\n", iter, xNorm, rNorm, m, start_time |> ktimer)
       end
 
-      # Stopping conditions that do not depend on user input.
-      # This is to guard against tolerances that are unreasonably small.
-      resid_decrease_mach = (rNorm + one(T) ≤ one(T))
-
       user_requested_exit = callback(workspace) :: Bool
       resid_decrease_lim = rNorm ≤ ε
-      resid_decrease = resid_decrease_lim || resid_decrease_mach
+      resid_decrease = resid_decrease_lim
       solved = resid_decrease || npcurv || on_boundary
       tired = iter ≥ itmax
       timer = time_ns() - start_time

--- a/src/diom.jl
+++ b/src/diom.jl
@@ -309,14 +309,10 @@ kwargs_workspace_diom = (:memory,)
       rNorm = Haux * abs(ξ / H[1])
       history && push!(rNorms, rNorm)
 
-      # Stopping conditions that do not depend on user input.
-      # This is to guard against tolerances that are unreasonably small.
-      resid_decrease_mach = (rNorm + one(T) ≤ one(T))
-
       # Update stopping criterion.
       user_requested_exit = callback(workspace) :: Bool
       resid_decrease_lim = rNorm ≤ ε
-      solved = resid_decrease_lim || resid_decrease_mach
+      solved = resid_decrease_lim
       tired = iter ≥ itmax
       timer = time_ns() - start_time
       overtimed = timer > timemax_ns

--- a/src/dqgmres.jl
+++ b/src/dqgmres.jl
@@ -315,14 +315,10 @@ kwargs_workspace_dqgmres = (:memory,)
       # Update γₖ.
       γₖ = γₖ₊₁
 
-      # Stopping conditions that do not depend on user input.
-      # This is to guard against tolerances that are unreasonably small.
-      resid_decrease_mach = (rNorm + one(T) ≤ one(T))
-
       # Update stopping criterion.
       user_requested_exit = callback(workspace) :: Bool
       resid_decrease_lim = rNorm ≤ ε
-      solved = resid_decrease_lim || resid_decrease_mach
+      solved = resid_decrease_lim
       tired = iter ≥ itmax
       timer = time_ns() - start_time
       overtimed = timer > timemax_ns

--- a/src/fgmres.jl
+++ b/src/fgmres.jl
@@ -303,15 +303,11 @@ kwargs_workspace_fgmres = (:memory,)
         # Update the number of coefficients in Rₖ
         nr = nr + inner_iter
 
-        # Stopping conditions that do not depend on user input.
-        # This is to guard against tolerances that are unreasonably small.
-        resid_decrease_mach = (rNorm + one(T) ≤ one(T))
-        
         # Update stopping criterion.
         user_requested_exit = callback(workspace) :: Bool
         resid_decrease_lim = rNorm ≤ ε
         breakdown = Hbis ≤ btol
-        solved = resid_decrease_lim || resid_decrease_mach
+        solved = resid_decrease_lim
         inner_tired = restart ? inner_iter ≥ min(mem, inner_itmax) : inner_iter ≥ inner_itmax
         timer = time_ns() - start_time
         overtimed = timer > timemax_ns

--- a/src/fom.jl
+++ b/src/fom.jl
@@ -287,15 +287,11 @@ kwargs_workspace_fom = (:memory,)
         # Update the number of coefficients in Uₖ
         nr = nr + inner_iter
 
-        # Stopping conditions that do not depend on user input.
-        # This is to guard against tolerances that are unreasonably small.
-        resid_decrease_mach = (rNorm + one(T) ≤ one(T))
-
         # Update stopping criterion.
         user_requested_exit = callback(workspace) :: Bool
         resid_decrease_lim = rNorm ≤ ε
         breakdown = Hbis ≤ btol
-        solved = resid_decrease_lim || resid_decrease_mach
+        solved = resid_decrease_lim
         inner_tired = restart ? inner_iter ≥ min(mem, inner_itmax) : inner_iter ≥ inner_itmax
         timer = time_ns() - start_time
         overtimed = timer > timemax_ns

--- a/src/gmres.jl
+++ b/src/gmres.jl
@@ -297,15 +297,11 @@ kwargs_workspace_gmres = (:memory,)
         # Update the number of coefficients in Rₖ
         nr = nr + inner_iter
 
-        # Stopping conditions that do not depend on user input.
-        # This is to guard against tolerances that are unreasonably small.
-        resid_decrease_mach = (rNorm + one(T) ≤ one(T))
-        
         # Update stopping criterion.
         user_requested_exit = callback(workspace) :: Bool
         resid_decrease_lim = rNorm ≤ ε
         breakdown = Hbis ≤ btol
-        solved = resid_decrease_lim || resid_decrease_mach
+        solved = resid_decrease_lim
         inner_tired = restart ? inner_iter ≥ min(mem, inner_itmax) : inner_iter ≥ inner_itmax
         timer = time_ns() - start_time
         overtimed = timer > timemax_ns

--- a/src/gpmr.jl
+++ b/src/gpmr.jl
@@ -453,15 +453,11 @@ kwargs_workspace_gpmr = (:memory,)
       # Update the number of coefficients in Rₖ.
       nr = nr + 4k-1
 
-      # Stopping conditions that do not depend on user input.
-      # This is to guard against tolerances that are unreasonably small.
-      resid_decrease_mach = (rNorm + one(T) ≤ one(T))
-
       # Update stopping criterion.
       user_requested_exit = callback(workspace) :: Bool
       resid_decrease_lim = rNorm ≤ ε
       breakdown = Faux ≤ btol && Haux ≤ btol
-      solved = resid_decrease_lim || resid_decrease_mach
+      solved = resid_decrease_lim
       tired = iter ≥ itmax
       timer = time_ns() - start_time
       overtimed = timer > timemax_ns

--- a/src/minres.jl
+++ b/src/minres.jl
@@ -440,7 +440,6 @@ kwargs_workspace_minres = (:window,)
       ill_cond_mach = (one(T) + inv(Acond) ≤ one(T))
       solved_mach = (one(T) + test2 ≤ one(T))
       zero_resid_mach = (one(T) + test1 ≤ one(T))
-      resid_decrease_mach = (rNorm + one(T) ≤ one(T))
       # solved_mach = (ϵx ≥ β₁)
 
       # Stopping conditions based on user-provided tolerances.
@@ -453,7 +452,7 @@ kwargs_workspace_minres = (:window,)
 
       user_requested_exit = callback(workspace) :: Bool
       zero_resid = zero_resid_mach || zero_resid_lim
-      resid_decrease = resid_decrease_mach || resid_decrease_lim
+      resid_decrease = resid_decrease_lim
       ill_cond = ill_cond_mach || ill_cond_lim
       solved = solved_mach || solved_lim || zero_resid || fwd_err || resid_decrease
       timer = time_ns() - start_time

--- a/src/minres_qlp.jl
+++ b/src/minres_qlp.jl
@@ -472,7 +472,6 @@ kwargs_minres_qlp = (:M, :ldiv, :linesearch, :λ, :atol, :rtol, :Artol, :itmax, 
       # Stopping conditions that do not depend on user input.
       # This is to guard against tolerances that are unreasonably small.
       ill_cond_mach = (one(T) + inv(Acond) ≤ one(T))
-      resid_decrease_mach = (one(T) + rNorm ≤ one(T))
       zero_resid_mach = (one(T) + backward ≤ one(T))
 
       # Stopping conditions based on user-provided tolerances.
@@ -483,7 +482,7 @@ kwargs_minres_qlp = (:M, :ldiv, :linesearch, :λ, :atol, :rtol, :Artol, :itmax, 
 
       user_requested_exit = callback(workspace) :: Bool
       zero_resid = zero_resid_mach | zero_resid_lim
-      resid_decrease = resid_decrease_mach | resid_decrease_lim
+      resid_decrease = resid_decrease_lim
       solved = resid_decrease | zero_resid
       inconsistent = (ArNorm ≤ κ && abs(μbarₖ) ≤ Artol) || (breakdown && !solved)
       timer = time_ns() - start_time

--- a/src/qmr.jl
+++ b/src/qmr.jl
@@ -364,14 +364,10 @@ kwargs_qmr = (:c, :M, :N, :ldiv, :atol, :rtol, :itmax, :timemax, :verbose, :hist
       γₖ    = γₖ₊₁
       τₖ    = τₖ₊₁
 
-      # Stopping conditions that do not depend on user input.
-      # This is to guard against tolerances that are unreasonably small.
-      resid_decrease_mach = (rNorm + one(T) ≤ one(T))
-
       # Update stopping criterion.
       user_requested_exit = callback(workspace) :: Bool
       resid_decrease_lim = rNorm ≤ ε
-      solved = resid_decrease_lim || resid_decrease_mach
+      solved = resid_decrease_lim
       tired = iter ≥ itmax
       breakdown = !solved && (pᴴq == 0)
       timer = time_ns() - start_time

--- a/src/symmlq.jl
+++ b/src/symmlq.jl
@@ -411,7 +411,6 @@ kwargs_workspace_symmlq = (:window,)
 
       # Stopping conditions that do not depend on user input.
       # This is to guard against tolerances that are unreasonably small.
-      resid_decrease_mach = (one(T) + rNorm ≤ one(T))
       ill_cond_mach = (one(T) + inv(Acond) ≤ one(T))
       zero_resid_mach = (one(T) + test1 ≤ one(T))
       # solved_mach = (ϵx ≥ β₁)
@@ -427,7 +426,7 @@ kwargs_workspace_symmlq = (:window,)
       user_requested_exit = callback(workspace) :: Bool
       zero_resid = solved_lq || solved_cg
       ill_cond = ill_cond_mach || ill_cond_lim
-      solved = solved_mach || zero_resid || zero_resid_mach || zero_resid_lim || fwd_err || resid_decrease_mach
+      solved = solved_mach || zero_resid || zero_resid_mach || zero_resid_lim || fwd_err
       timer = time_ns() - start_time
       overtimed = timer > timemax_ns
     end

--- a/src/tricg.jl
+++ b/src/tricg.jl
@@ -446,15 +446,11 @@ kwargs_tricg = (:M, :N, :ldiv, :spd, :snd, :flip, :τ, :ν, :atol, :rtol, :itmax
       d₂ₖ₋₂ = d₂ₖ
       δₖ₋₁  = δₖ
 
-      # Stopping conditions that do not depend on user input.
-      # This is to guard against tolerances that are unreasonably small.
-      resid_decrease_mach = (rNorm + one(T) ≤ one(T))
-
       # Update stopping criterion.
       user_requested_exit = callback(workspace) :: Bool
       resid_decrease_lim = rNorm ≤ ε
       breakdown = βₖ₊₁ ≤ btol && γₖ₊₁ ≤ btol
-      solved = resid_decrease_lim || resid_decrease_mach
+      solved = resid_decrease_lim
       tired = iter ≥ itmax
       timer = time_ns() - start_time
       overtimed = timer > timemax_ns

--- a/src/trilqr.jl
+++ b/src/trilqr.jl
@@ -189,10 +189,10 @@ kwargs_trilqr = (:transfer_to_usymcg, :atol, :rtol, :itmax, :timemax, :verbose, 
     # Stopping criterion.
     inconsistent = false
     solved_lq = bNorm == 0
-    solved_lq_tol = solved_lq_mach = false
-    solved_cg = solved_cg_tol = solved_cg_mach = false
+    solved_lq_tol = false
+    solved_cg = solved_cg_tol = false
     solved_primal = solved_lq || solved_cg
-    solved_qr_tol = solved_qr_mach = false
+    solved_qr_tol = false
     solved_dual = cNorm == 0
     tired = iter ≥ itmax
     status = "unknown"
@@ -315,11 +315,9 @@ kwargs_trilqr = (:transfer_to_usymcg, :atol, :rtol, :itmax, :timemax, :verbose, 
 
         # Update primal stopping criterion
         solved_lq_tol = rNorm_lq ≤ εL
-        solved_lq_mach = rNorm_lq + 1 ≤ 1
-        solved_lq = solved_lq_tol || solved_lq_mach
+        solved_lq = solved_lq_tol
         solved_cg_tol = transfer_to_usymcg && (abs(δbarₖ) > eps(T)) && (rNorm_cg ≤ εL)
-        solved_cg_mach = transfer_to_usymcg && (abs(δbarₖ) > eps(T)) && (rNorm_cg + 1 ≤ 1)
-        solved_cg = solved_cg_tol || solved_cg_mach
+        solved_cg = solved_cg_tol
         solved_primal = solved_lq || solved_cg
       end
 
@@ -380,9 +378,8 @@ kwargs_trilqr = (:transfer_to_usymcg, :atol, :rtol, :itmax, :timemax, :verbose, 
         # Update dual stopping criterion
         iter == 1 && (ξ = atol + rtol * AsNorm)
         solved_qr_tol = sNorm ≤ εQ
-        solved_qr_mach = sNorm + 1 ≤ 1
         inconsistent = AsNorm ≤ ξ
-        solved_dual = solved_qr_tol || solved_qr_mach || inconsistent
+        solved_dual = solved_qr_tol || inconsistent
       end
 
       # Compute uₖ₊₁ and uₖ₊₁.
@@ -433,15 +430,6 @@ kwargs_trilqr = (:transfer_to_usymcg, :atol, :rtol, :itmax, :timemax, :verbose, 
     !solved_primal && solved_qr_tol  && (status = "Only the dual solution t is good enough given atol and rtol")
     solved_lq_tol  && solved_qr_tol  && (status = "Both primal and dual solutions (xᴸ, t) are good enough given atol and rtol")
     solved_cg_tol  && solved_qr_tol  && (status = "Both primal and dual solutions (xᶜ, t) are good enough given atol and rtol")
-    solved_lq_mach && !solved_dual   && (status = "Only found approximate zero-residual primal solution xᴸ")
-    solved_cg_mach && !solved_dual   && (status = "Only found approximate zero-residual primal solution xᶜ")
-    !solved_primal && solved_qr_mach && (status = "Only found approximate zero-residual dual solution t")
-    solved_lq_mach && solved_qr_mach && (status = "Found approximate zero-residual primal and dual solutions (xᴸ, t)")
-    solved_cg_mach && solved_qr_mach && (status = "Found approximate zero-residual primal and dual solutions (xᶜ, t)")
-    solved_lq_mach && solved_qr_tol  && (status = "Found approximate zero-residual primal solutions xᴸ and a dual solution t good enough given atol and rtol")
-    solved_cg_mach && solved_qr_tol  && (status = "Found approximate zero-residual primal solutions xᶜ and a dual solution t good enough given atol and rtol")
-    solved_lq_tol  && solved_qr_mach && (status = "Found a primal solution xᴸ good enough given atol and rtol and an approximate zero-residual dual solutions t")
-    solved_cg_tol  && solved_qr_mach && (status = "Found a primal solution xᶜ good enough given atol and rtol and an approximate zero-residual dual solutions t")
     user_requested_exit              && (status = "user-requested exit")
     overtimed                        && (status = "time limit exceeded")
 

--- a/src/trimr.jl
+++ b/src/trimr.jl
@@ -539,15 +539,11 @@ kwargs_trimr = (:M, :N, :ldiv, :spd, :snd, :flip, :sp, :τ, :ν, :atol, :rtol, :
       πbar₂ₖ₋₁ = πbar₂ₖ₊₁
       πbar₂ₖ   = πbar₂ₖ₊₂
 
-      # Stopping conditions that do not depend on user input.
-      # This is to guard against tolerances that are unreasonably small.
-      resid_decrease_mach = (rNorm + one(T) ≤ one(T))
-
       # Update stopping criterion.
       user_requested_exit = callback(workspace) :: Bool
       resid_decrease_lim = rNorm ≤ ε
       breakdown = βₖ₊₁ ≤ btol && γₖ₊₁ ≤ btol
-      solved = resid_decrease_lim || resid_decrease_mach
+      solved = resid_decrease_lim
       tired = iter ≥ itmax
       timer = time_ns() - start_time
       overtimed = timer > timemax_ns


### PR DESCRIPTION
close #1109 
I will wait one week before that I merge it.
I would like to think more about #1109  and be sure that it is the right solution.

Additional comment: `Krylov.jl` have +35 solvers for one right-hand side and only 21 solvers have this stopping condition that is not documented.
If we decide to finally keep these stopping conditions, we should be consistent everywhere. 
